### PR TITLE
Fix HTTPS redirect issue behind reverse proxy with TLS termination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,7 @@ Backend base variables:
 - `ENABLE_PASSWORD_RESET` (`true` to enable)
 - `ENABLE_REFRESH_TOKEN_ROTATION` (`true`/`false`, default `true`)
 - `ENABLE_AUDIT_LOGGING` (`true`/`false`, default `false`)
+- `ENFORCE_HTTPS_REDIRECT` (`true`/`false`, default `true`) — when `FRONTEND_URL` uses `https://`, the backend auto-redirects plain-HTTP requests; set to `false` when the outer gateway already enforces HTTPS to avoid redirect loops
 - `BOOTSTRAP_SETUP_CODE_TTL_MS` (default `900000`)
 - `BOOTSTRAP_SETUP_CODE_MAX_ATTEMPTS` (default `10`)
 - `UPDATE_CHECK_OUTBOUND` (`true`/`false`/`1`/`yes`, default `true`)
@@ -271,6 +272,7 @@ E2E variables:
 - `ENABLE_PASSWORD_RESET`: enable/disable password reset flow.
 - `ENABLE_REFRESH_TOKEN_ROTATION`: control refresh-token rotation behavior.
 - `ENABLE_AUDIT_LOGGING`: enable/disable audit event logging.
+- `ENFORCE_HTTPS_REDIRECT`: disable built-in HTTP→HTTPS redirect when outer gateway handles it (set to `false`; default `true`).
 - `UPDATE_CHECK_OUTBOUND`: disable outbound version check traffic.
 - `DISABLE_ONBOARDING_GATE`: bypass first-run onboarding guard (not recommended in production).
 - `RUN_MIGRATIONS`: run migrations in backend container startup (`true` default).

--- a/README.md
+++ b/README.md
@@ -182,11 +182,12 @@ docker compose up -d
 
 When running ExcaliDash behind Traefik, Nginx, or another reverse proxy, configure both containers so that API + WebSocket calls resolve correctly:
 
-| Variable       | Purpose                                                                                                                                                                   |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `FRONTEND_URL` | Backend allowed origin(s). Must match the public URL users access (for example `https://excalidash.example.com`). Supports comma-separated values for multiple addresses. |
-| `TRUST_PROXY`  | Set to `1` when traffic passes through one trusted reverse-proxy hop (for example frontend nginx -> backend) and headers are sanitized.                                   |
-| `BACKEND_URL`  | Frontend container-to-backend target used by Nginx. Override when backend host differs from default service DNS/host.                                                     |
+| Variable                 | Purpose                                                                                                                                                                   |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FRONTEND_URL`           | Backend allowed origin(s). Must match the public URL users access (for example `https://excalidash.example.com`). Supports comma-separated values for multiple addresses. |
+| `TRUST_PROXY`            | Set to `1` when traffic passes through one trusted reverse-proxy hop (for example frontend nginx -> backend) and headers are sanitized.                                   |
+| `BACKEND_URL`            | Frontend container-to-backend target used by Nginx. Override when backend host differs from default service DNS/host.                                                     |
+| `ENFORCE_HTTPS_REDIRECT` | When `FRONTEND_URL` uses `https://`, the backend automatically redirects plain-HTTP requests to HTTPS. Set to `false` if your outer gateway already enforces HTTPS and you want to disable the built-in redirect (avoids redirect loops when `X-Forwarded-Proto` is not forwarded). Default: `true`. |
 
 ```yaml
 # docker-compose.yml example
@@ -198,6 +199,9 @@ backend:
     - TRUST_PROXY=1
     # Or multiple URLs (comma-separated) for local + network access
     # - FRONTEND_URL=http://localhost:6767,http://192.168.1.100:6767,http://nas.local:6767
+    # If your outer gateway enforces HTTPS and X-Forwarded-Proto is not forwarded,
+    # disable the built-in redirect to prevent redirect loops:
+    # - ENFORCE_HTTPS_REDIRECT=false
 frontend:
   environment:
     # For standard Docker Compose (default)
@@ -339,14 +343,15 @@ docker compose -f docker-compose.oidc.yml down
 
 Base values are documented in `backend/.env.example`. Common ones to care about:
 
-| Variable       | Default / Example         | Description                                                                         |
-| -------------- | ------------------------- | ----------------------------------------------------------------------------------- |
-| `DATABASE_URL` | `file:/app/prisma/dev.db` | SQLite file or external DB URL.                                                     |
-| `FRONTEND_URL` | `http://localhost:6767`   | Allowed frontend origin(s), comma-separated for multiple entries.                   |
-| `TRUST_PROXY`  | `false`                   | `false`, `true`, or hop count (for example `1`).                                    |
-| `JWT_SECRET`   | `change-this-secret...`   | Recommended in production so sessions remain stable across restarts and migrations. |
-| `CSRF_SECRET`  | `change-this-secret`      | Recommended in production so CSRF validation remains stable across restarts.        |
-| `AUTH_MODE`    | `local`                   | `local`, `hybrid`, `oidc_enforced`.                                                 |
+| Variable                 | Default / Example         | Description                                                                         |
+| ------------------------ | ------------------------- | ----------------------------------------------------------------------------------- |
+| `DATABASE_URL`           | `file:/app/prisma/dev.db` | SQLite file or external DB URL.                                                     |
+| `FRONTEND_URL`           | `http://localhost:6767`   | Allowed frontend origin(s), comma-separated for multiple entries.                   |
+| `TRUST_PROXY`            | `false`                   | `false`, `true`, or hop count (for example `1`).                                    |
+| `JWT_SECRET`             | `change-this-secret...`   | Recommended in production so sessions remain stable across restarts and migrations. |
+| `CSRF_SECRET`            | `change-this-secret`      | Recommended in production so CSRF validation remains stable across restarts.        |
+| `AUTH_MODE`              | `local`                   | `local`, `hybrid`, `oidc_enforced`.                                                 |
+| `ENFORCE_HTTPS_REDIRECT` | `true`                    | Set to `false` to disable the built-in HTTP→HTTPS redirect when your outer gateway handles it. |
 
 </details>
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,6 +15,12 @@ CSRF_SECRET=change-this-secret-in-production
 # ENABLE_REFRESH_TOKEN_ROTATION=true
 # ENABLE_AUDIT_LOGGING=false
 
