### PR TITLE
feat: add language selector with browser detection and custom MainMenu

### DIFF
--- a/frontend/src/components/LanguageSelector.tsx
+++ b/frontend/src/components/LanguageSelector.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { languages, useI18n } from '@excalidraw/excalidraw';
+
+const STORAGE_KEY = 'excalidash-lang';
+
+function detectLanguage(): string {
+  const browserLangs = Array.from(navigator.languages ?? [navigator.language]);
+  const supported = new Set(languages.map((l) => l.code));
+  for (const bl of browserLangs) {
+    if (supported.has(bl)) return bl;
+    const prefix = bl.split('-')[0];
+    const match = languages.find((l) => l.code.startsWith(prefix));
+    if (match) return match.code;
+  }
+  return 'en';
+}
+
+export function getInitialLangCode(): string {
+  try {
+    return localStorage.getItem(STORAGE_KEY) ?? detectLanguage();
+  } catch {
+    return detectLanguage();
+  }
+}
+
+interface LanguageSelectorProps {
+  langCode: string;
+  onChange: (code: string) => void;
+}
+
+/**
+ * Language selector rendered inside <Excalidraw> children so that `useI18n`
+ * can access the Excalidraw i18n context.
+ */
+export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
+  langCode,
+  onChange,
+}) => {
+  const { t } = useI18n();
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const code = e.target.value;
+    try {
+      localStorage.setItem(STORAGE_KEY, code);
+    } catch {
+      // ignore localStorage errors in restricted environments
+    }
+    onChange(code);
+  };
+
+  return (
+    <div
+      style={{
+        padding: '4px 8px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        width: '100%',
+      }}
+    >
+      <span style={{ fontSize: 13, flexShrink: 0 }}>
+        {t('labels.language', null, 'Language')}
+      </span>
+      <select
+        value={langCode}
+        onChange={handleChange}
+        style={{
+          flex: 1,
+          fontSize: 13,
+          padding: '2px 4px',
+          borderRadius: 4,
+          border: '1px solid var(--color-surface-mid)',
+          background: 'var(--color-surface-low)',
+          color: 'var(--color-on-surface)',
+          cursor: 'pointer',
+        }}
+        aria-label={t('labels.language', null, 'Language')}
+      >
+        {languages.map((lang) => (
+          <option key={lang.code} value={lang.code}>
+            {lang.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -5,10 +5,12 @@ import clsx from 'clsx';
 import {
   Excalidraw,
   CaptureUpdateAction,
+  MainMenu,
   convertToExcalidrawElements,
   exportToSvg,
   viewportCoordsToSceneCoords,
 } from '@excalidraw/excalidraw';
+import { getInitialLangCode, LanguageSelector } from '../components/LanguageSelector';
 import debounce from 'lodash/debounce';
 import throttle from 'lodash/throttle';
 import { Toaster, toast } from 'sonner';
@@ -207,6 +209,7 @@ export const Editor: React.FC = () => {
   const [isSavingOnLeave, setIsSavingOnLeave] = useState(false);
   const [autoHideEnabled, setAutoHideEnabled] = useState(getStoredAutoHideEnabled);
   const [isShareOpen, setIsShareOpen] = useState(false);
+  const [langCode, setLangCode] = useState(getInitialLangCode);
   const { isHeaderVisible, setIsHeaderVisible } = useEditorChrome({
     drawingName,
     autoHideEnabled,
@@ -1873,6 +1876,7 @@ export const Editor: React.FC = () => {
           <Excalidraw
             key={id}
             theme={theme === 'dark' ? 'dark' : 'light'}
+            langCode={langCode}
             initialData={initialData}
             onChange={handleCanvasChange}
             onPointerUpdate={onPointerUpdate}
@@ -1880,7 +1884,19 @@ export const Editor: React.FC = () => {
             excalidrawAPI={setExcalidrawAPI}
             UIOptions={UIOptions}
             viewModeEnabled={!canEdit}
-          />
+          >
+            <MainMenu>
+              <MainMenu.DefaultItems.ToggleTheme />
+              <MainMenu.DefaultItems.SaveAsImage />
+              <MainMenu.DefaultItems.ClearCanvas />
+              <MainMenu.DefaultItems.ChangeCanvasBackground />
+              <MainMenu.DefaultItems.Help />
+              <MainMenu.Separator />
+              <MainMenu.ItemCustom>
+                <LanguageSelector langCode={langCode} onChange={setLangCode} />
+              </MainMenu.ItemCustom>
+            </MainMenu>
+          </Excalidraw>
         ) : (
           <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-gray-500 dark:text-gray-400">
             <span className="text-sm font-medium">


### PR DESCRIPTION
feat: add language selector with browser detection and custom MainMenu

- Add LanguageSelector component that detects browser language on first
  load and persists the user's choice in localStorage
- Integrate LanguageSelector into a custom Excalidraw MainMenu so users
  can switch language from the editor toolbar
- Pass langCode state to <Excalidraw> to apply the selected language
- Supported languages are sourced directly from @excalidraw/excalidraw
