### PR TITLE
fix: callback error due to invalid JWT token type

### DIFF
--- a/backend/src/auth/oidcRoutes.ts
+++ b/backend/src/auth/oidcRoutes.ts
@@ -265,6 +265,7 @@ export const registerOidcRoutes = (deps: RegisterOidcRoutesDeps) => {
           redirect_uris: [config.oidc.redirectUri as string],
           response_types: ["code"],
           token_endpoint_auth_method: tokenEndpointAuthMethod,
+          id_token_signed_response_alg: (issuer.metadata.id_token_signing_alg_values_supported as string[])?.[0] ?? "RS256",
         };
 
         if (config.oidc.clientSecret) {


### PR DESCRIPTION
fix: callback error due to invalid JWT token type

I am using Logto as my OIDC Auth provider | So, I wanted to add a fix such that the ExcaliDash API auto picks the preferred 'id_token_signed_response_alg'

Original Error Log :-
<img width="906" height="127" alt="2026-02-28_05-26-35" src="https://github.com/user-attachments/assets/d5606e84-9bbe-47b3-9e44-6f6b62772d66" />
