### PR TITLE
Fix: 2 bugs relate to token expiration

### DIFF
--- a/backend/src/__tests__/link-sharing-public.integration.ts
+++ b/backend/src/__tests__/link-sharing-public.integration.ts
@@ -147,6 +147,56 @@ describe("Link Sharing - Public By Drawing ID", () => {
     expect(anonPut.body?.name).toBe("Renamed By Anonymous");
   });
 
+  it("returns 401 for expired token GET on a private drawing", async () => {
+    const drawing = await createDrawing();
+
+    const expiredToken = jwt.sign(
+      { userId: ownerUser.id, email: ownerUser.email, type: "access" },
+      config.jwtSecret,
+      { expiresIn: "0s" }
+    );
+
+    const res = await request(app)
+      .get(`/drawings/${drawing.id}`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${expiredToken}`);
+    expect(res.status).toBe(401);
+    expect(res.body?.error).toBe("Unauthorized");
+  });
+
+  it("returns 401 for expired token PUT on a private drawing", async () => {
+    const drawing = await createDrawing();
+
+    const expiredToken = jwt.sign(
+      { userId: ownerUser.id, email: ownerUser.email, type: "access" },
+      config.jwtSecret,
+      { expiresIn: "0s" }
+    );
+
+    const anonAgent = request.agent(app);
+    const anonCsrfRes = await anonAgent
+      .get("/csrf-token")
+      .set("User-Agent", userAgent);
+    const anonCsrfHeaderName = anonCsrfRes.body.header;
+    const anonCsrfToken = anonCsrfRes.body.token;
+
+    const res = await anonAgent
+      .put(`/drawings/${drawing.id}`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${expiredToken}`)
+      .set(anonCsrfHeaderName, anonCsrfToken)
+      .send({ name: "Should Not Save" });
+    expect(res.status).toBe(401);
+    expect(res.body?.error).toBe("Unauthorized");
+  });
+
+  it("returns 404 for anonymous GET on a non-existent drawing", async () => {
+    const anonGet = await request(app)
+      .get("/drawings/00000000-0000-0000-0000-000000000000")
+      .set("User-Agent", userAgent);
+    expect(anonGet.status).toBe(404);
+  });
+
   it("revokes previous active link-share when creating a new one", async () => {
     const drawing = await createDrawing();
 

--- a/backend/src/auth/cookies.ts
+++ b/backend/src/auth/cookies.ts
@@ -5,7 +5,6 @@ import { config } from "../config";
 export const ACCESS_TOKEN_COOKIE_NAME = "excalidash-access-token";
 export const REFRESH_TOKEN_COOKIE_NAME = "excalidash-refresh-token";
 
-const DEFAULT_ACCESS_TTL_MS = 15 * 60 * 1000;
 const DEFAULT_REFRESH_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 const parseDurationToMs = (value: string, fallbackMs: number): number => {
@@ -16,10 +15,6 @@ const parseDurationToMs = (value: string, fallbackMs: number): number => {
   return fallbackMs;
 };
 
-const ACCESS_TOKEN_COOKIE_MAX_AGE_MS = parseDurationToMs(
-  config.jwtAccessExpiresIn,
-  DEFAULT_ACCESS_TTL_MS
-);
 const REFRESH_TOKEN_COOKIE_MAX_AGE_MS = parseDurationToMs(
   config.jwtRefreshExpiresIn,
   DEFAULT_REFRESH_TTL_MS
@@ -59,9 +54,12 @@ export const setAuthCookies = (
   res: Response,
   tokens: { accessToken: string; refreshToken: string }
 ): void => {
+  // Access token cookie intentionally uses the refresh token lifetime so the
+  // browser always sends the (possibly expired) JWT.  The server detects the
+  // expired JWT and returns 401, letting the frontend refresh transparently.
   res.cookie(ACCESS_TOKEN_COOKIE_NAME, tokens.accessToken, {
     ...baseCookieOptions(req),
-    maxAge: ACCESS_TOKEN_COOKIE_MAX_AGE_MS,
+    maxAge: REFRESH_TOKEN_COOKIE_MAX_AGE_MS,
   });
   res.cookie(REFRESH_TOKEN_COOKIE_NAME, tokens.refreshToken, {
     ...baseCookieOptions(req),
@@ -76,7 +74,7 @@ export const setAccessTokenCookie = (
 ): void => {
   res.cookie(ACCESS_TOKEN_COOKIE_NAME, accessToken, {
     ...baseCookieOptions(req),
-    maxAge: ACCESS_TOKEN_COOKIE_MAX_AGE_MS,
+    maxAge: REFRESH_TOKEN_COOKIE_MAX_AGE_MS,
   });
 };
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -307,7 +307,6 @@ app.use(express.urlencoded({ extended: true, limit: "50mb" }));
 app.use((req, res, next) => {
   const requestId = req.headers["x-request-id"] || "unknown";
   const contentLength = req.headers["content-length"];
-  const userEmail = req.user?.email || "anonymous";
   
   if (contentLength) {
     const sizeInMB = parseInt(contentLength, 10) / 1024 / 1024;
@@ -315,13 +314,13 @@ app.use((req, res, next) => {
       console.log(
         `[LARGE REQUEST] ${req.method} ${req.path} - ${sizeInMB.toFixed(
           2
-        )}MB - User: ${userEmail} - RequestID: ${requestId}`
+        )}MB - RequestID: ${requestId}`
       );
     }
   }
   
   console.log(
-    `[REQUEST] ${req.method} ${req.path} - User: ${userEmail} - IP: ${req.ip} - RequestID: ${requestId}`
+    `[REQUEST] ${req.method} ${req.path} - IP: ${req.ip} - RequestID: ${requestId}`
   );
   
   next();

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -233,7 +233,13 @@ export const createAuthMiddleware = ({
     const payload = verifyToken(token);
 
     if (!payload) {
-      return next();
+      // Token present but invalid/expired — return 401 so the frontend
+      // interceptor can refresh the access token and retry.
+      res.status(401).json({
+        error: "Unauthorized",
+        message: "Invalid or expired token",
+      });
+      return;
     }
 
     try {


### PR DESCRIPTION


https://github.com/user-attachments/assets/186147ec-2fce-4110-b3cf-dea470e053e6


## Bug 1: Expired token results in 404
- `backend/src/middleware/auth.ts` — optionalAuth silently swallowed expired/invalid tokens by calling `next()` without setting `req.user`.
```ts
    const payload = verifyToken(token);

    if (!payload) {
      return next();
    }
```
This caused downstream access checks to fail with 404 "Drawing not found" instead of 401 (frontend can't know to refresh).
>[!note]
Fix: Return 401 when a token is present but invalid/expired.

## Bug 2: Access token cookie deleted before JWT can be evaluated
- backend/src/auth/cookies.ts — The access token cookie maxAge was set to the same 15m as the JWT expiration. After 15 minutes idle, the browser deleted the cookie entirely, so the expired JWT never reached the server -> Cause downstream access check to return 404 (frontend can't know to refresh).
```ts
    const token = extractToken(req);

    if (!token) {
      return next();
    }
```
>[!note]
Fix: Set the access token cookie lifetime to match the refresh token (7d) so the expired JWT always reaches the server and can be properly rejected with 401.