+# When FRONTEND_URL uses https://, the backend will redirect plain-HTTP requests
+# to HTTPS by default. Set to "false" when your external gateway (Nginx, Traefik,
+# Caddy, etc.) already enforces HTTPS and you want to prevent double-redirect
+# loops or want to delegate HTTPS enforcement entirely to the outer proxy.
+# ENFORCE_HTTPS_REDIRECT=true
+
 # Migration control
 # For SQLite in Kubernetes, prefer running migrations once via a Job/init container
 # and set RUN_MIGRATIONS=false on the main Deployment to avoid concurrent migrates.

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -23,6 +23,7 @@ interface Config {
   enablePasswordReset: boolean;
   enableRefreshTokenRotation: boolean;
   enableAuditLogging: boolean;
+  enforceHttpsRedirect: boolean;
   bootstrapSetupCodeTtlMs: number;
   bootstrapSetupCodeMaxAttempts: number;
 }
@@ -243,6 +244,7 @@ export const config: Config = {
   enablePasswordReset: getOptionalBoolean("ENABLE_PASSWORD_RESET", false),
   enableRefreshTokenRotation: getOptionalBoolean("ENABLE_REFRESH_TOKEN_ROTATION", true),
   enableAuditLogging: getOptionalBoolean("ENABLE_AUDIT_LOGGING", false),
+  enforceHttpsRedirect: getOptionalBoolean("ENFORCE_HTTPS_REDIRECT", true),
   bootstrapSetupCodeTtlMs: getRequiredEnvNumber("BOOTSTRAP_SETUP_CODE_TTL_MS", 15 * 60 * 1000),
   bootstrapSetupCodeMaxAttempts: getRequiredEnvNumber("BOOTSTRAP_SETUP_CODE_MAX_ATTEMPTS", 10),
 };

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -227,6 +227,7 @@ app.use((req, res, next) => {
 
 const shouldEnforceHttps =
   config.nodeEnv === "production" &&
+  config.enforceHttpsRedirect &&
   allowedOrigins.some((origin) => origin.toLowerCase().startsWith("https://"));
 
 if (shouldEnforceHttps) {


### PR DESCRIPTION
In this setup, TLS is handled only by the outer proxy, while frontend and backend communicate over internal HTTP, which is already the deployment model implied by the current frontend nginx config. The current backend HTTPS enforcement is too strict for this common reverse-proxy setup and breaks login/auth flows.

This PR adds a way to disable backend-level HTTPS redirect enforcement so deployments can safely rely on edge TLS termination only.

----

See https://github.com/OhYee/ExcaliDash/pull/1

Agent-Logs-Url: https://github.com/OhYee/ExcaliDash/sessions/3e16db38-2555-4d73-b89b-dbac6adcf659