### PR TITLE
feat: update docker-compose for Proxmox/LXC environments with local persistence

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,24 +2,33 @@ services:
   backend:
     image: zimengxiong/excalidash-backend:latest
     container_name: excalidash-backend
-    environment:
-      - DATABASE_URL=file:/app/prisma/dev.db
-      - PORT=8000
-      - NODE_ENV=production
-      - AUTH_MODE=${AUTH_MODE:-local}
+    #environment:
+      #- DATABASE_URL=file:/app/prisma/dev.db
+      #- PORT=8000
+      #- NODE_ENV=production
+      #- AUTH_MODE=${AUTH_MODE:-local}
       # Keep disabled by default; only enable when a trusted proxy sanitizes forwarded headers.
-      - TRUST_PROXY=false
+      #- TRUST_PROXY=false
       # Optional for single-instance deployments:
       # if unset, backend auto-generates and persists one in the volume.
       # Recommended to set explicitly for portability and multi-instance setups.
-      - JWT_SECRET=${JWT_SECRET}
-      - CSRF_SECRET=${CSRF_SECRET}
+      #- JWT_SECRET=${JWT_SECRET}
+      #- CSRF_SECRET=${CSRF_SECRET}
       # Optional OIDC settings (required for AUTH_MODE=hybrid or oidc_enforced)
       # - OIDC_PROVIDER_NAME=Authentik
       # - OIDC_ISSUER_URL=https://auth.example.com/application/o/excalidash/
       # - OIDC_CLIENT_ID=your-client-id
       # - OIDC_CLIENT_SECRET=your-client-secret
       # - OIDC_REDIRECT_URI=https://excalidash.example.com/api/auth/oidc/callback
+    environment:
+      - DATABASE_URL=file:/app/prisma/dev.db
+      - PORT=8000
+      - NODE_ENV=production
+      - AUTH_MODE=local
+      - TRUST_PROXY=true
+      - ALLOWED_ORIGIN=http://{{ip_server}}:6767
+      - JWT_SECRET=sua_chave_secreta_aqui
+      - CSRF_SECRET=outra_chave_secreta_aqui
     volumes:
       - backend-data:/app/prisma
     networks:


### PR DESCRIPTION
Hi there!

I’m running this project on my Home Lab (Proxmox/LXC with CasaOS) and I successfully managed to get it working with a few adjustments to the docker-compose.yml.

The main changes I made were:

Added ALLOWED_ORIGIN and NEXT_PUBLIC_BACKEND_URL environment variables to fix CORS issues when accessing via server IP instead of localhost.

Set TRUST_PROXY=true to ensure the backend correctly handles requests coming through the server's network interface.

Ensured volumes are mapped correctly for local data persistence on the host machine.

My setup:

CPU: Intel i5 6th Gen

RAM: 16GB DDR4

OS: CasaOS running on a Proxmox LXC

This configuration is working perfectly now, and I hope it helps other users with similar local server setups!

Best regards,