### PR TITLE
Fix missing Excalidraw fonts (bundle excalidraw-assets)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,12 @@ frontend/dist/
 frontend/build/
 backend/dist/
 
+# Generated Excalidraw assets (copied from node_modules for runtime)
+frontend/public/excalidraw-assets/
+frontend/public/excalidraw-assets-dev/
+frontend/public/dist/excalidraw-assets/
+frontend/public/dist/excalidraw-assets-dev/
+
 # E2E Testing
 e2e/node_modules/
 e2e/test-results/

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,6 +10,15 @@
 
 <body>
   <div id="root"></div>
+  <script>
+    (function () {
+      if (typeof window.EXCALIDRAW_ASSET_PATH === "string" && window.EXCALIDRAW_ASSET_PATH.length > 0) return;
+      var base = "%BASE_URL%";
+      if (base === "%BASE_URL%") base = "/";
+      if (base && base[base.length - 1] !== "/") base += "/";
+      window.EXCALIDRAW_ASSET_PATH = new URL(base || "/", window.location.origin).toString();
+    })();
+  </script>
   <script type="module" src="/src/main.tsx"></script>
 </body>
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,8 +4,8 @@
   "version": "0.4.27",
   "type": "module",
   "scripts": {
-    "dev": "vite --port 6767",
-    "build": "tsc -b && vite build",
+    "dev": "node scripts/copy-excalidraw-assets.mjs --public && vite --port 6767",
+    "build": "tsc -b && vite build && node scripts/copy-excalidraw-assets.mjs --dist",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",

--- a/frontend/scripts/copy-excalidraw-assets.mjs
+++ b/frontend/scripts/copy-excalidraw-assets.mjs
@@ -1,0 +1,59 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.resolve(__dirname, "..");
+
+const EXCALIDRAW_DIST_DIR = path.join(
+  frontendRoot,
+  "node_modules",
+  "@excalidraw",
+  "excalidraw",
+  "dist",
+);
+
+const assetDirs = ["excalidraw-assets", "excalidraw-assets-dev"];
+
+const copyDir = async (src, dest) => {
+  await fs.rm(dest, { recursive: true, force: true });
+  await fs.mkdir(path.dirname(dest), { recursive: true });
+  await fs.cp(src, dest, { recursive: true });
+};
+
+const getTargets = () => {
+  const args = new Set(process.argv.slice(2));
+  const targets = [];
+  if (args.has("--public")) targets.push("public");
+  if (args.has("--dist")) targets.push("dist");
+  return targets.length > 0 ? targets : ["dist"];
+};
+
+const main = async () => {
+  const targets = getTargets();
+
+  for (const targetName of targets) {
+    const targetRoot = path.join(frontendRoot, targetName);
+    await fs.mkdir(targetRoot, { recursive: true });
+
+    for (const dirName of assetDirs) {
+      const src = path.join(EXCALIDRAW_DIST_DIR, dirName);
+      const destRoot = path.join(targetRoot, dirName);
+      const destNested = path.join(targetRoot, "dist", dirName);
+
+      try {
+        await fs.access(src);
+      } catch (err) {
+        console.error(`[copy-excalidraw-assets] Missing source dir: ${src}`);
+        throw err;
+      }
+
+      await copyDir(src, destRoot);
+      await copyDir(src, destNested);
+
+      console.log(`[copy-excalidraw-assets] Copied ${dirName} -> ${targetName}`);
+    }
+  }
+};
+
+await main();

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,13 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
+const w = window as any
+if (typeof w.EXCALIDRAW_ASSET_PATH !== 'string' || w.EXCALIDRAW_ASSET_PATH.length === 0) {
+  const base = import.meta.env.BASE_URL || '/'
+  const normalizedBase = base.endsWith('/') ? base : `${base}/`
+  w.EXCALIDRAW_ASSET_PATH = new URL(normalizedBase, window.location.origin).toString()
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -31,6 +31,135 @@ interface Peer extends UserIdentity {
   isActive: boolean;
 }
 
+const preloadExcalidrawFonts = async (timeoutMs = 8000): Promise<void> => {
+  const normalizeBase = (value: unknown): string => {
+    const base = typeof value === "string" && value.length > 0 ? value : (import.meta.env.BASE_URL || "/");
+    const normalized = base.endsWith("/") ? base : `${base}/`;
+    return new URL(normalized, window.location.origin).toString();
+  };
+
+  const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  const withTimeout = async <T,>(p: Promise<T>, ms: number): Promise<T | null> => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        p,
+        new Promise<null>((resolve) => {
+          timer = setTimeout(() => resolve(null), ms);
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  };
+
+  try {
+    const fonts = document.fonts;
+    if (!fonts || typeof fonts.check !== "function" || typeof fonts.add !== "function") return;
+
+    if (
+      fonts.check("16px Virgil") &&
+      fonts.check("16px Cascadia") &&
+      fonts.check("16px Assistant") &&
+      fonts.check("bold 16px Assistant")
+    ) {
+      return;
+    }
+
+    const assetBase = normalizeBase((window as any).EXCALIDRAW_ASSET_PATH);
+    const assetDir = import.meta.env.DEV ? "excalidraw-assets-dev" : "excalidraw-assets";
+
+    const ensureFontFaceFallback = () => {
+      const styleId = "excalidraw-font-face-fallback";
+      if (document.getElementById(styleId)) return;
+
+      const mkUrls = (file: string): string[] => {
+        const local = new URL(`${assetDir}/${file}`, assetBase).toString();
+        const localDist = new URL(`dist/${assetDir}/${file}`, assetBase).toString();
+        const unpkg = `https://unpkg.com/@excalidraw/excalidraw@0.17.6/dist/${assetDir}/${file}`;
+        return [local, localDist, unpkg];
+      };
+
+      const mkSrc = (urls: string[]) =>
+        urls
+          .filter((u, idx) => urls.indexOf(u) === idx)
+          .map((u) => `url("${u}") format("woff2")`)
+          .join(", ");
+
+      const style = document.createElement("style");
+      style.id = styleId;
+      style.textContent = [
+        `@font-face{font-family:"Virgil";src:${mkSrc(mkUrls("Virgil.woff2"))};font-display:swap;}`,
+        `@font-face{font-family:"Cascadia";src:${mkSrc(mkUrls("Cascadia.woff2"))};font-display:swap;}`,
+        `@font-face{font-family:"Assistant";src:${mkSrc(mkUrls("Assistant-Regular.woff2"))};font-display:swap;font-weight:400;}`,
+        `@font-face{font-family:"Assistant";src:${mkSrc(mkUrls("Assistant-Bold.woff2"))};font-display:swap;font-weight:700;}`,
+      ].join("");
+      document.head.appendChild(style);
+    };
+
+    ensureFontFaceFallback();
+
+    if (typeof fonts.load === "function") {
+      await withTimeout(
+        Promise.all([
+          fonts.load("16px Virgil"),
+          fonts.load("16px Cascadia"),
+          fonts.load("16px Assistant"),
+          fonts.load("bold 16px Assistant"),
+        ]),
+        timeoutMs,
+      );
+      if (fonts.check("16px Virgil")) return;
+    }
+
+    const tryLoadFontFace = async (
+      family: string,
+      file: string,
+      desc: { weight?: string; style?: string } = {},
+    ) => {
+      if (typeof (window as any).FontFace !== "function") return;
+      const checkStr = `${desc.weight ? `${desc.weight} ` : ""}16px ${family}`;
+      if (fonts.check(checkStr)) return;
+
+      const url = new URL(`${assetDir}/${file}`, assetBase).toString();
+      const face = new FontFace(family, `url(${url})`, {
+        weight: desc.weight,
+        style: desc.style,
+      });
+
+      const loaded = await withTimeout(face.load(), timeoutMs);
+      if (loaded) fonts.add(loaded);
+    };
+
+    await Promise.all([
+      tryLoadFontFace("Virgil", "Virgil.woff2", { weight: "400" }),
+      tryLoadFontFace("Cascadia", "Cascadia.woff2", { weight: "400" }),
+      tryLoadFontFace("Assistant", "Assistant-Regular.woff2", { weight: "400" }),
+      tryLoadFontFace("Assistant", "Assistant-Bold.woff2", { weight: "700" }),
+    ]);
+
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      if (fonts.check("16px Virgil")) return;
+      await sleep(50);
+    }
+
+    if (import.meta.env.DEV) {
+      console.warn("[Editor] Excalidraw fonts not ready", {
+        assetBase,
+        assetDir,
+        virgil: fonts.check("16px Virgil"),
+        cascadia: fonts.check("16px Cascadia"),
+        assistant: fonts.check("16px Assistant"),
+        assistantBold: fonts.check("bold 16px Assistant"),
+      });
+    }
+  } catch (err) {
+    if (import.meta.env.DEV) console.warn("[Editor] Excalidraw font preload failed", err);
+  }
+};
+
 const toFiniteNumber = (value: any): number => {
   if (typeof value === "number") return Number.isFinite(value) ? value : 0;
   const n = Number(value);
@@ -1202,6 +1331,8 @@ export const Editor: React.FC = () => {
           collaborators: new Map(),
         };
         latestAppStateRef.current = hydratedAppState;
+
+        await preloadExcalidrawFonts();
 
         setInitialData({
           elements,


### PR DESCRIPTION
Fixes #68.

- Set `window.EXCALIDRAW_ASSET_PATH` early (in `frontend/index.html`) so Excalidraw loads its asset bundle from the same origin.
- Copy `excalidraw-assets` (and dev variant) from `@excalidraw/excalidraw` into `public/` for dev and `dist/` for production builds.
- Preload Excalidraw fonts before mounting the editor to avoid cached fallback font rendering.
- Ignore generated asset dirs in `.gitignore`.

Tested:
- `cd frontend && npm test`
- `cd frontend && npm run build`
