### PR TITLE
fix: hide empty Save to dialog in editor menu

### DIFF
--- a/frontend/src/pages/editor/shared.ts
+++ b/frontend/src/pages/editor/shared.ts
@@ -111,7 +111,7 @@ export const UIOptions = {
   canvasActions: {
     saveToActiveFile: false,
     loadScene: false,
-    export: { saveFileToDisk: false },
+    export: false as const,
     toggleTheme: true,
   },
 };


### PR DESCRIPTION
## Summary
- The "Save to..." menu item in the hamburger menu opened an empty modal dialog (just a title, no content)
- Root cause: `UIOptions.canvasActions.export` was set to `{ saveFileToDisk: false }`, which hid the only card inside the dialog but still showed the menu item
- Fix: set `export: false` to disable the menu item entirely — ExcaliDash auto-saves drawings so the dialog serves no purpose

## Test plan
- [ ] Open editor, click hamburger menu
- [ ] Verify "Save to..." no longer appears in the menu
- [ ] Verify "Save as image" still works (controlled by separate `saveAsImage` option)