### PR TITLE
Feat/collection sharing backend

### DIFF
--- a/backend/prisma/migrations/20260326143103_add_collection_sharing/migration.sql
+++ b/backend/prisma/migrations/20260326143103_add_collection_sharing/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "CollectionShare" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "collectionId" TEXT NOT NULL,
+    "granteeUserId" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'view',
+    "createdByUserId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "CollectionShare_collectionId_fkey" FOREIGN KEY ("collectionId") REFERENCES "Collection" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "CollectionShare_granteeUserId_fkey" FOREIGN KEY ("granteeUserId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "CollectionShare_collectionId_idx" ON "CollectionShare"("collectionId");
+
+-- CreateIndex
+CREATE INDEX "CollectionShare_granteeUserId_idx" ON "CollectionShare"("granteeUserId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CollectionShare_collectionId_granteeUserId_key" ON "CollectionShare"("collectionId", "granteeUserId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,6 +22,7 @@ model User {
   drawings            Drawing[]
   collections         Collection[]
   drawingPermissions  DrawingPermission[]
+  collectionShares    CollectionShare[]
   passwordResetTokens PasswordResetToken[]
   refreshTokens       RefreshToken[]
   auditLogs           AuditLog[]
@@ -36,7 +37,7 @@ model SystemConfig {
   registrationEnabled        Boolean  @default(false)
   oidcJitProvisioningEnabled Boolean?
   authLoginRateLimitEnabled  Boolean  @default(true)
-  authLoginRateLimitWindowMs Int      @default(900000) // 15 minutes
+  authLoginRateLimitWindowMs Int      @default(900000)
   authLoginRateLimitMax      Int      @default(20)
   bootstrapSetupCodeHash     String?
   bootstrapSetupCodeIssuedAt DateTime?
@@ -47,13 +48,14 @@ model SystemConfig {
 }
 
 model Collection {
-  id        String    @id @default(uuid())
+  id        String            @id @default(uuid())
   name      String
   userId    String
-  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user      User              @relation(fields: [userId], references: [id], onDelete: Cascade)
   drawings  Drawing[]
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @updatedAt
+  shares    CollectionShare[]
+  createdAt DateTime          @default(now())
+  updatedAt DateTime          @updatedAt
 
   @@index([userId, updatedAt])
 }
@@ -61,10 +63,10 @@ model Collection {
 model Drawing {
   id           String      @id @default(uuid())
   name         String
-  elements     String // Stored as JSON string
-  appState     String // Stored as JSON string
-  files        String      @default("{}") // Stored as JSON string
-  preview      String? // SVG string for thumbnail
+  elements     String
+  appState     String
+  files        String      @default("{}")
+  preview      String?
   version      Int         @default(1)
   userId       String
   user         User        @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -80,15 +82,15 @@ model Drawing {
 }
 
 model DrawingPermission {
-  id           String   @id @default(uuid())
-  drawingId    String
-  drawing      Drawing  @relation(fields: [drawingId], references: [id], onDelete: Cascade)
-  granteeUserId String
-  granteeUser  User     @relation(fields: [granteeUserId], references: [id], onDelete: Cascade)
-  permission   String // "view" | "edit"
+  id              String   @id @default(uuid())
+  drawingId       String
+  drawing         Drawing  @relation(fields: [drawingId], references: [id], onDelete: Cascade)
+  granteeUserId   String
+  granteeUser     User     @relation(fields: [granteeUserId], references: [id], onDelete: Cascade)
+  permission      String
   createdByUserId String
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 
   @@unique([drawingId, granteeUserId], name: "drawingId_granteeUserId")
   @@index([granteeUserId])
@@ -96,28 +98,44 @@ model DrawingPermission {
 }
 
 model DrawingLinkShare {
-  id            String   @id @default(uuid())
-  drawingId     String
-  drawing       Drawing  @relation(fields: [drawingId], references: [id], onDelete: Cascade)
-  permission    String // "view" | "edit"
-  tokenHash     String   @unique
-  passphraseHash String?
-  expiresAt     DateTime?
-  revokedAt     DateTime?
-  failedAttempts Int     @default(0)
-  lockedUntil   DateTime?
-  lastUsedAt    DateTime?
-  lastUsedIp    String?
+  id              String    @id @default(uuid())
+  drawingId       String
+  drawing         Drawing   @relation(fields: [drawingId], references: [id], onDelete: Cascade)
+  permission      String
+  tokenHash       String    @unique
+  passphraseHash  String?
+  expiresAt       DateTime?
+  revokedAt       DateTime?
+  failedAttempts  Int       @default(0)
+  lockedUntil     DateTime?
+  lastUsedAt      DateTime?
+  lastUsedIp      String?
   createdByUserId String
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
 
   @@index([drawingId])
 }
 
+model CollectionShare {
+  id              String     @id @default(uuid())
+  collectionId    String
+  collection      Collection @relation(fields: [collectionId], references: [id], onDelete: Cascade)
+  granteeUserId   String
+  granteeUser     User       @relation(fields: [granteeUserId], references: [id], onDelete: Cascade)
+  role            String     @default("view")
+  createdByUserId String
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @updatedAt
+
+  @@unique([collectionId, granteeUserId])
+  @@index([collectionId])
+  @@index([granteeUserId])
+}
+
 model Library {
-  id        String   @id // User-specific library ID (e.g., "user_<userId>")
-  items     String   @default("[]") // Stored as JSON string array of library items
+  id        String   @id
+  items     String   @default("[]")
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
@@ -146,25 +164,25 @@ model AuditLog {
   id        String   @id @default(uuid())
   userId    String?
   user      User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
-  action    String   // e.g., "login", "login_failed", "password_reset", "password_changed", "drawing_deleted"
-  resource  String?  // e.g., "drawing:123", "collection:456"
+  action    String
+  resource  String?
   ipAddress String?
   userAgent String?
-  details   String?  // JSON string for additional details
+  details   String?
   createdAt DateTime @default(now())
 }
 
 model AuthIdentity {
-  id          String   @id @default(uuid())
+  id          String    @id @default(uuid())
   userId      String
-  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   provider    String
   issuer      String
   subject     String
   emailAtLink String
   lastLoginAt DateTime?
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 
   @@unique([issuer, subject])
   @@unique([provider, userId])

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,6 +22,7 @@ model User {
   drawings            Drawing[]
   collections         Collection[]
   drawingPermissions  DrawingPermission[]
+  collectionShares    CollectionShare[]
   passwordResetTokens PasswordResetToken[]
   refreshTokens       RefreshToken[]
   auditLogs           AuditLog[]
@@ -36,7 +37,7 @@ model SystemConfig {
   registrationEnabled        Boolean  @default(false)
   oidcJitProvisioningEnabled Boolean?
   authLoginRateLimitEnabled  Boolean  @default(true)
-  authLoginRateLimitWindowMs Int      @default(900000) // 15 minutes
+  authLoginRateLimitWindowMs Int      @default(900000)
   authLoginRateLimitMax      Int      @default(20)
   bootstrapSetupCodeHash     String?
   bootstrapSetupCodeIssuedAt DateTime?
@@ -47,13 +48,14 @@ model SystemConfig {
 }
 
 model Collection {
-  id        String    @id @default(uuid())
+  id        String            @id @default(uuid())
   name      String
   userId    String
-  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user      User              @relation(fields: [userId], references: [id], onDelete: Cascade)
   drawings  Drawing[]
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @updatedAt
+  shares    CollectionShare[]
+  createdAt DateTime          @default(now())
+  updatedAt DateTime          @updatedAt
 
   @@index([userId, updatedAt])
 }
@@ -61,10 +63,10 @@ model Collection {
 model Drawing {
   id           String      @id @default(uuid())
   name         String
-  elements     String // Stored as JSON string
-  appState     String // Stored as JSON string
-  files        String      @default("{}") // Stored as JSON string
-  preview      String? // SVG string for thumbnail
+  elements     String
+  appState     String
+  files        String      @default("{}")
+  preview      String?
   version      Int         @default(1)
   userId       String
   user         User        @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -95,15 +97,15 @@ model DrawingSnapshot {
 }
 
 model DrawingPermission {
-  id           String   @id @default(uuid())
-  drawingId    String
-  drawing      Drawing  @relation(fields: [drawingId], references: [id], onDelete: Cascade)
-  granteeUserId String
-  granteeUser  User     @relation(fields: [granteeUserId], references: [id], onDelete: Cascade)
-  permission   String // "view" | "edit"
+  id              String   @id @default(uuid())
+  drawingId       String
+  drawing         Drawing  @relation(fields: [drawingId], references: [id], onDelete: Cascade)
+  granteeUserId   String
+  granteeUser     User     @relation(fields: [granteeUserId], references: [id], onDelete: Cascade)
+  permission      String
   createdByUserId String
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 
   @@unique([drawingId, granteeUserId], name: "drawingId_granteeUserId")
   @@index([granteeUserId])
@@ -111,28 +113,44 @@ model DrawingPermission {
 }
 
 model DrawingLinkShare {
-  id            String   @id @default(uuid())
-  drawingId     String
-  drawing       Drawing  @relation(fields: [drawingId], references: [id], onDelete: Cascade)
-  permission    String // "view" | "edit"
-  tokenHash     String   @unique
-  passphraseHash String?
-  expiresAt     DateTime?
-  revokedAt     DateTime?
-  failedAttempts Int     @default(0)
-  lockedUntil   DateTime?
-  lastUsedAt    DateTime?
-  lastUsedIp    String?
+  id              String    @id @default(uuid())
+  drawingId       String
+  drawing         Drawing   @relation(fields: [drawingId], references: [id], onDelete: Cascade)
+  permission      String
+  tokenHash       String    @unique
+  passphraseHash  String?
+  expiresAt       DateTime?
+  revokedAt       DateTime?
+  failedAttempts  Int       @default(0)
+  lockedUntil     DateTime?
+  lastUsedAt      DateTime?
+  lastUsedIp      String?
   createdByUserId String
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
 
   @@index([drawingId])
 }
 
+model CollectionShare {
+  id              String     @id @default(uuid())
+  collectionId    String
+  collection      Collection @relation(fields: [collectionId], references: [id], onDelete: Cascade)
+  granteeUserId   String
+  granteeUser     User       @relation(fields: [granteeUserId], references: [id], onDelete: Cascade)
+  role            String     @default("view")
+  createdByUserId String
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @updatedAt
+
+  @@unique([collectionId, granteeUserId])
+  @@index([collectionId])
+  @@index([granteeUserId])
+}
+
 model Library {
-  id        String   @id // User-specific library ID (e.g., "user_<userId>")
-  items     String   @default("[]") // Stored as JSON string array of library items
+  id        String   @id
+  items     String   @default("[]")
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
@@ -161,25 +179,25 @@ model AuditLog {
   id        String   @id @default(uuid())
   userId    String?
   user      User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
-  action    String   // e.g., "login", "login_failed", "password_reset", "password_changed", "drawing_deleted"
-  resource  String?  // e.g., "drawing:123", "collection:456"
+  action    String
+  resource  String?
   ipAddress String?
   userAgent String?
-  details   String?  // JSON string for additional details
+  details   String?
   createdAt DateTime @default(now())
 }
 
 model AuthIdentity {
-  id          String   @id @default(uuid())
+  id          String    @id @default(uuid())
   userId      String
-  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   provider    String
   issuer      String
   subject     String
   emailAtLink String
   lastLoginAt DateTime?
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 
   @@unique([issuer, subject])
   @@unique([provider, userId])

--- a/backend/src/__tests__/collection-sharing.integration.ts
+++ b/backend/src/__tests__/collection-sharing.integration.ts
@@ -1,0 +1,388 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import request from "supertest";
+import bcrypt from "bcrypt";
+import jwt, { SignOptions } from "jsonwebtoken";
+import { StringValue } from "ms";
+import { PrismaClient } from "../generated/client";
+import { config } from "../config";
+import { getTestPrisma, setupTestDb } from "./testUtils";
+
+describe("Collection Sharing - Backend Integration", () => {
+  const userAgent = "vitest-collection-sharing";
+  let prisma: PrismaClient;
+  let app: any;
+
+  let owner: { id: string; email: string };
+  let viewer: { id: string; email: string };
+  let editor: { id: string; email: string };
+
+  let ownerToken: string;
+  let viewerToken: string;
+  let editorToken: string;
+
+  let ownerAgent: any;
+  let ownerCsrfHeaderName: string;
+  let ownerCsrfToken: string;
+
+  let viewerAgent: any;
+  let viewerCsrfHeaderName: string;
+  let viewerCsrfToken: string;
+
+  let editorAgent: any;
+  let editorCsrfHeaderName: string;
+  let editorCsrfToken: string;
+
+  const signAccessToken = (user: { id: string; email: string }) => {
+    const signOptions: SignOptions = {
+      expiresIn: config.jwtAccessExpiresIn as StringValue,
+    };
+    return jwt.sign(
+      { userId: user.id, email: user.email, type: "access" },
+      config.jwtSecret,
+      signOptions,
+    );
+  };
+
+  const createUser = async (email: string, name: string) => {
+    const passwordHash = await bcrypt.hash("password123", 10);
+    return prisma.user.create({
+      data: {
+        email,
+        passwordHash,
+        name,
+        role: "USER",
+        isActive: true,
+      },
+      select: { id: true, email: true },
+    });
+  };
+
+  const createCollection = async () =>
+    prisma.collection.create({
+      data: { name: "Shared Collection", userId: owner.id },
+      select: { id: true, userId: true, name: true },
+    });
+
+  const createDrawingInCollection = async (collectionId: string) =>
+    prisma.drawing.create({
+      data: {
+        name: "Owner Drawing",
+        elements: "[]",
+        appState: "{}",
+        files: "{}",
+        userId: owner.id,
+        collectionId,
+      },
+      select: { id: true, collectionId: true, userId: true },
+    });
+
+  beforeAll(async () => {
+    setupTestDb();
+    prisma = getTestPrisma();
+    ({ app } = await import("../index"));
+
+    await prisma.systemConfig.upsert({
+      where: { id: "default" },
+      update: {
+        authEnabled: true,
+        registrationEnabled: false,
+      },
+      create: {
+        id: "default",
+        authEnabled: true,
+        registrationEnabled: false,
+      },
+    });
+
+    owner = await createUser("owner-collections@test.local", "Owner User");
+    viewer = await createUser("viewer-collections@test.local", "Viewer User");
+    editor = await createUser("editor-collections@test.local", "Editor User");
+
+    ownerToken = signAccessToken(owner);
+    viewerToken = signAccessToken(viewer);
+    editorToken = signAccessToken(editor);
+
+    ownerAgent = request.agent(app);
+    const ownerCsrfRes = await ownerAgent
+      .get("/csrf-token")
+      .set("User-Agent", userAgent);
+    ownerCsrfHeaderName = ownerCsrfRes.body.header;
+    ownerCsrfToken = ownerCsrfRes.body.token;
+
+    viewerAgent = request.agent(app);
+    const viewerCsrfRes = await viewerAgent
+      .get("/csrf-token")
+      .set("User-Agent", userAgent);
+    viewerCsrfHeaderName = viewerCsrfRes.body.header;
+    viewerCsrfToken = viewerCsrfRes.body.token;
+
+    editorAgent = request.agent(app);
+    const editorCsrfRes = await editorAgent
+      .get("/csrf-token")
+      .set("User-Agent", userAgent);
+    editorCsrfHeaderName = editorCsrfRes.body.header;
+    editorCsrfToken = editorCsrfRes.body.token;
+  }, 120000);
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("adds a viewer share and returns collection metadata for the recipient", async () => {
+    const collection = await createCollection();
+
+    const shareResponse = await ownerAgent
+      .post(`/collections/${collection.id}/shares`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${ownerToken}`)
+      .set(ownerCsrfHeaderName, ownerCsrfToken)
+      .send({ identifier: viewer.email, role: "view" });
+
+    expect(shareResponse.status).toBe(200);
+    expect(shareResponse.body?.share?.role).toBe("view");
+    expect(shareResponse.body?.share?.granteeUserId).toBe(viewer.id);
+
+    const collectionsResponse = await request(app)
+      .get("/collections")
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${viewerToken}`);
+
+    expect(collectionsResponse.status).toBe(200);
+    const sharedCollection = (collectionsResponse.body as any[]).find(
+      (c) => c.id === collection.id,
+    );
+    expect(sharedCollection).toBeTruthy();
+    expect(sharedCollection?.isOwner).toBe(false);
+    expect(sharedCollection?.sharedRole).toBe("view");
+  });
+
+  it("allows view access to drawings in shared collection but blocks creating for view-only share", async () => {
+    const collection = await createCollection();
+    await createDrawingInCollection(collection.id);
+
+    await ownerAgent
+      .post(`/collections/${collection.id}/shares`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${ownerToken}`)
+      .set(ownerCsrfHeaderName, ownerCsrfToken)
+      .send({ identifier: viewer.email, role: "view" });
+
+    const drawingsListResponse = await request(app)
+      .get(`/drawings?collectionId=${collection.id}`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${viewerToken}`);
+
+    expect(drawingsListResponse.status).toBe(200);
+    expect((drawingsListResponse.body?.drawings ?? []).length).toBe(1);
+
+    const createDrawingResponse = await viewerAgent
+      .post("/drawings")
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${viewerToken}`)
+      .set(viewerCsrfHeaderName, viewerCsrfToken)
+      .send({
+        name: "Viewer Cannot Create Here",
+        elements: [],
+        appState: {},
+        files: {},
+        collectionId: collection.id,
+      });
+
+    expect(createDrawingResponse.status).toBe(403);
+    expect(createDrawingResponse.body?.error).toContain("No edit access");
+  });
+
+  it("allows creating drawings in shared collection for editor role", async () => {
+    const collection = await createCollection();
+
+    await ownerAgent
+      .post(`/collections/${collection.id}/shares`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${ownerToken}`)
+      .set(ownerCsrfHeaderName, ownerCsrfToken)
+      .send({ identifier: editor.email, role: "edit" });
+
+    const createDrawingResponse = await editorAgent
+      .post("/drawings")
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${editorToken}`)
+      .set(editorCsrfHeaderName, editorCsrfToken)
+      .send({
+        name: "Editor Can Create Here",
+        elements: [],
+        appState: {},
+        files: {},
+        collectionId: collection.id,
+      });
+
+    expect(createDrawingResponse.status).toBe(200);
+    expect(createDrawingResponse.body?.collectionId).toBe(collection.id);
+    expect(createDrawingResponse.body?.userId).toBe(editor.id);
+  });
+
+  it("revokes access after removing collection share", async () => {
+    const collection = await createCollection();
+
+    await ownerAgent
+      .post(`/collections/${collection.id}/shares`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${ownerToken}`)
+      .set(ownerCsrfHeaderName, ownerCsrfToken)
+      .send({ identifier: viewer.email, role: "view" });
+
+    const deleteShareResponse = await ownerAgent
+      .delete(`/collections/${collection.id}/shares/${viewer.id}`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${ownerToken}`)
+      .set(ownerCsrfHeaderName, ownerCsrfToken);
+
+    expect(deleteShareResponse.status).toBe(200);
+    expect(deleteShareResponse.body?.success).toBe(true);
+
+    const drawingsListResponse = await request(app)
+      .get(`/drawings?collectionId=${collection.id}`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${viewerToken}`);
+
+    expect(drawingsListResponse.status).toBe(404);
+  });
+
+  it("hides a previously shared collection from the recipient after the owner deletes it", async () => {
+    const collection = await createCollection();
+
+    await ownerAgent
+      .post(`/collections/${collection.id}/shares`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${ownerToken}`)
+      .set(ownerCsrfHeaderName, ownerCsrfToken)
+      .send({ identifier: viewer.email, role: "view" });
+
+    const beforeDeleteCollectionsResponse = await request(app)
+      .get("/collections")
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${viewerToken}`);
+
+    expect(beforeDeleteCollectionsResponse.status).toBe(200);
+    expect(
+      (beforeDeleteCollectionsResponse.body as any[]).some(
+        (c) => c.id === collection.id,
+      ),
+    ).toBe(true);
+
+    const deleteCollectionResponse = await ownerAgent
+      .delete(`/collections/${collection.id}`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${ownerToken}`)
+      .set(ownerCsrfHeaderName, ownerCsrfToken);
+
+    expect(deleteCollectionResponse.status).toBe(200);
+    expect(deleteCollectionResponse.body?.success).toBe(true);
+
+    const afterDeleteCollectionsResponse = await request(app)
+      .get("/collections")
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${viewerToken}`);
+
+    expect(afterDeleteCollectionsResponse.status).toBe(200);
+    expect(
+      (afterDeleteCollectionsResponse.body as any[]).some(
+        (c) => c.id === collection.id,
+      ),
+    ).toBe(false);
+  });
+
+  it("prevents a view-only invited user from renaming, editing, or deleting drawings in the shared collection", async () => {
+    const collection = await createCollection();
+    const drawing = await createDrawingInCollection(collection.id);
+
+    await ownerAgent
+      .post(`/collections/${collection.id}/shares`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${ownerToken}`)
+      .set(ownerCsrfHeaderName, ownerCsrfToken)
+      .send({ identifier: viewer.email, role: "view" });
+
+    const renameResponse = await viewerAgent
+      .put(`/drawings/${drawing.id}`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${viewerToken}`)
+      .set(viewerCsrfHeaderName, viewerCsrfToken)
+      .send({ name: "Viewer Rename Attempt" });
+    expect(renameResponse.status).toBe(404);
+
+    const editResponse = await viewerAgent
+      .put(`/drawings/${drawing.id}`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${viewerToken}`)
+      .set(viewerCsrfHeaderName, viewerCsrfToken)
+      .send({
+        elements: [{ id: "v1", type: "rectangle", x: 0, y: 0, width: 10, height: 10 }],
+        appState: {},
+        files: {},
+      });
+    expect(editResponse.status).toBe(404);
+
+    const deleteResponse = await viewerAgent
+      .delete(`/drawings/${drawing.id}`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${viewerToken}`)
+      .set(viewerCsrfHeaderName, viewerCsrfToken);
+    expect(deleteResponse.status).toBe(404);
+  });
+
+  it("prevents a view-only invited user from creating a new drawing in a shared collection", async () => {
+    const collection = await createCollection();
+
+    await ownerAgent
+      .post(`/collections/${collection.id}/shares`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${ownerToken}`)
+      .set(ownerCsrfHeaderName, ownerCsrfToken)
+      .send({ identifier: viewer.email, role: "view" });
+
+    const createDrawingResponse = await viewerAgent
+      .post("/drawings")
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${viewerToken}`)
+      .set(viewerCsrfHeaderName, viewerCsrfToken)
+      .send({
+        name: "Viewer Cannot Create Here",
+        elements: [],
+        appState: {},
+        files: {},
+        collectionId: collection.id,
+      });
+
+    expect(createDrawingResponse.status).toBe(403);
+    expect(createDrawingResponse.body?.error).toContain("No edit access");
+  });
+
+  it("prevents a view-only invited user from importing a new drawing into a shared collection", async () => {
+    const collection = await createCollection();
+
+    await ownerAgent
+      .post(`/collections/${collection.id}/shares`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${ownerToken}`)
+      .set(ownerCsrfHeaderName, ownerCsrfToken)
+      .send({ identifier: viewer.email, role: "view" });
+
+    const importDrawingResponse = await viewerAgent
+      .post("/drawings")
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${viewerToken}`)
+      .set(viewerCsrfHeaderName, viewerCsrfToken)
+      .set("x-imported-file", "true")
+      .send({
+        name: "Imported by Viewer",
+        elements: [],
+        appState: {},
+        files: {},
+        preview: null,
+        collectionId: collection.id,
+      });
+
+    expect(importDrawingResponse.status).toBe(403);
+    expect(importDrawingResponse.body?.error).toContain("No edit access");
+  });
+});

--- a/backend/src/authz/sharing.ts
+++ b/backend/src/authz/sharing.ts
@@ -7,14 +7,18 @@ export type DrawingAccess = "none" | DrawingPermission | "owner";
 
 export type DrawingPrincipal = { kind: "user"; userId: string };
 
-export const normalizeDrawingPermission = (input: unknown): DrawingPermission | null => {
+export const normalizeDrawingPermission = (
+  input: unknown,
+): DrawingPermission | null => {
   if (input === "view" || input === "edit") return input;
   return null;
 };
 
-export const buildShareLinkToken = (): string => crypto.randomBytes(24).toString("base64url");
+export const buildShareLinkToken = (): string =>
+  crypto.randomBytes(24).toString("base64url");
 
-export const hashShareLinkToken = (token: string): string => hashTokenForStorage(token);
+export const hashShareLinkToken = (token: string): string =>
+  hashTokenForStorage(token);
 
 const normalizePassphraseForHash = (value: string): string =>
   value.trim().toLowerCase().replace(/\s+/g, " ");
@@ -39,7 +43,7 @@ export const hashPassphrase = (value: string, pepper: string): string => {
       blockSize: DEFAULT_SCRYPT_R,
       parallelization: DEFAULT_SCRYPT_P,
       maxmem: DEFAULT_SCRYPT_MAXMEM,
-    }
+    },
   );
   return [
     SCRYPT_PREFIX,
@@ -54,7 +58,7 @@ export const hashPassphrase = (value: string, pepper: string): string => {
 export const verifyPassphraseHash = (
   provided: string,
   expected: string,
-  pepper: string
+  pepper: string,
 ): boolean => {
   const normalized = normalizePassphraseForHash(provided);
   const expectedText = (expected || "").trim();
@@ -93,7 +97,7 @@ export const verifyPassphraseHash = (
         blockSize: r,
         parallelization: p,
         maxmem: DEFAULT_SCRYPT_MAXMEM,
-      }
+      },
     );
     if (actualKey.length !== expectedKey.length) return false;
     return crypto.timingSafeEqual(actualKey, expectedKey);
@@ -101,7 +105,10 @@ export const verifyPassphraseHash = (
 
   // Legacy format: sha256 hex of `${pepper}|${normalized}` (no salt).
   if (/^[0-9a-f]{64}$/i.test(expectedText)) {
-    const legacyHash = crypto.createHash("sha256").update(`${pepper}|${normalized}`, "utf8").digest("hex");
+    const legacyHash = crypto
+      .createHash("sha256")
+      .update(`${pepper}|${normalized}`, "utf8")
+      .digest("hex");
     const expectedBuf = Buffer.from(expectedText, "hex");
     const actualBuf = Buffer.from(legacyHash, "hex");
     if (expectedBuf.length !== actualBuf.length) return false;
@@ -140,6 +147,27 @@ export const getDrawingAccess = async (params: {
       select: { permission: true },
     });
     baseAccess = normalizeDrawingPermission(perm?.permission) ?? baseAccess;
+
+    // Check collection-level share if no direct drawing permission found
+    if (baseAccess === "none") {
+      const drawing = await params.prisma.drawing.findUnique({
+        where: { id: params.drawingId },
+        select: { collectionId: true },
+      });
+      if (drawing?.collectionId) {
+        const collectionShare = await params.prisma.collectionShare.findFirst({
+          where: {
+            collectionId: drawing.collectionId,
+            granteeUserId: params.principal.userId,
+          },
+          select: { role: true },
+        });
+        if (collectionShare) {
+          baseAccess =
+            normalizeDrawingPermission(collectionShare.role) ?? baseAccess;
+        }
+      }
+    }
   }
 
   // Google Docs-style link policy: applies regardless of whether the visitor is signed in.
@@ -155,15 +183,16 @@ export const getDrawingAccess = async (params: {
 };
 
 export const canViewDrawing = (
-  access: DrawingAccess
+  access: DrawingAccess,
 ): access is Exclude<DrawingAccess, "none"> => access !== "none";
 
 export const canEditDrawing = (
-  access: DrawingAccess
+  access: DrawingAccess,
 ): access is Extract<DrawingAccess, "edit" | "owner"> =>
   access === "edit" || access === "owner";
 
-export const isOwnerAccess = (access: DrawingAccess): boolean => access === "owner";
+export const isOwnerAccess = (access: DrawingAccess): boolean =>
+  access === "owner";
 
 const getActiveLinkShareAccess = async (params: {
   prisma: PrismaClient;

--- a/backend/src/authz/sharing.ts
+++ b/backend/src/authz/sharing.ts
@@ -149,22 +149,38 @@ export const getDrawingAccess = async (params: {
     baseAccess = normalizeDrawingPermission(perm?.permission) ?? baseAccess;
 
     // Check collection-level share if no direct drawing permission found
+    // Check collection-level access if no direct drawing permission found
     if (baseAccess === "none") {
       const drawing = await params.prisma.drawing.findUnique({
         where: { id: params.drawingId },
-        select: { collectionId: true },
+        select: { collectionId: true, userId: true },
       });
       if (drawing?.collectionId) {
-        const collectionShare = await params.prisma.collectionShare.findFirst({
+        // Check if user owns the collection (guest created drawing in owner's collection)
+        const ownedCollection = await params.prisma.collection.findFirst({
           where: {
-            collectionId: drawing.collectionId,
-            granteeUserId: params.principal.userId,
+            id: drawing.collectionId,
+            userId: params.principal.userId,
           },
-          select: { role: true },
+          select: { id: true },
         });
-        if (collectionShare) {
-          baseAccess =
-            normalizeDrawingPermission(collectionShare.role) ?? baseAccess;
+        if (ownedCollection) {
+          baseAccess = "owner";
+        } else {
+          // Check if user has a collection share entry
+          const collectionShare = await params.prisma.collectionShare.findFirst(
+            {
+              where: {
+                collectionId: drawing.collectionId,
+                granteeUserId: params.principal.userId,
+              },
+              select: { role: true },
+            },
+          );
+          if (collectionShare) {
+            baseAccess =
+              normalizeDrawingPermission(collectionShare.role) ?? baseAccess;
+          }
         }
       }
     }

--- a/backend/src/routes/dashboard/collections.ts
+++ b/backend/src/routes/dashboard/collections.ts
@@ -34,6 +34,19 @@ export const registerCollectionRoutes = (
       const hasInternalTrash = rawCollections.some(
         (c) => c.id === trashCollectionId,
       );
+      const shareCountMap = await prisma.collectionShare.groupBy({
+        by: ["collectionId"],
+        where: {
+          collectionId: {
+            in: rawCollections.map((c) => c.id),
+          },
+        },
+        _count: { collectionId: true },
+      });
+      const sharedCollectionIds = new Set(
+        shareCountMap.map((s) => s.collectionId),
+      );
+
       const ownedCollections = rawCollections
         .filter((c) => !(hasInternalTrash && c.id === "trash"))
         .map((c) =>
@@ -44,8 +57,14 @@ export const registerCollectionRoutes = (
                 name: "Trash",
                 sharedRole: null,
                 isOwner: true,
+                isShared: false,
               }
-            : { ...c, sharedRole: null, isOwner: true },
+            : {
+                ...c,
+                sharedRole: null,
+                isOwner: true,
+                isShared: sharedCollectionIds.has(c.id),
+              },
         );
 
       // Collections shared with this user by others
@@ -101,12 +120,10 @@ export const registerCollectionRoutes = (
 
       const { id } = req.params;
       if (isTrashCollectionId(id, req.user.id)) {
-        return res
-          .status(400)
-          .json({
-            error: "Validation error",
-            message: "Trash collection cannot be renamed",
-          });
+        return res.status(400).json({
+          error: "Validation error",
+          message: "Trash collection cannot be renamed",
+        });
       }
       const existing = await prisma.collection.findFirst({
         where: { id, userId: req.user.id },
@@ -116,12 +133,10 @@ export const registerCollectionRoutes = (
 
       const parsed = collectionNameSchema.safeParse(req.body.name);
       if (!parsed.success) {
-        return res
-          .status(400)
-          .json({
-            error: "Validation error",
-            message: "Collection name must be between 1 and 100 characters",
-          });
+        return res.status(400).json({
+          error: "Validation error",
+          message: "Collection name must be between 1 and 100 characters",
+        });
       }
 
       const sanitizedName = sanitizeText(parsed.data, 100);
@@ -147,12 +162,10 @@ export const registerCollectionRoutes = (
 
       const { id } = req.params;
       if (isTrashCollectionId(id, req.user.id)) {
-        return res
-          .status(400)
-          .json({
-            error: "Validation error",
-            message: "Trash collection cannot be deleted",
-          });
+        return res.status(400).json({
+          error: "Validation error",
+          message: "Trash collection cannot be deleted",
+        });
       }
       const collection = await prisma.collection.findFirst({
         where: { id, userId: req.user.id },

--- a/backend/src/routes/dashboard/collections.ts
+++ b/backend/src/routes/dashboard/collections.ts
@@ -4,7 +4,7 @@ import { getUserTrashCollectionId, isTrashCollectionId } from "./trash";
 
 export const registerCollectionRoutes = (
   app: express.Express,
-  deps: DashboardRouteDeps
+  deps: DashboardRouteDeps,
 ) => {
   const {
     prisma,
@@ -18,119 +18,354 @@ export const registerCollectionRoutes = (
     logAuditEvent,
   } = deps;
 
-  app.get("/collections", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-    const trashCollectionId = getUserTrashCollectionId(req.user.id);
-    await ensureTrashCollection(prisma, req.user.id);
+  // GET /collections — returns owned collections + collections shared with user
+  app.get(
+    "/collections",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const trashCollectionId = getUserTrashCollectionId(req.user.id);
+      await ensureTrashCollection(prisma, req.user.id);
 
-    const rawCollections = await prisma.collection.findMany({
-      where: { userId: req.user.id },
-      orderBy: { createdAt: "desc" },
-    });
-    const hasInternalTrash = rawCollections.some((collection) => collection.id === trashCollectionId);
-    const collections = rawCollections
-      .filter((collection) => !(hasInternalTrash && collection.id === "trash"))
-      .map((collection) =>
-        collection.id === trashCollectionId
-          ? { ...collection, id: "trash", name: "Trash" }
-          : collection
+      const rawCollections = await prisma.collection.findMany({
+        where: { userId: req.user.id },
+        orderBy: { createdAt: "desc" },
+      });
+      const hasInternalTrash = rawCollections.some(
+        (c) => c.id === trashCollectionId,
       );
-    return res.json(collections);
-  }));
+      const ownedCollections = rawCollections
+        .filter((c) => !(hasInternalTrash && c.id === "trash"))
+        .map((c) =>
+          c.id === trashCollectionId
+            ? {
+                ...c,
+                id: "trash",
+                name: "Trash",
+                sharedRole: null,
+                isOwner: true,
+              }
+            : { ...c, sharedRole: null, isOwner: true },
+        );
 
-  app.post("/collections", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-
-    const parsed = collectionNameSchema.safeParse(req.body.name);
-    if (!parsed.success) {
-      return res.status(400).json({
-        error: "Validation error",
-        message: "Collection name must be between 1 and 100 characters",
+      // Collections shared with this user by others
+      const sharedEntries = await prisma.collectionShare.findMany({
+        where: { granteeUserId: req.user.id },
+        include: {
+          collection: {
+            include: {
+              user: { select: { id: true, name: true, email: true } },
+            },
+          },
+        },
       });
-    }
+      const sharedCollections = sharedEntries.map((s) => ({
+        ...s.collection,
+        sharedRole: s.role,
+        isOwner: false,
+      }));
 
-    const sanitizedName = sanitizeText(parsed.data, 100);
-    const newCollection = await prisma.collection.create({
-      data: { name: sanitizedName, userId: req.user.id },
-    });
-    return res.json(newCollection);
-  }));
+      return res.json([...ownedCollections, ...sharedCollections]);
+    }),
+  );
 
-  app.put("/collections/:id", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+  // POST /collections
+  app.post(
+    "/collections",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
 
-    const { id } = req.params;
-    if (isTrashCollectionId(id, req.user.id)) {
-      return res.status(400).json({
-        error: "Validation error",
-        message: "Trash collection cannot be renamed",
+      const parsed = collectionNameSchema.safeParse(req.body.name);
+      if (!parsed.success) {
+        return res.status(400).json({
+          error: "Validation error",
+          message: "Collection name must be between 1 and 100 characters",
+        });
+      }
+
+      const sanitizedName = sanitizeText(parsed.data, 100);
+      const newCollection = await prisma.collection.create({
+        data: { name: sanitizedName, userId: req.user.id },
       });
-    }
-    const existingCollection = await prisma.collection.findFirst({
-      where: { id, userId: req.user.id },
-    });
-    if (!existingCollection) return res.status(404).json({ error: "Collection not found" });
+      return res.json({ ...newCollection, sharedRole: null, isOwner: true });
+    }),
+  );
 
-    const parsed = collectionNameSchema.safeParse(req.body.name);
-    if (!parsed.success) {
-      return res.status(400).json({
-        error: "Validation error",
-        message: "Collection name must be between 1 and 100 characters",
+  // PUT /collections/:id — owner only
+  app.put(
+    "/collections/:id",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+
+      const { id } = req.params;
+      if (isTrashCollectionId(id, req.user.id)) {
+        return res
+          .status(400)
+          .json({
+            error: "Validation error",
+            message: "Trash collection cannot be renamed",
+          });
+      }
+      const existing = await prisma.collection.findFirst({
+        where: { id, userId: req.user.id },
       });
-    }
+      if (!existing)
+        return res.status(404).json({ error: "Collection not found" });
 
-    const sanitizedName = sanitizeText(parsed.data, 100);
-    const updateResult = await prisma.collection.updateMany({
-      where: { id, userId: req.user.id },
-      data: { name: sanitizedName },
-    });
-    if (updateResult.count === 0) {
-      return res.status(404).json({ error: "Collection not found" });
-    }
-    const updatedCollection = await prisma.collection.findFirst({
-      where: { id, userId: req.user.id },
-    });
-    if (!updatedCollection) {
-      return res.status(404).json({ error: "Collection not found" });
-    }
-    return res.json(updatedCollection);
-  }));
+      const parsed = collectionNameSchema.safeParse(req.body.name);
+      if (!parsed.success) {
+        return res
+          .status(400)
+          .json({
+            error: "Validation error",
+            message: "Collection name must be between 1 and 100 characters",
+          });
+      }
 
-  app.delete("/collections/:id", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-
-    const { id } = req.params;
-    if (isTrashCollectionId(id, req.user.id)) {
-      return res.status(400).json({
-        error: "Validation error",
-        message: "Trash collection cannot be deleted",
+      const sanitizedName = sanitizeText(parsed.data, 100);
+      await prisma.collection.updateMany({
+        where: { id, userId: req.user.id },
+        data: { name: sanitizedName },
       });
-    }
-    const collection = await prisma.collection.findFirst({
-      where: { id, userId: req.user.id },
-    });
-    if (!collection) return res.status(404).json({ error: "Collection not found" });
-
-    await prisma.$transaction([
-      prisma.drawing.updateMany({
-        where: { collectionId: id, userId: req.user.id },
-        data: { collectionId: null },
-      }),
-      prisma.collection.deleteMany({ where: { id, userId: req.user.id } }),
-    ]);
-    invalidateDrawingsCache();
-
-    if (config.enableAuditLogging) {
-      await logAuditEvent({
-        userId: req.user.id,
-        action: "collection_deleted",
-        resource: `collection:${id}`,
-        ipAddress: req.ip || req.connection.remoteAddress || undefined,
-        userAgent: req.headers["user-agent"] || undefined,
-        details: { collectionId: id, collectionName: collection.name },
+      const updated = await prisma.collection.findFirst({
+        where: { id, userId: req.user.id },
       });
-    }
+      if (!updated)
+        return res.status(404).json({ error: "Collection not found" });
+      return res.json(updated);
+    }),
+  );
 
-    return res.json({ success: true });
-  }));
+  // DELETE /collections/:id — owner only
+  app.delete(
+    "/collections/:id",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+
+      const { id } = req.params;
+      if (isTrashCollectionId(id, req.user.id)) {
+        return res
+          .status(400)
+          .json({
+            error: "Validation error",
+            message: "Trash collection cannot be deleted",
+          });
+      }
+      const collection = await prisma.collection.findFirst({
+        where: { id, userId: req.user.id },
+      });
+      if (!collection)
+        return res.status(404).json({ error: "Collection not found" });
+
+      await prisma.$transaction([
+        prisma.drawing.updateMany({
+          where: { collectionId: id, userId: req.user.id },
+          data: { collectionId: null },
+        }),
+        prisma.collectionShare.deleteMany({ where: { collectionId: id } }),
+        prisma.collection.deleteMany({ where: { id, userId: req.user.id } }),
+      ]);
+      invalidateDrawingsCache();
+
+      if (config.enableAuditLogging) {
+        await logAuditEvent({
+          userId: req.user.id,
+          action: "collection_deleted",
+          resource: `collection:${id}`,
+          ipAddress: req.ip || req.connection.remoteAddress || undefined,
+          userAgent: req.headers["user-agent"] || undefined,
+          details: { collectionId: id, collectionName: collection.name },
+        });
+      }
+
+      return res.json({ success: true });
+    }),
+  );
+
+  // ─── Collection Sharing ───────────────────────────────────────────────────
+
+  // GET /collections/:id/shares — list shares (owner only)
+  app.get(
+    "/collections/:id/shares",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const { id } = req.params;
+
+      const collection = await prisma.collection.findFirst({
+        where: { id, userId: req.user.id },
+      });
+      if (!collection)
+        return res.status(404).json({ error: "Collection not found" });
+
+      const shares = await prisma.collectionShare.findMany({
+        where: { collectionId: id },
+        include: {
+          granteeUser: { select: { id: true, name: true, email: true } },
+        },
+        orderBy: { createdAt: "asc" },
+      });
+
+      return res.json({ shares });
+    }),
+  );
+
+  // POST /collections/:id/shares — add or update a user share (owner only)
+  app.post(
+    "/collections/:id/shares",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const { id } = req.params;
+      const { identifier, role } = req.body as {
+        identifier: string;
+        role: string;
+      };
+
+      if (!identifier || !["view", "edit"].includes(role)) {
+        return res
+          .status(400)
+          .json({ error: "identifier and role (view|edit) are required" });
+      }
+
+      const collection = await prisma.collection.findFirst({
+        where: { id, userId: req.user.id },
+      });
+      if (!collection)
+        return res.status(404).json({ error: "Collection not found" });
+
+      // Resolve user by email or username
+      const grantee = await prisma.user.findFirst({
+        where: {
+          isActive: true,
+          OR: [
+            { email: identifier.toLowerCase() },
+            { username: identifier },
+            { name: identifier },
+          ],
+        },
+        select: { id: true, name: true, email: true },
+      });
+      if (!grantee) return res.status(404).json({ error: "User not found" });
+      if (grantee.id === req.user.id)
+        return res.status(400).json({ error: "Cannot share with yourself" });
+
+      const share = await prisma.collectionShare.upsert({
+        where: {
+          collectionId_granteeUserId: {
+            collectionId: id,
+            granteeUserId: grantee.id,
+          },
+        },
+        update: { role, updatedAt: new Date() },
+        create: {
+          collectionId: id,
+          granteeUserId: grantee.id,
+          role,
+          createdByUserId: req.user.id,
+        },
+        include: {
+          granteeUser: { select: { id: true, name: true, email: true } },
+        },
+      });
+
+      return res.json({ share });
+    }),
+  );
+
+  // PATCH /collections/:id/shares/:userId — update role (owner only)
+  app.patch(
+    "/collections/:id/shares/:userId",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const { id, userId } = req.params;
+      const { role } = req.body as { role: string };
+
+      if (!["view", "edit"].includes(role)) {
+        return res.status(400).json({ error: "role must be view or edit" });
+      }
+
+      const collection = await prisma.collection.findFirst({
+        where: { id, userId: req.user.id },
+      });
+      if (!collection)
+        return res.status(404).json({ error: "Collection not found" });
+
+      const share = await prisma.collectionShare.updateMany({
+        where: { collectionId: id, granteeUserId: userId },
+        data: { role, updatedAt: new Date() },
+      });
+      if (share.count === 0)
+        return res.status(404).json({ error: "Share not found" });
+
+      return res.json({ success: true });
+    }),
+  );
+
+  // DELETE /collections/:id/shares/:userId — remove a user (owner only)
+  app.delete(
+    "/collections/:id/shares/:userId",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const { id, userId } = req.params;
+
+      const collection = await prisma.collection.findFirst({
+        where: { id, userId: req.user.id },
+      });
+      if (!collection)
+        return res.status(404).json({ error: "Collection not found" });
+
+      await prisma.collectionShare.deleteMany({
+        where: { collectionId: id, granteeUserId: userId },
+      });
+      return res.json({ success: true });
+    }),
+  );
+
+  // GET /collections/:id/share-resolve — search users to share with (owner only)
+  app.get(
+    "/collections/:id/share-resolve",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const { id } = req.params;
+      const q = String(req.query.q || "").trim();
+
+      if (q.length < 2) return res.json({ users: [] });
+
+      const collection = await prisma.collection.findFirst({
+        where: { id, userId: req.user.id },
+      });
+      if (!collection)
+        return res.status(404).json({ error: "Collection not found" });
+
+      // Get already-shared user IDs to exclude them
+      const existing = await prisma.collectionShare.findMany({
+        where: { collectionId: id },
+        select: { granteeUserId: true },
+      });
+      const excludeIds = [req.user.id, ...existing.map((s) => s.granteeUserId)];
+
+      const users = await prisma.user.findMany({
+        where: {
+          isActive: true,
+          id: { notIn: excludeIds },
+          OR: [
+            { email: { contains: q } },
+            { name: { contains: q } },
+            { username: { contains: q } },
+          ],
+        },
+        select: { id: true, name: true, email: true },
+        take: 8,
+      });
+
+      return res.json({ users });
+    }),
+  );
 };

--- a/backend/src/routes/dashboard/drawings.ts
+++ b/backend/src/routes/dashboard/drawings.ts
@@ -20,7 +20,7 @@ import {
 
 export const registerDrawingRoutes = (
   app: express.Express,
-  deps: DashboardRouteDeps
+  deps: DashboardRouteDeps,
 ) => {
   const {
     prisma,
@@ -43,7 +43,7 @@ export const registerDrawingRoutes = (
   } = deps;
 
   const getRequestPrincipal = async (
-    req: express.Request
+    req: express.Request,
   ): Promise<DrawingPrincipal | null> => {
     if (req.user?.id) {
       return { kind: "user", userId: req.user.id };
@@ -58,7 +58,9 @@ export const registerDrawingRoutes = (
         : process.env.LINK_SHARE_VIEW_DEFAULT_TTL_MS;
     const parsed = raw ? Number(raw) : NaN;
     if (Number.isFinite(parsed) && parsed > 0) return parsed;
-    return permission === "edit" ? 7 * 24 * 60 * 60 * 1000 : 30 * 24 * 60 * 60 * 1000;
+    return permission === "edit"
+      ? 7 * 24 * 60 * 60 * 1000
+      : 30 * 24 * 60 * 60 * 1000;
   };
 
   const resolveMaxTtlMs = (): number => {
@@ -69,7 +71,7 @@ export const registerDrawingRoutes = (
 
   const respondWithAuthErrorIfPresent = (
     req: express.Request,
-    res: express.Response
+    res: express.Response,
   ): boolean => {
     if (!req.authError) return false;
 
@@ -80,597 +82,853 @@ export const registerDrawingRoutes = (
     return true;
   };
 
-  app.get("/drawings", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) {
-      return res.status(401).json({ error: "Unauthorized" });
-    }
-
-    const trashCollectionId = getUserTrashCollectionId(req.user.id);
-    const { search, collectionId, includeData, limit, offset, sortField, sortDirection } = req.query;
-    const where: Prisma.DrawingWhereInput = { userId: req.user.id };
-    const searchTerm =
-      typeof search === "string" && search.trim().length > 0 ? search.trim() : undefined;
-
-    if (searchTerm) {
-      where.name = { contains: searchTerm };
-    }
-
-    let collectionFilterKey = "default";
-    if (collectionId === "null") {
-      where.collectionId = null;
-      collectionFilterKey = "null";
-    } else if (collectionId) {
-      const normalizedCollectionId = String(collectionId);
-      if (normalizedCollectionId === "trash") {
-        where.collectionId = { in: [trashCollectionId, "trash"] };
-        collectionFilterKey = "trash";
-      } else {
-        const collection = await prisma.collection.findFirst({
-          where: { id: normalizedCollectionId, userId: req.user.id },
-        });
-        if (!collection) {
-          return res.status(404).json({ error: "Collection not found" });
-        }
-        where.collectionId = normalizedCollectionId;
-        collectionFilterKey = `id:${normalizedCollectionId}`;
+  app.get(
+    "/drawings",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) {
+        return res.status(401).json({ error: "Unauthorized" });
       }
-    } else {
-      where.OR = [
-        { collectionId: { notIn: [trashCollectionId, "trash"] } },
-        { collectionId: null },
-      ];
-    }
 
-    const shouldIncludeData =
-      typeof includeData === "string"
-        ? includeData.toLowerCase() === "true" || includeData === "1"
-        : false;
-    const parsedSortField: SortField =
-      sortField === "name" || sortField === "createdAt" || sortField === "updatedAt"
-        ? sortField
-        : "updatedAt";
-    const parsedSortDirection: SortDirection =
-      sortDirection === "asc" || sortDirection === "desc"
-        ? sortDirection
-        : parsedSortField === "name"
-        ? "asc"
-        : "desc";
+      const trashCollectionId = getUserTrashCollectionId(req.user.id);
+      const {
+        search,
+        collectionId,
+        includeData,
+        limit,
+        offset,
+        sortField,
+        sortDirection,
+      } = req.query;
+      const where: Prisma.DrawingWhereInput = { userId: req.user.id };
+      const searchTerm =
+        typeof search === "string" && search.trim().length > 0
+          ? search.trim()
+          : undefined;
 
-    const rawLimit = limit ? Number.parseInt(limit as string, 10) : undefined;
-    const rawOffset = offset ? Number.parseInt(offset as string, 10) : undefined;
-    const parsedLimit =
-      rawLimit !== undefined && Number.isFinite(rawLimit)
-        ? Math.min(Math.max(rawLimit, 1), MAX_PAGE_SIZE)
+      if (searchTerm) {
+        where.name = { contains: searchTerm };
+      }
+
+      let collectionFilterKey = "default";
+      if (collectionId === "null") {
+        where.collectionId = null;
+        collectionFilterKey = "null";
+      } else if (collectionId) {
+        const normalizedCollectionId = String(collectionId);
+        if (normalizedCollectionId === "trash") {
+          where.collectionId = { in: [trashCollectionId, "trash"] };
+          collectionFilterKey = "trash";
+        } else {
+          const collection = await prisma.collection.findFirst({
+            where: { id: normalizedCollectionId },
+          });
+          if (!collection) {
+            return res.status(404).json({ error: "Collection not found" });
+          }
+
+          // Check if user is owner or has a share entry
+          const isOwner = collection.userId === req.user.id;
+          if (!isOwner) {
+            const share = await prisma.collectionShare.findFirst({
+              where: {
+                collectionId: normalizedCollectionId,
+                granteeUserId: req.user.id,
+              },
+            });
+            if (!share) {
+              return res.status(404).json({ error: "Collection not found" });
+            }
+          }
+          // Always fetch all drawings in the collection regardless of who created them
+          delete (where as any).userId;
+
+          where.collectionId = normalizedCollectionId;
+          collectionFilterKey = `id:${normalizedCollectionId}`;
+        }
+      } else {
+        where.OR = [
+          { collectionId: { notIn: [trashCollectionId, "trash"] } },
+          { collectionId: null },
+        ];
+      }
+
+      const shouldIncludeData =
+        typeof includeData === "string"
+          ? includeData.toLowerCase() === "true" || includeData === "1"
+          : false;
+      const parsedSortField: SortField =
+        sortField === "name" ||
+        sortField === "createdAt" ||
+        sortField === "updatedAt"
+          ? sortField
+          : "updatedAt";
+      const parsedSortDirection: SortDirection =
+        sortDirection === "asc" || sortDirection === "desc"
+          ? sortDirection
+          : parsedSortField === "name"
+            ? "asc"
+            : "desc";
+
+      const rawLimit = limit ? Number.parseInt(limit as string, 10) : undefined;
+      const rawOffset = offset
+        ? Number.parseInt(offset as string, 10)
         : undefined;
-    const parsedOffset =
-      rawOffset !== undefined && Number.isFinite(rawOffset) ? Math.max(rawOffset, 0) : undefined;
+      const parsedLimit =
+        rawLimit !== undefined && Number.isFinite(rawLimit)
+          ? Math.min(Math.max(rawLimit, 1), MAX_PAGE_SIZE)
+          : undefined;
+      const parsedOffset =
+        rawOffset !== undefined && Number.isFinite(rawOffset)
+          ? Math.max(rawOffset, 0)
+          : undefined;
 
-    const cacheKey =
-      buildDrawingsCacheKey({
-        userId: req.user.id,
-        searchTerm: searchTerm ?? "",
-        collectionFilter: collectionFilterKey,
-        includeData: shouldIncludeData,
-        sortField: parsedSortField,
-        sortDirection: parsedSortDirection,
-      }) + `:${parsedLimit}:${parsedOffset}`;
+      const cacheKey =
+        buildDrawingsCacheKey({
+          userId: req.user.id,
+          searchTerm: searchTerm ?? "",
+          collectionFilter: collectionFilterKey,
+          includeData: shouldIncludeData,
+          sortField: parsedSortField,
+          sortDirection: parsedSortDirection,
+        }) + `:${parsedLimit}:${parsedOffset}`;
 
-    const cachedBody = getCachedDrawingsBody(cacheKey);
-    if (cachedBody) {
-      res.setHeader("X-Cache", "HIT");
-      res.setHeader("Content-Type", "application/json");
-      return res.send(cachedBody);
-    }
+      const cachedBody = getCachedDrawingsBody(cacheKey);
+      if (cachedBody) {
+        res.setHeader("X-Cache", "HIT");
+        res.setHeader("Content-Type", "application/json");
+        return res.send(cachedBody);
+      }
 
-    const summarySelect: Prisma.DrawingSelect = {
-      id: true,
-      name: true,
-      collectionId: true,
-      preview: true,
-      version: true,
-      createdAt: true,
-      updatedAt: true,
-    };
-
-    const orderBy: Prisma.DrawingOrderByWithRelationInput =
-      parsedSortField === "name"
-        ? { name: parsedSortDirection }
-        : parsedSortField === "createdAt"
-        ? { createdAt: parsedSortDirection }
-        : { updatedAt: parsedSortDirection };
-
-    const queryOptions: Prisma.DrawingFindManyArgs = { where, orderBy };
-    if (parsedLimit !== undefined) queryOptions.take = parsedLimit;
-    if (parsedOffset !== undefined) queryOptions.skip = parsedOffset;
-    if (!shouldIncludeData) queryOptions.select = summarySelect;
-
-    const [drawings, totalCount] = await Promise.all([
-      prisma.drawing.findMany(queryOptions),
-      prisma.drawing.count({ where }),
-    ]);
-
-    let responsePayload: any[] = drawings as any[];
-    if (shouldIncludeData) {
-      responsePayload = (drawings as any[]).map((d: any) => ({
-        ...d,
-        collectionId: toPublicTrashCollectionId(d.collectionId, req.user!.id),
-        elements: parseJsonField(d.elements, []),
-        appState: parseJsonField(d.appState, {}),
-        files: parseJsonField(d.files, {}),
-      }));
-    } else {
-      responsePayload = (drawings as any[]).map((d: any) => ({
-        ...d,
-        collectionId: toPublicTrashCollectionId(d.collectionId, req.user!.id),
-      }));
-    }
-
-    const finalResponse = {
-      drawings: responsePayload,
-      totalCount,
-      limit: parsedLimit,
-      offset: parsedOffset,
-    };
-
-    const body = cacheDrawingsResponse(cacheKey, finalResponse);
-    res.setHeader("X-Cache", "MISS");
-    res.setHeader("Content-Type", "application/json");
-    return res.send(body);
-  }));
-
-  // Shared with me list (does not mix into /drawings cache semantics)
-  // Must be registered before `/drawings/:id` so it doesn't get treated as a drawing id.
-  app.get("/drawings/shared", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-
-    const { search, includeData, limit, offset, sortField, sortDirection } = req.query;
-    const searchTerm =
-      typeof search === "string" && search.trim().length > 0 ? search.trim() : undefined;
-
-    const shouldIncludeData =
-      typeof includeData === "string"
-        ? includeData.toLowerCase() === "true" || includeData === "1"
-        : false;
-    const parsedSortField: SortField =
-      sortField === "name" || sortField === "createdAt" || sortField === "updatedAt"
-        ? sortField
-        : "updatedAt";
-    const parsedSortDirection: SortDirection =
-      sortDirection === "asc" || sortDirection === "desc"
-        ? sortDirection
-        : parsedSortField === "name"
-        ? "asc"
-        : "desc";
-
-    const rawLimit = limit ? Number.parseInt(limit as string, 10) : undefined;
-    const rawOffset = offset ? Number.parseInt(offset as string, 10) : undefined;
-    const parsedLimit =
-      rawLimit !== undefined && Number.isFinite(rawLimit)
-        ? Math.min(Math.max(rawLimit, 1), MAX_PAGE_SIZE)
-        : undefined;
-    const parsedOffset =
-      rawOffset !== undefined && Number.isFinite(rawOffset) ? Math.max(rawOffset, 0) : undefined;
-
-    const orderBy: Prisma.DrawingOrderByWithRelationInput =
-      parsedSortField === "name"
-        ? { name: parsedSortDirection }
-        : parsedSortField === "createdAt"
-        ? { createdAt: parsedSortDirection }
-        : { updatedAt: parsedSortDirection };
-
-    const whereDrawing: Prisma.DrawingWhereInput = {
-      // "Shared with me" should only include drawings owned by someone else.
-      // Some deployments keep an owner self-permission row for access control; exclude those.
-      userId: { not: req.user.id },
-      permissions: {
-        some: {
-          granteeUserId: req.user.id,
-        },
-      },
-    };
-    if (searchTerm) {
-      whereDrawing.name = { contains: searchTerm };
-    }
-
-    const summarySelect: Prisma.DrawingSelect = {
-      id: true,
-      name: true,
-      collectionId: true,
-      preview: true,
-      version: true,
-      createdAt: true,
-      updatedAt: true,
-      userId: true,
-      permissions: {
-        where: { granteeUserId: req.user.id },
-        select: { permission: true },
-      },
-    };
-
-    const queryOptions: Prisma.DrawingFindManyArgs = { where: whereDrawing, orderBy };
-    if (parsedLimit !== undefined) queryOptions.take = parsedLimit;
-    if (parsedOffset !== undefined) queryOptions.skip = parsedOffset;
-    if (!shouldIncludeData) queryOptions.select = summarySelect;
-
-    const [drawings, totalCount] = await Promise.all([
-      prisma.drawing.findMany(queryOptions),
-      prisma.drawing.count({ where: whereDrawing }),
-    ]);
-
-    const normalize = (d: any) => {
-      const rawPerm = Array.isArray(d?.permissions) ? d.permissions[0]?.permission : null;
-      const perm = normalizeDrawingPermission(rawPerm) ?? "view";
-      const { permissions: _permissions, ...rest } = d;
-      return {
-        ...rest,
-        // Collections are owner-scoped; don't leak the owner's collection ids to viewers.
-        collectionId: null,
-        accessLevel: perm,
+      const summarySelect: Prisma.DrawingSelect = {
+        id: true,
+        name: true,
+        collectionId: true,
+        preview: true,
+        version: true,
+        createdAt: true,
+        updatedAt: true,
+        user: { select: { id: true, name: true } },
       };
-    };
 
-    let responsePayload: any[] = drawings as any[];
-    if (shouldIncludeData) {
-      responsePayload = (drawings as any[]).map((d: any) => {
-        const normalized = normalize(d);
-        return {
-          ...normalized,
+      const orderBy: Prisma.DrawingOrderByWithRelationInput =
+        parsedSortField === "name"
+          ? { name: parsedSortDirection }
+          : parsedSortField === "createdAt"
+            ? { createdAt: parsedSortDirection }
+            : { updatedAt: parsedSortDirection };
+
+      const queryOptions: Prisma.DrawingFindManyArgs = { where, orderBy };
+      if (parsedLimit !== undefined) queryOptions.take = parsedLimit;
+      if (parsedOffset !== undefined) queryOptions.skip = parsedOffset;
+      if (!shouldIncludeData) queryOptions.select = summarySelect;
+
+      const [drawings, totalCount] = await Promise.all([
+        prisma.drawing.findMany(queryOptions),
+        prisma.drawing.count({ where }),
+      ]);
+
+      let responsePayload: any[] = drawings as any[];
+      if (shouldIncludeData) {
+        responsePayload = (drawings as any[]).map((d: any) => ({
+          ...d,
+          collectionId: toPublicTrashCollectionId(d.collectionId, req.user!.id),
           elements: parseJsonField(d.elements, []),
           appState: parseJsonField(d.appState, {}),
           files: parseJsonField(d.files, {}),
-        };
-      });
-    } else {
-      responsePayload = (drawings as any[]).map((d: any) => normalize(d));
-    }
-
-    return res.json({
-      drawings: responsePayload,
-      totalCount,
-      limit: parsedLimit,
-      offset: parsedOffset,
-    });
-  }));
-
-  app.get("/drawings/:id", optionalAuth, asyncHandler(async (req, res) => {
-    const principal = await getRequestPrincipal(req);
-
-    const { id } = req.params;
-    const access = await getDrawingAccess({ prisma, principal, drawingId: id });
-    if (!canViewDrawing(access)) {
-      if (respondWithAuthErrorIfPresent(req, res)) return;
-      return res.status(404).json({ error: "Drawing not found", message: "Drawing does not exist" });
-    }
-
-    const drawing = await prisma.drawing.findUnique({ where: { id } });
-    if (!drawing) {
-      return res.status(404).json({ error: "Drawing not found", message: "Drawing does not exist" });
-    }
-
-    const isOwner = principal?.kind === "user" && principal.userId === drawing.userId;
-    return res.json({
-      ...drawing,
-      // Collections (and trash mapping) are owner-scoped. For shared/public access, avoid leaking
-      // owner collection ids like `trash:<ownerId>` and avoid implying the viewer can organize it.
-      collectionId: isOwner ? toPublicTrashCollectionId(drawing.collectionId, drawing.userId) : null,
-      elements: parseJsonField(drawing.elements, []),
-      appState: parseJsonField(drawing.appState, {}),
-      files: parseJsonField(drawing.files, {}),
-      accessLevel: access,
-    });
-  }));
-
-  app.post("/drawings", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-
-    const isImportedDrawing = req.headers["x-imported-file"] === "true";
-    if (isImportedDrawing && !validateImportedDrawing(req.body)) {
-      return res.status(400).json({
-        error: "Invalid imported drawing file",
-        message: "The imported file contains potentially malicious content or invalid structure",
-      });
-    }
-
-    const parsed = drawingCreateSchema.safeParse(req.body);
-    if (!parsed.success) {
-      return respondWithValidationErrors(res, parsed.error.issues);
-    }
-
-    const payload = parsed.data as {
-      name?: string;
-      collectionId?: string | null;
-      elements: unknown[];
-      appState: Record<string, unknown>;
-      preview?: string | null;
-      files?: Record<string, unknown>;
-    };
-    const drawingName = payload.name ?? "Untitled Drawing";
-    const targetCollectionIdRaw = payload.collectionId === undefined ? null : payload.collectionId;
-    const targetCollectionId =
-      toInternalTrashCollectionId(targetCollectionIdRaw, req.user.id) ?? null;
-
-    if (targetCollectionId && !isTrashCollectionId(targetCollectionId, req.user.id)) {
-      const collection = await prisma.collection.findFirst({
-        where: { id: targetCollectionId, userId: req.user.id },
-      });
-      if (!collection) return res.status(404).json({ error: "Collection not found" });
-    } else if (targetCollectionIdRaw === "trash") {
-      await ensureTrashCollection(prisma, req.user.id);
-    }
-
-    const newDrawing = await prisma.drawing.create({
-      data: {
-        name: drawingName,
-        elements: JSON.stringify(payload.elements),
-        appState: JSON.stringify(payload.appState),
-        userId: req.user.id,
-        collectionId: targetCollectionId,
-        preview: payload.preview ?? null,
-        files: JSON.stringify(payload.files ?? {}),
-      },
-    });
-    invalidateDrawingsCache();
-
-    return res.json({
-      ...newDrawing,
-      collectionId: toPublicTrashCollectionId(newDrawing.collectionId, req.user.id),
-      elements: parseJsonField(newDrawing.elements, []),
-      appState: parseJsonField(newDrawing.appState, {}),
-      files: parseJsonField(newDrawing.files, {}),
-    });
-  }));
-
-  app.put("/drawings/:id", optionalAuth, asyncHandler(async (req, res) => {
-    const principal = await getRequestPrincipal(req);
-
-    const { id } = req.params;
-    const access = await getDrawingAccess({ prisma, principal, drawingId: id });
-    if (!canEditDrawing(access)) {
-      if (respondWithAuthErrorIfPresent(req, res)) return;
-      return res.status(404).json({ error: "Drawing not found" });
-    }
-
-    const existingDrawing = await prisma.drawing.findUnique({ where: { id } });
-    if (!existingDrawing) return res.status(404).json({ error: "Drawing not found" });
-
-    const parsed = drawingUpdateSchema.safeParse(req.body);
-    if (!parsed.success) {
-      if (config.nodeEnv === "development") {
-        console.error("[API] Validation failed", { id, errors: parsed.error.issues });
-      }
-      return respondWithValidationErrors(res, parsed.error.issues);
-    }
-
-    const payload = parsed.data as {
-      name?: string;
-      collectionId?: string | null;
-      elements?: unknown[];
-      appState?: Record<string, unknown>;
-      preview?: string | null;
-      files?: Record<string, unknown>;
-      version?: number;
-    };
-    const ownerUserId = existingDrawing.userId;
-    const trashCollectionId = getUserTrashCollectionId(ownerUserId);
-    const isSceneUpdate =
-      payload.elements !== undefined ||
-      payload.appState !== undefined ||
-      payload.files !== undefined;
-    const data: Prisma.DrawingUpdateInput = isSceneUpdate
-      ? { version: { increment: 1 } }
-      : {};
-
-    if (payload.name !== undefined) data.name = payload.name;
-    if (payload.elements !== undefined) data.elements = JSON.stringify(payload.elements);
-    if (payload.appState !== undefined) data.appState = JSON.stringify(payload.appState);
-    if (payload.files !== undefined) data.files = JSON.stringify(payload.files);
-    if (payload.preview !== undefined) data.preview = payload.preview;
-
-    if (payload.collectionId !== undefined) {
-      if (!isOwnerAccess(access)) {
-        return res.status(403).json({
-          error: "Forbidden",
-          message: "Only the owner can move drawings between collections",
-        });
-      }
-      if (payload.collectionId === "trash") {
-        await ensureTrashCollection(prisma, ownerUserId);
-        (data as Prisma.DrawingUncheckedUpdateInput).collectionId = trashCollectionId;
-      } else if (payload.collectionId) {
-        const collection = await prisma.collection.findFirst({
-          where: { id: payload.collectionId, userId: ownerUserId },
-        });
-        if (!collection) return res.status(404).json({ error: "Collection not found" });
-        (data as Prisma.DrawingUncheckedUpdateInput).collectionId = payload.collectionId;
+          creatorName: d.user?.name ?? null,
+          user: undefined,
+        }));
       } else {
-        (data as Prisma.DrawingUncheckedUpdateInput).collectionId = null;
+        responsePayload = (drawings as any[]).map((d: any) => ({
+          ...d,
+          collectionId: toPublicTrashCollectionId(d.collectionId, req.user!.id),
+          creatorName: d.user?.name ?? null,
+          user: undefined,
+        }));
       }
-    }
 
-    const updateWhere: Prisma.DrawingWhereInput = { id };
-    if (isSceneUpdate && payload.version !== undefined) {
-      updateWhere.version = payload.version;
-    }
+      const finalResponse = {
+        drawings: responsePayload,
+        totalCount,
+        limit: parsedLimit,
+        offset: parsedOffset,
+      };
 
-    const versionConflictError = new Error("VERSION_CONFLICT");
-    let updatedDrawing: typeof existingDrawing | null = null;
+      const body = cacheDrawingsResponse(cacheKey, finalResponse);
+      res.setHeader("X-Cache", "MISS");
+      res.setHeader("Content-Type", "application/json");
+      return res.send(body);
+    }),
+  );
 
-    try {
-      if (isSceneUpdate) {
-        updatedDrawing = await prisma.$transaction(async (tx) => {
-          await tx.drawingSnapshot.create({
-            data: {
-              drawingId: id,
-              version: existingDrawing.version,
-              elements: existingDrawing.elements,
-              appState: existingDrawing.appState,
-              files: existingDrawing.files,
+  // Shared with me list (does not mix into /drawings cache semantics)
+  // Must be registered before `/drawings/:id` so it doesn't get treated as a drawing id.
+  app.get(
+    "/drawings/shared",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+
+      const { search, includeData, limit, offset, sortField, sortDirection } =
+        req.query;
+      const searchTerm =
+        typeof search === "string" && search.trim().length > 0
+          ? search.trim()
+          : undefined;
+
+      const shouldIncludeData =
+        typeof includeData === "string"
+          ? includeData.toLowerCase() === "true" || includeData === "1"
+          : false;
+      const parsedSortField: SortField =
+        sortField === "name" ||
+        sortField === "createdAt" ||
+        sortField === "updatedAt"
+          ? sortField
+          : "updatedAt";
+      const parsedSortDirection: SortDirection =
+        sortDirection === "asc" || sortDirection === "desc"
+          ? sortDirection
+          : parsedSortField === "name"
+            ? "asc"
+            : "desc";
+
+      const rawLimit = limit ? Number.parseInt(limit as string, 10) : undefined;
+      const rawOffset = offset
+        ? Number.parseInt(offset as string, 10)
+        : undefined;
+      const parsedLimit =
+        rawLimit !== undefined && Number.isFinite(rawLimit)
+          ? Math.min(Math.max(rawLimit, 1), MAX_PAGE_SIZE)
+          : undefined;
+      const parsedOffset =
+        rawOffset !== undefined && Number.isFinite(rawOffset)
+          ? Math.max(rawOffset, 0)
+          : undefined;
+
+      const orderBy: Prisma.DrawingOrderByWithRelationInput =
+        parsedSortField === "name"
+          ? { name: parsedSortDirection }
+          : parsedSortField === "createdAt"
+            ? { createdAt: parsedSortDirection }
+            : { updatedAt: parsedSortDirection };
+
+      // Get collection IDs shared with this user to exclude drawings already visible via collection sharing
+      const sharedCollectionIds = await prisma.collectionShare.findMany({
+        where: { granteeUserId: req.user.id },
+        select: { collectionId: true },
+      });
+      const sharedColIds = sharedCollectionIds.map((s) => s.collectionId);
+
+      const whereDrawing: Prisma.DrawingWhereInput = {
+        // "Shared with me" should only include drawings owned by someone else.
+        // Some deployments keep an owner self-permission row for access control; exclude those.
+        userId: { not: req.user.id },
+        permissions: {
+          some: {
+            granteeUserId: req.user.id,
+          },
+        },
+        // Exclude drawings already accessible via a shared collection
+        ...(sharedColIds.length > 0 && {
+          NOT: {
+            collectionId: { in: sharedColIds },
+          },
+        }),
+      };
+      if (searchTerm) {
+        whereDrawing.name = { contains: searchTerm };
+      }
+
+      const summarySelect: Prisma.DrawingSelect = {
+        id: true,
+        name: true,
+        collectionId: true,
+        preview: true,
+        version: true,
+        createdAt: true,
+        updatedAt: true,
+        userId: true,
+        permissions: {
+          where: { granteeUserId: req.user.id },
+          select: { permission: true },
+        },
+      };
+
+      const queryOptions: Prisma.DrawingFindManyArgs = {
+        where: whereDrawing,
+        orderBy,
+      };
+      if (parsedLimit !== undefined) queryOptions.take = parsedLimit;
+      if (parsedOffset !== undefined) queryOptions.skip = parsedOffset;
+      if (!shouldIncludeData) queryOptions.select = summarySelect;
+
+      const [drawings, totalCount] = await Promise.all([
+        prisma.drawing.findMany(queryOptions),
+        prisma.drawing.count({ where: whereDrawing }),
+      ]);
+
+      const normalize = (d: any) => {
+        const rawPerm = Array.isArray(d?.permissions)
+          ? d.permissions[0]?.permission
+          : null;
+        const perm = normalizeDrawingPermission(rawPerm) ?? "view";
+        const { permissions: _permissions, ...rest } = d;
+        return {
+          ...rest,
+          // Collections are owner-scoped; don't leak the owner's collection ids to viewers.
+          collectionId: null,
+          accessLevel: perm,
+        };
+      };
+
+      let responsePayload: any[] = drawings as any[];
+      if (shouldIncludeData) {
+        responsePayload = (drawings as any[]).map((d: any) => {
+          const normalized = normalize(d);
+          return {
+            ...normalized,
+            elements: parseJsonField(d.elements, []),
+            appState: parseJsonField(d.appState, {}),
+            files: parseJsonField(d.files, {}),
+          };
+        });
+      } else {
+        responsePayload = (drawings as any[]).map((d: any) => normalize(d));
+      }
+
+      return res.json({
+        drawings: responsePayload,
+        totalCount,
+        limit: parsedLimit,
+        offset: parsedOffset,
+      });
+    }),
+  );
+
+  app.get(
+    "/drawings/:id",
+    optionalAuth,
+    asyncHandler(async (req, res) => {
+      const principal = await getRequestPrincipal(req);
+
+      const { id } = req.params;
+      const access = await getDrawingAccess({
+        prisma,
+        principal,
+        drawingId: id,
+      });
+      if (!canViewDrawing(access)) {
+        if (respondWithAuthErrorIfPresent(req, res)) return;
+        return res.status(404).json({
+          error: "Drawing not found",
+          message: "Drawing does not exist",
+        });
+      }
+
+      const drawing = await prisma.drawing.findUnique({ where: { id } });
+      if (!drawing) {
+        return res.status(404).json({
+          error: "Drawing not found",
+          message: "Drawing does not exist",
+        });
+      }
+
+      const isOwner =
+        principal?.kind === "user" && principal.userId === drawing.userId;
+      return res.json({
+        ...drawing,
+        // Collections (and trash mapping) are owner-scoped. For shared/public access, avoid leaking
+        // owner collection ids like `trash:<ownerId>` and avoid implying the viewer can organize it.
+        collectionId: isOwner
+          ? toPublicTrashCollectionId(drawing.collectionId, drawing.userId)
+          : null,
+        elements: parseJsonField(drawing.elements, []),
+        appState: parseJsonField(drawing.appState, {}),
+        files: parseJsonField(drawing.files, {}),
+        accessLevel: access,
+      });
+    }),
+  );
+
+  app.post(
+    "/drawings",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+
+      const isImportedDrawing = req.headers["x-imported-file"] === "true";
+      if (isImportedDrawing && !validateImportedDrawing(req.body)) {
+        return res.status(400).json({
+          error: "Invalid imported drawing file",
+          message:
+            "The imported file contains potentially malicious content or invalid structure",
+        });
+      }
+
+      const parsed = drawingCreateSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return respondWithValidationErrors(res, parsed.error.issues);
+      }
+
+      const payload = parsed.data as {
+        name?: string;
+        collectionId?: string | null;
+        elements: unknown[];
+        appState: Record<string, unknown>;
+        preview?: string | null;
+        files?: Record<string, unknown>;
+      };
+      const drawingName = payload.name ?? "Untitled Drawing";
+      const targetCollectionIdRaw =
+        payload.collectionId === undefined ? null : payload.collectionId;
+      const targetCollectionId =
+        toInternalTrashCollectionId(targetCollectionIdRaw, req.user.id) ?? null;
+
+      if (
+        targetCollectionId &&
+        !isTrashCollectionId(targetCollectionId, req.user.id)
+      ) {
+        const collection = await prisma.collection.findFirst({
+          where: { id: targetCollectionId },
+        });
+        if (!collection)
+          return res.status(404).json({ error: "Collection not found" });
+
+        // If the collection belongs to someone else, check the user has editor access
+        if (collection.userId !== req.user.id) {
+          const share = await prisma.collectionShare.findFirst({
+            where: {
+              collectionId: targetCollectionId,
+              granteeUserId: req.user.id,
+              role: "edit",
             },
           });
+          if (!share)
+            return res
+              .status(403)
+              .json({ error: "No edit access to this collection" });
+        }
+      } else if (targetCollectionIdRaw === "trash") {
+        await ensureTrashCollection(prisma, req.user.id);
+      }
 
-          const updateResult = await tx.drawing.updateMany({
+      const newDrawing = await prisma.drawing.create({
+        data: {
+          name: drawingName,
+          elements: JSON.stringify(payload.elements),
+          appState: JSON.stringify(payload.appState),
+          userId: req.user.id,
+          collectionId: targetCollectionId,
+          preview: payload.preview ?? null,
+          files: JSON.stringify(payload.files ?? {}),
+        },
+      });
+      invalidateDrawingsCache();
+
+      return res.json({
+        ...newDrawing,
+        collectionId: toPublicTrashCollectionId(
+          newDrawing.collectionId,
+          req.user.id,
+        ),
+        elements: parseJsonField(newDrawing.elements, []),
+        appState: parseJsonField(newDrawing.appState, {}),
+        files: parseJsonField(newDrawing.files, {}),
+      });
+    }),
+  );
+
+  app.put(
+    "/drawings/:id",
+    optionalAuth,
+    asyncHandler(async (req, res) => {
+      const principal = await getRequestPrincipal(req);
+
+      const { id } = req.params;
+      const access = await getDrawingAccess({
+        prisma,
+        principal,
+        drawingId: id,
+      });
+      if (!canEditDrawing(access)) {
+        if (respondWithAuthErrorIfPresent(req, res)) return;
+        return res.status(404).json({
+          error: "Drawing not found",
+          message: "Drawing does not exist",
+        });
+      }
+
+      const existingDrawing = await prisma.drawing.findUnique({
+        where: { id },
+      });
+      if (!existingDrawing)
+        return res.status(404).json({ error: "Drawing not found" });
+
+      const parsed = drawingUpdateSchema.safeParse(req.body);
+      if (!parsed.success) {
+        if (config.nodeEnv === "development") {
+          console.error("[API] Validation failed", {
+            id,
+            errors: parsed.error.issues,
+          });
+        }
+        return respondWithValidationErrors(res, parsed.error.issues);
+      }
+
+      const payload = parsed.data as {
+        name?: string;
+        collectionId?: string | null;
+        elements?: unknown[];
+        appState?: Record<string, unknown>;
+        preview?: string | null;
+        files?: Record<string, unknown>;
+        version?: number;
+      };
+      const ownerUserId = existingDrawing.userId;
+      const trashCollectionId = getUserTrashCollectionId(ownerUserId);
+      const isSceneUpdate =
+        payload.elements !== undefined ||
+        payload.appState !== undefined ||
+        payload.files !== undefined;
+      const data: Prisma.DrawingUpdateInput = isSceneUpdate
+        ? { version: { increment: 1 } }
+        : {};
+
+      if (payload.name !== undefined) data.name = payload.name;
+      if (payload.elements !== undefined)
+        data.elements = JSON.stringify(payload.elements);
+      if (payload.appState !== undefined)
+        data.appState = JSON.stringify(payload.appState);
+      if (payload.files !== undefined)
+        data.files = JSON.stringify(payload.files);
+      if (payload.preview !== undefined) data.preview = payload.preview;
+
+      if (payload.collectionId !== undefined) {
+        if (!isOwnerAccess(access)) {
+          return res.status(403).json({
+            error: "Forbidden",
+            message: "Only the owner can move drawings between collections",
+          });
+        }
+        if (payload.collectionId === "trash") {
+          await ensureTrashCollection(prisma, ownerUserId);
+          (data as Prisma.DrawingUncheckedUpdateInput).collectionId =
+            trashCollectionId;
+        } else if (payload.collectionId) {
+          const collection = await prisma.collection.findFirst({
+            where: { id: payload.collectionId, userId: ownerUserId },
+          });
+          if (!collection)
+            return res.status(404).json({ error: "Collection not found" });
+          (data as Prisma.DrawingUncheckedUpdateInput).collectionId =
+            payload.collectionId;
+        } else {
+          (data as Prisma.DrawingUncheckedUpdateInput).collectionId = null;
+        }
+      }
+
+      const updateWhere: Prisma.DrawingWhereInput = { id };
+      if (isSceneUpdate && payload.version !== undefined) {
+        updateWhere.version = payload.version;
+      }
+
+      const versionConflictError = new Error("VERSION_CONFLICT");
+      let updatedDrawing: typeof existingDrawing | null = null;
+
+      try {
+        if (isSceneUpdate) {
+          updatedDrawing = await prisma.$transaction(async (tx) => {
+            await tx.drawingSnapshot.create({
+              data: {
+                drawingId: id,
+                version: existingDrawing.version,
+                elements: existingDrawing.elements,
+                appState: existingDrawing.appState,
+                files: existingDrawing.files,
+              },
+            });
+
+            const updateResult = await tx.drawing.updateMany({
+              where: updateWhere,
+              data,
+            });
+            if (updateResult.count === 0) {
+              throw versionConflictError;
+            }
+
+            return tx.drawing.findFirst({ where: { id } });
+          });
+        } else {
+          const updateResult = await prisma.drawing.updateMany({
             where: updateWhere,
             data,
           });
           if (updateResult.count === 0) {
-            throw versionConflictError;
+            return res.status(404).json({ error: "Drawing not found" });
           }
-
-          return tx.drawing.findFirst({ where: { id } });
-        });
-      } else {
-        const updateResult = await prisma.drawing.updateMany({
-          where: updateWhere,
-          data,
-        });
-        if (updateResult.count === 0) {
-          return res.status(404).json({ error: "Drawing not found" });
-        }
-        updatedDrawing = await prisma.drawing.findFirst({
-          where: { id },
-        });
-      }
-    } catch (error) {
-      if (
-        error === versionConflictError ||
-        (error instanceof Error && error.message === versionConflictError.message)
-      ) {
-        const latestDrawing = await prisma.drawing.findFirst({
-          where: { id },
-          select: { version: true },
-        });
-        if (isSceneUpdate && payload.version !== undefined) {
-          return res.status(409).json({
-            error: "Conflict",
-            code: "VERSION_CONFLICT",
-            message: "Drawing has changed since this editor state was loaded.",
-            currentVersion: latestDrawing?.version ?? null,
+          updatedDrawing = await prisma.drawing.findFirst({
+            where: { id },
           });
         }
+      } catch (error) {
+        if (
+          error === versionConflictError ||
+          (error instanceof Error &&
+            error.message === versionConflictError.message)
+        ) {
+          const latestDrawing = await prisma.drawing.findFirst({
+            where: { id },
+            select: { version: true },
+          });
+          if (isSceneUpdate && payload.version !== undefined) {
+            return res.status(409).json({
+              error: "Conflict",
+              code: "VERSION_CONFLICT",
+              message:
+                "Drawing has changed since this editor state was loaded.",
+              currentVersion: latestDrawing?.version ?? null,
+            });
+          }
+        }
+        throw error;
       }
-      throw error;
-    }
-    if (!updatedDrawing) {
-      return res.status(404).json({ error: "Drawing not found" });
-    }
-    invalidateDrawingsCache();
+      if (!updatedDrawing) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
+      invalidateDrawingsCache();
 
-    return res.json({
-      ...updatedDrawing,
-      collectionId: toPublicTrashCollectionId(updatedDrawing.collectionId, ownerUserId),
-      elements: parseJsonField(updatedDrawing.elements, []),
-      appState: parseJsonField(updatedDrawing.appState, {}),
-      files: parseJsonField(updatedDrawing.files, {}),
-      accessLevel: access,
-    });
-  }));
-
-  app.delete("/drawings/:id", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-    const { id } = req.params;
-
-    const drawing = await prisma.drawing.findFirst({ where: { id, userId: req.user.id } });
-    if (!drawing) return res.status(404).json({ error: "Drawing not found" });
-
-    const deleteResult = await prisma.drawing.deleteMany({
-      where: { id, userId: req.user.id },
-    });
-    if (deleteResult.count === 0) {
-      return res.status(404).json({ error: "Drawing not found" });
-    }
-    invalidateDrawingsCache();
-
-    if (config.enableAuditLogging) {
-      await logAuditEvent({
-        userId: req.user.id,
-        action: "drawing_deleted",
-        resource: `drawing:${id}`,
-        ipAddress: req.ip || req.connection.remoteAddress || undefined,
-        userAgent: req.headers["user-agent"] || undefined,
-        details: { drawingId: id, drawingName: drawing.name },
+      return res.json({
+        ...updatedDrawing,
+        collectionId: toPublicTrashCollectionId(
+          updatedDrawing.collectionId,
+          ownerUserId,
+        ),
+        elements: parseJsonField(updatedDrawing.elements, []),
+        appState: parseJsonField(updatedDrawing.appState, {}),
+        files: parseJsonField(updatedDrawing.files, {}),
+        accessLevel: access,
       });
-    }
+    }),
+  );
 
-    return res.json({ success: true });
-  }));
+  app.delete(
+    "/drawings/:id",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const { id } = req.params;
 
-  app.post("/drawings/:id/duplicate", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const drawing = await prisma.drawing.findFirst({
+        where: { id, userId: req.user.id },
+      });
+      if (!drawing) return res.status(404).json({ error: "Drawing not found" });
 
-    const { id } = req.params;
-    const original = await prisma.drawing.findFirst({ where: { id, userId: req.user.id } });
-    if (!original) return res.status(404).json({ error: "Original drawing not found" });
-    let duplicatedCollectionId = original.collectionId;
-    if (isTrashCollectionId(original.collectionId, req.user.id)) {
-      await ensureTrashCollection(prisma, req.user.id);
-      duplicatedCollectionId = getUserTrashCollectionId(req.user.id);
-    }
+      const deleteResult = await prisma.drawing.deleteMany({
+        where: { id, userId: req.user.id },
+      });
+      if (deleteResult.count === 0) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
+      invalidateDrawingsCache();
 
-    const newDrawing = await prisma.drawing.create({
-      data: {
-        name: `${original.name} (Copy)`,
-        elements: original.elements,
-        appState: original.appState,
-        files: original.files,
-        userId: req.user.id,
-        collectionId: duplicatedCollectionId,
-        version: 1,
-      },
-    });
-    invalidateDrawingsCache();
+      if (config.enableAuditLogging) {
+        await logAuditEvent({
+          userId: req.user.id,
+          action: "drawing_deleted",
+          resource: `drawing:${id}`,
+          ipAddress: req.ip || req.connection.remoteAddress || undefined,
+          userAgent: req.headers["user-agent"] || undefined,
+          details: { drawingId: id, drawingName: drawing.name },
+        });
+      }
 
-    return res.json({
-      ...newDrawing,
-      collectionId: toPublicTrashCollectionId(newDrawing.collectionId, req.user.id),
-      elements: parseJsonField(newDrawing.elements, []),
-      appState: parseJsonField(newDrawing.appState, {}),
-      files: parseJsonField(newDrawing.files, {}),
-    });
-  }));
+      return res.json({ success: true });
+    }),
+  );
+
+  app.post(
+    "/drawings/:id/duplicate",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+
+      const { id } = req.params;
+      const original = await prisma.drawing.findFirst({
+        where: { id, userId: req.user.id },
+      });
+      if (!original)
+        return res.status(404).json({ error: "Original drawing not found" });
+      let duplicatedCollectionId = original.collectionId;
+      if (isTrashCollectionId(original.collectionId, req.user.id)) {
+        await ensureTrashCollection(prisma, req.user.id);
+        duplicatedCollectionId = getUserTrashCollectionId(req.user.id);
+      }
+
+      const newDrawing = await prisma.drawing.create({
+        data: {
+          name: `${original.name} (Copy)`,
+          elements: original.elements,
+          appState: original.appState,
+          files: original.files,
+          userId: req.user.id,
+          collectionId: duplicatedCollectionId,
+          version: 1,
+        },
+      });
+      invalidateDrawingsCache();
+
+      return res.json({
+        ...newDrawing,
+        collectionId: toPublicTrashCollectionId(
+          newDrawing.collectionId,
+          req.user.id,
+        ),
+        elements: parseJsonField(newDrawing.elements, []),
+        appState: parseJsonField(newDrawing.appState, {}),
+        files: parseJsonField(newDrawing.files, {}),
+      });
+    }),
+  );
 
   // Owner-only: resolve users by name/email in the context of a drawing you own (reduces enumeration risk).
-  app.get("/drawings/:id/share-resolve", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+  app.get(
+    "/drawings/:id/share-resolve",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
 
-    const { id } = req.params;
-    const qRaw = typeof req.query.q === "string" ? req.query.q.trim() : "";
-    const q = qRaw.toLowerCase();
-    if (q.length < 3) return res.json({ users: [] });
+      const { id } = req.params;
+      const qRaw = typeof req.query.q === "string" ? req.query.q.trim() : "";
+      const q = qRaw.toLowerCase();
+      if (q.length < 3) return res.json({ users: [] });
 
-    const drawing = await prisma.drawing.findUnique({ where: { id }, select: { userId: true } });
-    if (!drawing || drawing.userId !== req.user.id) {
-      return res.status(404).json({ error: "Drawing not found" });
-    }
+      const drawing = await prisma.drawing.findUnique({
+        where: { id },
+        select: { userId: true },
+      });
+      if (!drawing || drawing.userId !== req.user.id) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
 
-    const users = await prisma.user.findMany({
-      where: {
-        isActive: true,
-        id: { not: req.user.id },
-        OR: [
-          { email: { contains: q } },
-          { name: { contains: q } },
-          { username: { contains: q } },
-        ],
-      },
-      select: { id: true, name: true, email: true },
-      take: 10,
-    });
+      const users = await prisma.user.findMany({
+        where: {
+          isActive: true,
+          id: { not: req.user.id },
+          OR: [
+            { email: { contains: q } },
+            { name: { contains: q } },
+            { username: { contains: q } },
+          ],
+        },
+        select: { id: true, name: true, email: true },
+        take: 10,
+      });
 
-    return res.json({ users });
-  }));
+      return res.json({ users });
+    }),
+  );
 
-  app.get("/drawings/:id/sharing", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-    const { id } = req.params;
+  app.get(
+    "/drawings/:id/sharing",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const { id } = req.params;
 
-    const drawing = await prisma.drawing.findUnique({ where: { id }, select: { userId: true } });
-    if (!drawing || drawing.userId !== req.user.id) {
-      return res.status(404).json({ error: "Drawing not found" });
-    }
+      const drawing = await prisma.drawing.findUnique({
+        where: { id },
+        select: { userId: true },
+      });
+      if (!drawing || drawing.userId !== req.user.id) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
 
-    const [permissions, linkShares] = await Promise.all([
-      prisma.drawingPermission.findMany({
-        where: { drawingId: id },
+      const [permissions, linkShares] = await Promise.all([
+        prisma.drawingPermission.findMany({
+          where: { drawingId: id },
+          select: {
+            id: true,
+            granteeUserId: true,
+            permission: true,
+            createdAt: true,
+            updatedAt: true,
+            granteeUser: { select: { id: true, name: true, email: true } },
+          },
+          orderBy: { createdAt: "desc" },
+        }),
+        prisma.drawingLinkShare.findMany({
+          where: { drawingId: id },
+          select: {
+            id: true,
+            permission: true,
+            expiresAt: true,
+            revokedAt: true,
+            createdAt: true,
+            updatedAt: true,
+            lastUsedAt: true,
+          },
+          orderBy: { createdAt: "desc" },
+        }),
+      ]);
+
+      return res.json({ permissions, linkShares });
+    }),
+  );
+
+  app.post(
+    "/drawings/:id/permissions",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const { id } = req.params;
+
+      const drawing = await prisma.drawing.findUnique({
+        where: { id },
+        select: { userId: true },
+      });
+      if (!drawing || drawing.userId !== req.user.id) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
+
+      const granteeUserId =
+        typeof req.body?.granteeUserId === "string"
+          ? req.body.granteeUserId
+          : null;
+      const permission = normalizeDrawingPermission(req.body?.permission);
+      if (!granteeUserId || !permission) {
+        return res.status(400).json({
+          error: "Validation error",
+          message: "Invalid grantee or permission",
+        });
+      }
+      if (granteeUserId === req.user.id) {
+        return res.status(400).json({
+          error: "Validation error",
+          message: "Cannot share with yourself",
+        });
+      }
+
+      const user = await prisma.user.findUnique({
+        where: { id: granteeUserId },
+        select: { id: true, isActive: true },
+      });
+      if (!user || !user.isActive) {
+        return res.status(404).json({ error: "User not found" });
+      }
+
+      const saved = await prisma.drawingPermission.upsert({
+        where: {
+          drawingId_granteeUserId: { drawingId: id, granteeUserId },
+        },
+        update: { permission, createdByUserId: req.user.id },
+        create: {
+          drawingId: id,
+          granteeUserId,
+          permission,
+          createdByUserId: req.user.id,
+        },
         select: {
           id: true,
           granteeUserId: true,
@@ -679,221 +937,198 @@ export const registerDrawingRoutes = (
           updatedAt: true,
           granteeUser: { select: { id: true, name: true, email: true } },
         },
-        orderBy: { createdAt: "desc" },
-      }),
-      prisma.drawingLinkShare.findMany({
-        where: { drawingId: id },
+      });
+
+      invalidateDrawingsCache();
+
+      if (config.enableAuditLogging) {
+        await logAuditEvent({
+          userId: req.user.id,
+          action: "drawing_shared_user_upsert",
+          resource: `drawing:${id}`,
+          ipAddress: req.ip || req.connection.remoteAddress || undefined,
+          userAgent: req.headers["user-agent"] || undefined,
+          details: { drawingId: id, granteeUserId, permission },
+        });
+      }
+
+      return res.json({ permission: saved });
+    }),
+  );
+
+  app.delete(
+    "/drawings/:id/permissions/:permId",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const { id, permId } = req.params;
+
+      const drawing = await prisma.drawing.findUnique({
+        where: { id },
+        select: { userId: true },
+      });
+      if (!drawing || drawing.userId !== req.user.id) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
+
+      await prisma.drawingPermission.deleteMany({
+        where: { id: permId, drawingId: id },
+      });
+      invalidateDrawingsCache();
+
+      if (config.enableAuditLogging) {
+        await logAuditEvent({
+          userId: req.user.id,
+          action: "drawing_shared_user_revoke",
+          resource: `drawing:${id}`,
+          ipAddress: req.ip || req.connection.remoteAddress || undefined,
+          userAgent: req.headers["user-agent"] || undefined,
+          details: { drawingId: id, permissionId: permId },
+        });
+      }
+
+      return res.json({ success: true });
+    }),
+  );
+
+  app.post(
+    "/drawings/:id/link-shares",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const { id } = req.params;
+
+      const drawing = await prisma.drawing.findUnique({
+        where: { id },
+        select: { userId: true },
+      });
+      if (!drawing || drawing.userId !== req.user.id) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
+
+      const permission = normalizeDrawingPermission(req.body?.permission);
+      if (!permission) {
+        return res
+          .status(400)
+          .json({ error: "Validation error", message: "Invalid permission" });
+      }
+
+      const rawExpiresAt =
+        typeof req.body?.expiresAt === "string" ? req.body.expiresAt : null;
+      const expiresAtText = (rawExpiresAt || "").trim();
+      const requestedExpiresAt =
+        expiresAtText.length > 0 ? new Date(expiresAtText) : null;
+      const hasValidRequestedExpiry = Boolean(
+        requestedExpiresAt && Number.isFinite(requestedExpiresAt.getTime()),
+      );
+
+      const now = Date.now();
+      const maxTtlMs = resolveMaxTtlMs();
+      const defaultTtlMs = resolveDefaultTtlMs(permission);
+
+      let expiresAt: Date | null = null;
+      // View links can be truly non-expiring unless an explicit expiry is provided.
+      // Edit links default to an expiry window when none is provided.
+      if (
+        permission === "view" &&
+        !hasValidRequestedExpiry &&
+        expiresAtText.length === 0
+      ) {
+        expiresAt = null;
+      } else {
+        const candidateTtlMs =
+          hasValidRequestedExpiry && requestedExpiresAt
+            ? requestedExpiresAt.getTime() - now
+            : defaultTtlMs;
+        const ttlMs = Math.min(Math.max(candidateTtlMs, 60_000), maxTtlMs);
+        expiresAt = new Date(now + ttlMs);
+      }
+
+      // Passphrase support is currently disabled. We keep passphraseHash nullable for backwards compatibility.
+      const passphraseHashValue: string | null = null;
+
+      // Enforce a single active "anyone with the link" policy per drawing. The public link is the drawing id,
+      // so multiple active link-share rows would be confusing and could unintentionally widen access.
+      await prisma.drawingLinkShare.updateMany({
+        where: { drawingId: id, revokedAt: null },
+        data: { revokedAt: new Date() },
+      });
+
+      // Token is generated only to satisfy the current schema's tokenHash requirement.
+      // Link access is based on drawing id + active policy (no secret token in the URL).
+      const tokenHash = hashShareLinkToken(buildShareLinkToken());
+
+      const created = await prisma.drawingLinkShare.create({
+        data: {
+          drawingId: id,
+          permission,
+          tokenHash,
+          passphraseHash: passphraseHashValue,
+          expiresAt,
+          createdByUserId: req.user.id,
+        },
         select: {
           id: true,
           permission: true,
           expiresAt: true,
           revokedAt: true,
           createdAt: true,
-          updatedAt: true,
-          lastUsedAt: true,
         },
-        orderBy: { createdAt: "desc" },
-      }),
-    ]);
-
-    return res.json({ permissions, linkShares });
-  }));
-
-  app.post("/drawings/:id/permissions", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-    const { id } = req.params;
-
-    const drawing = await prisma.drawing.findUnique({ where: { id }, select: { userId: true } });
-    if (!drawing || drawing.userId !== req.user.id) {
-      return res.status(404).json({ error: "Drawing not found" });
-    }
-
-    const granteeUserId = typeof req.body?.granteeUserId === "string" ? req.body.granteeUserId : null;
-    const permission = normalizeDrawingPermission(req.body?.permission);
-    if (!granteeUserId || !permission) {
-      return res.status(400).json({ error: "Validation error", message: "Invalid grantee or permission" });
-    }
-    if (granteeUserId === req.user.id) {
-      return res.status(400).json({ error: "Validation error", message: "Cannot share with yourself" });
-    }
-
-    const user = await prisma.user.findUnique({
-      where: { id: granteeUserId },
-      select: { id: true, isActive: true },
-    });
-    if (!user || !user.isActive) {
-      return res.status(404).json({ error: "User not found" });
-    }
-
-    const saved = await prisma.drawingPermission.upsert({
-      where: {
-        drawingId_granteeUserId: { drawingId: id, granteeUserId },
-      },
-      update: { permission, createdByUserId: req.user.id },
-      create: { drawingId: id, granteeUserId, permission, createdByUserId: req.user.id },
-      select: {
-        id: true,
-        granteeUserId: true,
-        permission: true,
-        createdAt: true,
-        updatedAt: true,
-        granteeUser: { select: { id: true, name: true, email: true } },
-      },
-    });
-
-    invalidateDrawingsCache();
-
-    if (config.enableAuditLogging) {
-      await logAuditEvent({
-        userId: req.user.id,
-        action: "drawing_shared_user_upsert",
-        resource: `drawing:${id}`,
-        ipAddress: req.ip || req.connection.remoteAddress || undefined,
-        userAgent: req.headers["user-agent"] || undefined,
-        details: { drawingId: id, granteeUserId, permission },
       });
-    }
 
-    return res.json({ permission: saved });
-  }));
+      if (config.enableAuditLogging) {
+        await logAuditEvent({
+          userId: req.user.id,
+          action: "drawing_link_share_created",
+          resource: `drawing:${id}`,
+          ipAddress: req.ip || req.connection.remoteAddress || undefined,
+          userAgent: req.headers["user-agent"] || undefined,
+          details: {
+            drawingId: id,
+            permission,
+            expiresAt: expiresAt ? expiresAt.toISOString() : null,
+          },
+        });
+      }
 
-  app.delete("/drawings/:id/permissions/:permId", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-    const { id, permId } = req.params;
+      return res.json({ share: created });
+    }),
+  );
 
-    const drawing = await prisma.drawing.findUnique({ where: { id }, select: { userId: true } });
-    if (!drawing || drawing.userId !== req.user.id) {
-      return res.status(404).json({ error: "Drawing not found" });
-    }
+  app.delete(
+    "/drawings/:id/link-shares/:shareId",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const { id, shareId } = req.params;
 
-    await prisma.drawingPermission.deleteMany({
-      where: { id: permId, drawingId: id },
-    });
-    invalidateDrawingsCache();
-
-    if (config.enableAuditLogging) {
-      await logAuditEvent({
-        userId: req.user.id,
-        action: "drawing_shared_user_revoke",
-        resource: `drawing:${id}`,
-        ipAddress: req.ip || req.connection.remoteAddress || undefined,
-        userAgent: req.headers["user-agent"] || undefined,
-        details: { drawingId: id, permissionId: permId },
+      const drawing = await prisma.drawing.findUnique({
+        where: { id },
+        select: { userId: true },
       });
-    }
+      if (!drawing || drawing.userId !== req.user.id) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
 
-    return res.json({ success: true });
-  }));
-
-  app.post("/drawings/:id/link-shares", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-    const { id } = req.params;
-
-    const drawing = await prisma.drawing.findUnique({ where: { id }, select: { userId: true } });
-    if (!drawing || drawing.userId !== req.user.id) {
-      return res.status(404).json({ error: "Drawing not found" });
-    }
-
-    const permission = normalizeDrawingPermission(req.body?.permission);
-    if (!permission) {
-      return res.status(400).json({ error: "Validation error", message: "Invalid permission" });
-    }
-
-    const rawExpiresAt = typeof req.body?.expiresAt === "string" ? req.body.expiresAt : null;
-    const expiresAtText = (rawExpiresAt || "").trim();
-    const requestedExpiresAt = expiresAtText.length > 0 ? new Date(expiresAtText) : null;
-    const hasValidRequestedExpiry = Boolean(requestedExpiresAt && Number.isFinite(requestedExpiresAt.getTime()));
-
-    const now = Date.now();
-    const maxTtlMs = resolveMaxTtlMs();
-    const defaultTtlMs = resolveDefaultTtlMs(permission);
-
-    let expiresAt: Date | null = null;
-    // View links can be truly non-expiring unless an explicit expiry is provided.
-    // Edit links default to an expiry window when none is provided.
-    if (permission === "view" && !hasValidRequestedExpiry && expiresAtText.length === 0) {
-      expiresAt = null;
-    } else {
-      const candidateTtlMs = hasValidRequestedExpiry && requestedExpiresAt
-        ? requestedExpiresAt.getTime() - now
-        : defaultTtlMs;
-      const ttlMs = Math.min(Math.max(candidateTtlMs, 60_000), maxTtlMs);
-      expiresAt = new Date(now + ttlMs);
-    }
-
-    // Passphrase support is currently disabled. We keep passphraseHash nullable for backwards compatibility.
-    const passphraseHashValue: string | null = null;
-
-    // Enforce a single active "anyone with the link" policy per drawing. The public link is the drawing id,
-    // so multiple active link-share rows would be confusing and could unintentionally widen access.
-    await prisma.drawingLinkShare.updateMany({
-      where: { drawingId: id, revokedAt: null },
-      data: { revokedAt: new Date() },
-    });
-
-    // Token is generated only to satisfy the current schema's tokenHash requirement.
-    // Link access is based on drawing id + active policy (no secret token in the URL).
-    const tokenHash = hashShareLinkToken(buildShareLinkToken());
-
-    const created = await prisma.drawingLinkShare.create({
-      data: {
-        drawingId: id,
-        permission,
-        tokenHash,
-        passphraseHash: passphraseHashValue,
-        expiresAt,
-        createdByUserId: req.user.id,
-      },
-      select: {
-        id: true,
-        permission: true,
-        expiresAt: true,
-        revokedAt: true,
-        createdAt: true,
-      },
-    });
-
-    if (config.enableAuditLogging) {
-      await logAuditEvent({
-        userId: req.user.id,
-        action: "drawing_link_share_created",
-        resource: `drawing:${id}`,
-        ipAddress: req.ip || req.connection.remoteAddress || undefined,
-        userAgent: req.headers["user-agent"] || undefined,
-        details: { drawingId: id, permission, expiresAt: expiresAt ? expiresAt.toISOString() : null },
+      await prisma.drawingLinkShare.updateMany({
+        where: { id: shareId, drawingId: id, revokedAt: null },
+        data: { revokedAt: new Date() },
       });
-    }
 
-    return res.json({ share: created });
-  }));
+      if (config.enableAuditLogging) {
+        await logAuditEvent({
+          userId: req.user.id,
+          action: "drawing_link_share_revoked",
+          resource: `drawing:${id}`,
+          ipAddress: req.ip || req.connection.remoteAddress || undefined,
+          userAgent: req.headers["user-agent"] || undefined,
+          details: { drawingId: id, shareId },
+        });
+      }
 
-  app.delete("/drawings/:id/link-shares/:shareId", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-    const { id, shareId } = req.params;
-
-    const drawing = await prisma.drawing.findUnique({ where: { id }, select: { userId: true } });
-    if (!drawing || drawing.userId !== req.user.id) {
-      return res.status(404).json({ error: "Drawing not found" });
-    }
-
-    await prisma.drawingLinkShare.updateMany({
-      where: { id: shareId, drawingId: id, revokedAt: null },
-      data: { revokedAt: new Date() },
-    });
-
-    if (config.enableAuditLogging) {
-      await logAuditEvent({
-        userId: req.user.id,
-        action: "drawing_link_share_revoked",
-        resource: `drawing:${id}`,
-        ipAddress: req.ip || req.connection.remoteAddress || undefined,
-        userAgent: req.headers["user-agent"] || undefined,
-        details: { drawingId: id, shareId },
-      });
-    }
-
-    return res.json({ success: true });
-  }));
+      return res.json({ success: true });
+    }),
+  );
 
   // Legacy share-token exchange endpoint removed: link access is based on drawing id + active policy.
 
@@ -902,102 +1137,130 @@ export const registerDrawingRoutes = (
   // ============================================================
 
   // List snapshots (metadata only)
-  app.get("/drawings/:id/history", optionalAuth, asyncHandler(async (req, res) => {
-    const principal = await getRequestPrincipal(req);
-    const { id } = req.params;
-    const access = await getDrawingAccess({ prisma, principal, drawingId: id });
-    if (!canViewDrawing(access)) {
-      if (respondWithAuthErrorIfPresent(req, res)) return;
-      return res.status(404).json({ error: "Drawing not found" });
-    }
+  app.get(
+    "/drawings/:id/history",
+    optionalAuth,
+    asyncHandler(async (req, res) => {
+      const principal = await getRequestPrincipal(req);
+      const { id } = req.params;
+      const access = await getDrawingAccess({
+        prisma,
+        principal,
+        drawingId: id,
+      });
+      if (!canViewDrawing(access)) {
+        if (respondWithAuthErrorIfPresent(req, res)) return;
+        return res.status(404).json({ error: "Drawing not found" });
+      }
 
-    const limit = Math.min(parseInt(req.query.limit as string) || 50, 200);
-    const offset = parseInt(req.query.offset as string) || 0;
+      const limit = Math.min(parseInt(req.query.limit as string) || 50, 200);
+      const offset = parseInt(req.query.offset as string) || 0;
 
-    const [snapshots, totalCount] = await Promise.all([
-      prisma.drawingSnapshot.findMany({
-        where: { drawingId: id },
-        select: { id: true, version: true, createdAt: true },
-        orderBy: { createdAt: "desc" },
-        take: limit,
-        skip: offset,
-      }),
-      prisma.drawingSnapshot.count({ where: { drawingId: id } }),
-    ]);
+      const [snapshots, totalCount] = await Promise.all([
+        prisma.drawingSnapshot.findMany({
+          where: { drawingId: id },
+          select: { id: true, version: true, createdAt: true },
+          orderBy: { createdAt: "desc" },
+          take: limit,
+          skip: offset,
+        }),
+        prisma.drawingSnapshot.count({ where: { drawingId: id } }),
+      ]);
 
-    return res.json({ snapshots, totalCount });
-  }));
+      return res.json({ snapshots, totalCount });
+    }),
+  );
 
   // Get full snapshot for preview
-  app.get("/drawings/:id/history/:snapshotId", optionalAuth, asyncHandler(async (req, res) => {
-    const principal = await getRequestPrincipal(req);
-    const { id, snapshotId } = req.params;
-    const access = await getDrawingAccess({ prisma, principal, drawingId: id });
-    if (!canViewDrawing(access)) {
-      if (respondWithAuthErrorIfPresent(req, res)) return;
-      return res.status(404).json({ error: "Drawing not found" });
-    }
+  app.get(
+    "/drawings/:id/history/:snapshotId",
+    optionalAuth,
+    asyncHandler(async (req, res) => {
+      const principal = await getRequestPrincipal(req);
+      const { id, snapshotId } = req.params;
+      const access = await getDrawingAccess({
+        prisma,
+        principal,
+        drawingId: id,
+      });
+      if (!canViewDrawing(access)) {
+        if (respondWithAuthErrorIfPresent(req, res)) return;
+        return res.status(404).json({ error: "Drawing not found" });
+      }
 
-    const snapshot = await prisma.drawingSnapshot.findFirst({
-      where: { id: snapshotId, drawingId: id },
-    });
-    if (!snapshot) return res.status(404).json({ error: "Snapshot not found" });
+      const snapshot = await prisma.drawingSnapshot.findFirst({
+        where: { id: snapshotId, drawingId: id },
+      });
+      if (!snapshot)
+        return res.status(404).json({ error: "Snapshot not found" });
 
-    return res.json({
-      ...snapshot,
-      elements: parseJsonField(snapshot.elements, []),
-      appState: parseJsonField(snapshot.appState, {}),
-      files: parseJsonField(snapshot.files, {}),
-    });
-  }));
+      return res.json({
+        ...snapshot,
+        elements: parseJsonField(snapshot.elements, []),
+        appState: parseJsonField(snapshot.appState, {}),
+        files: parseJsonField(snapshot.files, {}),
+      });
+    }),
+  );
 
   // Restore a snapshot (snapshots current state first, then applies old state)
-  app.post("/drawings/:id/history/:snapshotId/restore", optionalAuth, asyncHandler(async (req, res) => {
-    const principal = await getRequestPrincipal(req);
-    const { id, snapshotId } = req.params;
-    const access = await getDrawingAccess({ prisma, principal, drawingId: id });
-    if (!canEditDrawing(access)) {
-      if (respondWithAuthErrorIfPresent(req, res)) return;
-      return res.status(404).json({ error: "Drawing not found" });
-    }
-
-    const [drawing, snapshot] = await Promise.all([
-      prisma.drawing.findUnique({ where: { id } }),
-      prisma.drawingSnapshot.findFirst({ where: { id: snapshotId, drawingId: id } }),
-    ]);
-    if (!drawing) return res.status(404).json({ error: "Drawing not found" });
-    if (!snapshot) return res.status(404).json({ error: "Snapshot not found" });
-
-    // Snapshot current state before restoring (so restore is reversible)
-    await prisma.drawingSnapshot.create({
-      data: {
+  app.post(
+    "/drawings/:id/history/:snapshotId/restore",
+    optionalAuth,
+    asyncHandler(async (req, res) => {
+      const principal = await getRequestPrincipal(req);
+      const { id, snapshotId } = req.params;
+      const access = await getDrawingAccess({
+        prisma,
+        principal,
         drawingId: id,
-        version: drawing.version,
-        elements: drawing.elements,
-        appState: drawing.appState,
-        files: drawing.files,
-      },
-    });
+      });
+      if (!canEditDrawing(access)) {
+        if (respondWithAuthErrorIfPresent(req, res)) return;
+        return res.status(404).json({ error: "Drawing not found" });
+      }
 
-    // Apply snapshot
-    const updated = await prisma.drawing.update({
-      where: { id },
-      data: {
-        elements: snapshot.elements,
-        appState: snapshot.appState,
-        files: snapshot.files,
-        version: { increment: 1 },
-      },
-    });
+      const [drawing, snapshot] = await Promise.all([
+        prisma.drawing.findUnique({ where: { id } }),
+        prisma.drawingSnapshot.findFirst({
+          where: { id: snapshotId, drawingId: id },
+        }),
+      ]);
+      if (!drawing) return res.status(404).json({ error: "Drawing not found" });
+      if (!snapshot)
+        return res.status(404).json({ error: "Snapshot not found" });
 
-    invalidateDrawingsCache();
+      // Snapshot current state before restoring (so restore is reversible)
+      await prisma.drawingSnapshot.create({
+        data: {
+          drawingId: id,
+          version: drawing.version,
+          elements: drawing.elements,
+          appState: drawing.appState,
+          files: drawing.files,
+        },
+      });
 
-    return res.json({
-      ...updated,
-      elements: parseJsonField(updated.elements, []),
-      appState: parseJsonField(updated.appState, {}),
-      files: parseJsonField(updated.files, {}),
-      accessLevel: access,
-    });
-  }));
+      // Apply snapshot
+      const updated = await prisma.drawing.update({
+        where: { id },
+        data: {
+          elements: snapshot.elements,
+          appState: snapshot.appState,
+          files: snapshot.files,
+          version: { increment: 1 },
+        },
+      });
+
+      invalidateDrawingsCache();
+
+      return res.json({
+        ...updated,
+        elements: parseJsonField(updated.elements, []),
+        appState: parseJsonField(updated.appState, {}),
+        files: parseJsonField(updated.files, {}),
+        accessLevel: access,
+      });
+    }),
+  );
 };

--- a/backend/src/routes/dashboard/drawings.ts
+++ b/backend/src/routes/dashboard/drawings.ts
@@ -20,7 +20,7 @@ import {
 
 export const registerDrawingRoutes = (
   app: express.Express,
-  deps: DashboardRouteDeps
+  deps: DashboardRouteDeps,
 ) => {
   const {
     prisma,
@@ -43,7 +43,7 @@ export const registerDrawingRoutes = (
   } = deps;
 
   const getRequestPrincipal = async (
-    req: express.Request
+    req: express.Request,
   ): Promise<DrawingPrincipal | null> => {
     if (req.user?.id) {
       return { kind: "user", userId: req.user.id };
@@ -58,7 +58,9 @@ export const registerDrawingRoutes = (
         : process.env.LINK_SHARE_VIEW_DEFAULT_TTL_MS;
     const parsed = raw ? Number(raw) : NaN;
     if (Number.isFinite(parsed) && parsed > 0) return parsed;
-    return permission === "edit" ? 7 * 24 * 60 * 60 * 1000 : 30 * 24 * 60 * 60 * 1000;
+    return permission === "edit"
+      ? 7 * 24 * 60 * 60 * 1000
+      : 30 * 24 * 60 * 60 * 1000;
   };
 
   const resolveMaxTtlMs = (): number => {
@@ -69,7 +71,7 @@ export const registerDrawingRoutes = (
 
   const respondWithAuthErrorIfPresent = (
     req: express.Request,
-    res: express.Response
+    res: express.Response,
   ): boolean => {
     if (!req.authError) return false;
 
@@ -80,562 +82,816 @@ export const registerDrawingRoutes = (
     return true;
   };
 
-  app.get("/drawings", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) {
-      return res.status(401).json({ error: "Unauthorized" });
-    }
-
-    const trashCollectionId = getUserTrashCollectionId(req.user.id);
-    const { search, collectionId, includeData, limit, offset, sortField, sortDirection } = req.query;
-    const where: Prisma.DrawingWhereInput = { userId: req.user.id };
-    const searchTerm =
-      typeof search === "string" && search.trim().length > 0 ? search.trim() : undefined;
-
-    if (searchTerm) {
-      where.name = { contains: searchTerm };
-    }
-
-    let collectionFilterKey = "default";
-    if (collectionId === "null") {
-      where.collectionId = null;
-      collectionFilterKey = "null";
-    } else if (collectionId) {
-      const normalizedCollectionId = String(collectionId);
-      if (normalizedCollectionId === "trash") {
-        where.collectionId = { in: [trashCollectionId, "trash"] };
-        collectionFilterKey = "trash";
-      } else {
-        const collection = await prisma.collection.findFirst({
-          where: { id: normalizedCollectionId, userId: req.user.id },
-        });
-        if (!collection) {
-          return res.status(404).json({ error: "Collection not found" });
-        }
-        where.collectionId = normalizedCollectionId;
-        collectionFilterKey = `id:${normalizedCollectionId}`;
+  app.get(
+    "/drawings",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) {
+        return res.status(401).json({ error: "Unauthorized" });
       }
-    } else {
-      where.OR = [
-        { collectionId: { notIn: [trashCollectionId, "trash"] } },
-        { collectionId: null },
-      ];
-    }
 
-    const shouldIncludeData =
-      typeof includeData === "string"
-        ? includeData.toLowerCase() === "true" || includeData === "1"
-        : false;
-    const parsedSortField: SortField =
-      sortField === "name" || sortField === "createdAt" || sortField === "updatedAt"
-        ? sortField
-        : "updatedAt";
-    const parsedSortDirection: SortDirection =
-      sortDirection === "asc" || sortDirection === "desc"
-        ? sortDirection
-        : parsedSortField === "name"
-        ? "asc"
-        : "desc";
+      const trashCollectionId = getUserTrashCollectionId(req.user.id);
+      const {
+        search,
+        collectionId,
+        includeData,
+        limit,
+        offset,
+        sortField,
+        sortDirection,
+      } = req.query;
+      const where: Prisma.DrawingWhereInput = { userId: req.user.id };
+      const searchTerm =
+        typeof search === "string" && search.trim().length > 0
+          ? search.trim()
+          : undefined;
 
-    const rawLimit = limit ? Number.parseInt(limit as string, 10) : undefined;
-    const rawOffset = offset ? Number.parseInt(offset as string, 10) : undefined;
-    const parsedLimit =
-      rawLimit !== undefined && Number.isFinite(rawLimit)
-        ? Math.min(Math.max(rawLimit, 1), MAX_PAGE_SIZE)
+      if (searchTerm) {
+        where.name = { contains: searchTerm };
+      }
+
+      let collectionFilterKey = "default";
+      if (collectionId === "null") {
+        where.collectionId = null;
+        collectionFilterKey = "null";
+      } else if (collectionId) {
+        const normalizedCollectionId = String(collectionId);
+        if (normalizedCollectionId === "trash") {
+          where.collectionId = { in: [trashCollectionId, "trash"] };
+          collectionFilterKey = "trash";
+        } else {
+          const collection = await prisma.collection.findFirst({
+            where: { id: normalizedCollectionId },
+          });
+          if (!collection) {
+            return res.status(404).json({ error: "Collection not found" });
+          }
+
+          // Check if user is owner or has a share entry
+          const isOwner = collection.userId === req.user.id;
+          if (!isOwner) {
+            const share = await prisma.collectionShare.findFirst({
+              where: {
+                collectionId: normalizedCollectionId,
+                granteeUserId: req.user.id,
+              },
+            });
+            if (!share) {
+              return res.status(404).json({ error: "Collection not found" });
+            }
+          }
+          // Always fetch all drawings in the collection regardless of who created them
+          delete (where as any).userId;
+
+          where.collectionId = normalizedCollectionId;
+          collectionFilterKey = `id:${normalizedCollectionId}`;
+        }
+      } else {
+        where.OR = [
+          { collectionId: { notIn: [trashCollectionId, "trash"] } },
+          { collectionId: null },
+        ];
+      }
+
+      const shouldIncludeData =
+        typeof includeData === "string"
+          ? includeData.toLowerCase() === "true" || includeData === "1"
+          : false;
+      const parsedSortField: SortField =
+        sortField === "name" ||
+        sortField === "createdAt" ||
+        sortField === "updatedAt"
+          ? sortField
+          : "updatedAt";
+      const parsedSortDirection: SortDirection =
+        sortDirection === "asc" || sortDirection === "desc"
+          ? sortDirection
+          : parsedSortField === "name"
+            ? "asc"
+            : "desc";
+
+      const rawLimit = limit ? Number.parseInt(limit as string, 10) : undefined;
+      const rawOffset = offset
+        ? Number.parseInt(offset as string, 10)
         : undefined;
-    const parsedOffset =
-      rawOffset !== undefined && Number.isFinite(rawOffset) ? Math.max(rawOffset, 0) : undefined;
+      const parsedLimit =
+        rawLimit !== undefined && Number.isFinite(rawLimit)
+          ? Math.min(Math.max(rawLimit, 1), MAX_PAGE_SIZE)
+          : undefined;
+      const parsedOffset =
+        rawOffset !== undefined && Number.isFinite(rawOffset)
+          ? Math.max(rawOffset, 0)
+          : undefined;
 
-    const cacheKey =
-      buildDrawingsCacheKey({
-        userId: req.user.id,
-        searchTerm: searchTerm ?? "",
-        collectionFilter: collectionFilterKey,
-        includeData: shouldIncludeData,
-        sortField: parsedSortField,
-        sortDirection: parsedSortDirection,
-      }) + `:${parsedLimit}:${parsedOffset}`;
+      const cacheKey =
+        buildDrawingsCacheKey({
+          userId: req.user.id,
+          searchTerm: searchTerm ?? "",
+          collectionFilter: collectionFilterKey,
+          includeData: shouldIncludeData,
+          sortField: parsedSortField,
+          sortDirection: parsedSortDirection,
+        }) + `:${parsedLimit}:${parsedOffset}`;
 
-    const cachedBody = getCachedDrawingsBody(cacheKey);
-    if (cachedBody) {
-      res.setHeader("X-Cache", "HIT");
-      res.setHeader("Content-Type", "application/json");
-      return res.send(cachedBody);
-    }
+      const cachedBody = getCachedDrawingsBody(cacheKey);
+      if (cachedBody) {
+        res.setHeader("X-Cache", "HIT");
+        res.setHeader("Content-Type", "application/json");
+        return res.send(cachedBody);
+      }
 
-    const summarySelect: Prisma.DrawingSelect = {
-      id: true,
-      name: true,
-      collectionId: true,
-      preview: true,
-      version: true,
-      createdAt: true,
-      updatedAt: true,
-    };
-
-    const orderBy: Prisma.DrawingOrderByWithRelationInput =
-      parsedSortField === "name"
-        ? { name: parsedSortDirection }
-        : parsedSortField === "createdAt"
-        ? { createdAt: parsedSortDirection }
-        : { updatedAt: parsedSortDirection };
-
-    const queryOptions: Prisma.DrawingFindManyArgs = { where, orderBy };
-    if (parsedLimit !== undefined) queryOptions.take = parsedLimit;
-    if (parsedOffset !== undefined) queryOptions.skip = parsedOffset;
-    if (!shouldIncludeData) queryOptions.select = summarySelect;
-
-    const [drawings, totalCount] = await Promise.all([
-      prisma.drawing.findMany(queryOptions),
-      prisma.drawing.count({ where }),
-    ]);
-
-    let responsePayload: any[] = drawings as any[];
-    if (shouldIncludeData) {
-      responsePayload = (drawings as any[]).map((d: any) => ({
-        ...d,
-        collectionId: toPublicTrashCollectionId(d.collectionId, req.user!.id),
-        elements: parseJsonField(d.elements, []),
-        appState: parseJsonField(d.appState, {}),
-        files: parseJsonField(d.files, {}),
-      }));
-    } else {
-      responsePayload = (drawings as any[]).map((d: any) => ({
-        ...d,
-        collectionId: toPublicTrashCollectionId(d.collectionId, req.user!.id),
-      }));
-    }
-
-    const finalResponse = {
-      drawings: responsePayload,
-      totalCount,
-      limit: parsedLimit,
-      offset: parsedOffset,
-    };
-
-    const body = cacheDrawingsResponse(cacheKey, finalResponse);
-    res.setHeader("X-Cache", "MISS");
-    res.setHeader("Content-Type", "application/json");
-    return res.send(body);
-  }));
-
-  // Shared with me list (does not mix into /drawings cache semantics)
-  // Must be registered before `/drawings/:id` so it doesn't get treated as a drawing id.
-  app.get("/drawings/shared", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-
-    const { search, includeData, limit, offset, sortField, sortDirection } = req.query;
-    const searchTerm =
-      typeof search === "string" && search.trim().length > 0 ? search.trim() : undefined;
-
-    const shouldIncludeData =
-      typeof includeData === "string"
-        ? includeData.toLowerCase() === "true" || includeData === "1"
-        : false;
-    const parsedSortField: SortField =
-      sortField === "name" || sortField === "createdAt" || sortField === "updatedAt"
-        ? sortField
-        : "updatedAt";
-    const parsedSortDirection: SortDirection =
-      sortDirection === "asc" || sortDirection === "desc"
-        ? sortDirection
-        : parsedSortField === "name"
-        ? "asc"
-        : "desc";
-
-    const rawLimit = limit ? Number.parseInt(limit as string, 10) : undefined;
-    const rawOffset = offset ? Number.parseInt(offset as string, 10) : undefined;
-    const parsedLimit =
-      rawLimit !== undefined && Number.isFinite(rawLimit)
-        ? Math.min(Math.max(rawLimit, 1), MAX_PAGE_SIZE)
-        : undefined;
-    const parsedOffset =
-      rawOffset !== undefined && Number.isFinite(rawOffset) ? Math.max(rawOffset, 0) : undefined;
-
-    const orderBy: Prisma.DrawingOrderByWithRelationInput =
-      parsedSortField === "name"
-        ? { name: parsedSortDirection }
-        : parsedSortField === "createdAt"
-        ? { createdAt: parsedSortDirection }
-        : { updatedAt: parsedSortDirection };
-
-    const whereDrawing: Prisma.DrawingWhereInput = {
-      // "Shared with me" should only include drawings owned by someone else.
-      // Some deployments keep an owner self-permission row for access control; exclude those.
-      userId: { not: req.user.id },
-      permissions: {
-        some: {
-          granteeUserId: req.user.id,
-        },
-      },
-    };
-    if (searchTerm) {
-      whereDrawing.name = { contains: searchTerm };
-    }
-
-    const summarySelect: Prisma.DrawingSelect = {
-      id: true,
-      name: true,
-      collectionId: true,
-      preview: true,
-      version: true,
-      createdAt: true,
-      updatedAt: true,
-      userId: true,
-      permissions: {
-        where: { granteeUserId: req.user.id },
-        select: { permission: true },
-      },
-    };
-
-    const queryOptions: Prisma.DrawingFindManyArgs = { where: whereDrawing, orderBy };
-    if (parsedLimit !== undefined) queryOptions.take = parsedLimit;
-    if (parsedOffset !== undefined) queryOptions.skip = parsedOffset;
-    if (!shouldIncludeData) queryOptions.select = summarySelect;
-
-    const [drawings, totalCount] = await Promise.all([
-      prisma.drawing.findMany(queryOptions),
-      prisma.drawing.count({ where: whereDrawing }),
-    ]);
-
-    const normalize = (d: any) => {
-      const rawPerm = Array.isArray(d?.permissions) ? d.permissions[0]?.permission : null;
-      const perm = normalizeDrawingPermission(rawPerm) ?? "view";
-      const { permissions: _permissions, ...rest } = d;
-      return {
-        ...rest,
-        // Collections are owner-scoped; don't leak the owner's collection ids to viewers.
-        collectionId: null,
-        accessLevel: perm,
+      const summarySelect: Prisma.DrawingSelect = {
+        id: true,
+        name: true,
+        collectionId: true,
+        preview: true,
+        version: true,
+        createdAt: true,
+        updatedAt: true,
+        user: { select: { id: true, name: true } },
       };
-    };
 
-    let responsePayload: any[] = drawings as any[];
-    if (shouldIncludeData) {
-      responsePayload = (drawings as any[]).map((d: any) => {
-        const normalized = normalize(d);
-        return {
-          ...normalized,
+      const orderBy: Prisma.DrawingOrderByWithRelationInput =
+        parsedSortField === "name"
+          ? { name: parsedSortDirection }
+          : parsedSortField === "createdAt"
+            ? { createdAt: parsedSortDirection }
+            : { updatedAt: parsedSortDirection };
+
+      const queryOptions: Prisma.DrawingFindManyArgs = { where, orderBy };
+      if (parsedLimit !== undefined) queryOptions.take = parsedLimit;
+      if (parsedOffset !== undefined) queryOptions.skip = parsedOffset;
+      if (!shouldIncludeData) queryOptions.select = summarySelect;
+
+      const [drawings, totalCount] = await Promise.all([
+        prisma.drawing.findMany(queryOptions),
+        prisma.drawing.count({ where }),
+      ]);
+
+      let responsePayload: any[] = drawings as any[];
+      if (shouldIncludeData) {
+        responsePayload = (drawings as any[]).map((d: any) => ({
+          ...d,
+          collectionId: toPublicTrashCollectionId(d.collectionId, req.user!.id),
           elements: parseJsonField(d.elements, []),
           appState: parseJsonField(d.appState, {}),
           files: parseJsonField(d.files, {}),
-        };
-      });
-    } else {
-      responsePayload = (drawings as any[]).map((d: any) => normalize(d));
-    }
-
-    return res.json({
-      drawings: responsePayload,
-      totalCount,
-      limit: parsedLimit,
-      offset: parsedOffset,
-    });
-  }));
-
-  app.get("/drawings/:id", optionalAuth, asyncHandler(async (req, res) => {
-    const principal = await getRequestPrincipal(req);
-
-    const { id } = req.params;
-    const access = await getDrawingAccess({ prisma, principal, drawingId: id });
-    if (!canViewDrawing(access)) {
-      if (respondWithAuthErrorIfPresent(req, res)) return;
-      return res.status(404).json({ error: "Drawing not found", message: "Drawing does not exist" });
-    }
-
-    const drawing = await prisma.drawing.findUnique({ where: { id } });
-    if (!drawing) {
-      return res.status(404).json({ error: "Drawing not found", message: "Drawing does not exist" });
-    }
-
-    const isOwner = principal?.kind === "user" && principal.userId === drawing.userId;
-    return res.json({
-      ...drawing,
-      // Collections (and trash mapping) are owner-scoped. For shared/public access, avoid leaking
-      // owner collection ids like `trash:<ownerId>` and avoid implying the viewer can organize it.
-      collectionId: isOwner ? toPublicTrashCollectionId(drawing.collectionId, drawing.userId) : null,
-      elements: parseJsonField(drawing.elements, []),
-      appState: parseJsonField(drawing.appState, {}),
-      files: parseJsonField(drawing.files, {}),
-      accessLevel: access,
-    });
-  }));
-
-  app.post("/drawings", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-
-    const isImportedDrawing = req.headers["x-imported-file"] === "true";
-    if (isImportedDrawing && !validateImportedDrawing(req.body)) {
-      return res.status(400).json({
-        error: "Invalid imported drawing file",
-        message: "The imported file contains potentially malicious content or invalid structure",
-      });
-    }
-
-    const parsed = drawingCreateSchema.safeParse(req.body);
-    if (!parsed.success) {
-      return respondWithValidationErrors(res, parsed.error.issues);
-    }
-
-    const payload = parsed.data as {
-      name?: string;
-      collectionId?: string | null;
-      elements: unknown[];
-      appState: Record<string, unknown>;
-      preview?: string | null;
-      files?: Record<string, unknown>;
-    };
-    const drawingName = payload.name ?? "Untitled Drawing";
-    const targetCollectionIdRaw = payload.collectionId === undefined ? null : payload.collectionId;
-    const targetCollectionId =
-      toInternalTrashCollectionId(targetCollectionIdRaw, req.user.id) ?? null;
-
-    if (targetCollectionId && !isTrashCollectionId(targetCollectionId, req.user.id)) {
-      const collection = await prisma.collection.findFirst({
-        where: { id: targetCollectionId, userId: req.user.id },
-      });
-      if (!collection) return res.status(404).json({ error: "Collection not found" });
-    } else if (targetCollectionIdRaw === "trash") {
-      await ensureTrashCollection(prisma, req.user.id);
-    }
-
-    const newDrawing = await prisma.drawing.create({
-      data: {
-        name: drawingName,
-        elements: JSON.stringify(payload.elements),
-        appState: JSON.stringify(payload.appState),
-        userId: req.user.id,
-        collectionId: targetCollectionId,
-        preview: payload.preview ?? null,
-        files: JSON.stringify(payload.files ?? {}),
-      },
-    });
-    invalidateDrawingsCache();
-
-    return res.json({
-      ...newDrawing,
-      collectionId: toPublicTrashCollectionId(newDrawing.collectionId, req.user.id),
-      elements: parseJsonField(newDrawing.elements, []),
-      appState: parseJsonField(newDrawing.appState, {}),
-      files: parseJsonField(newDrawing.files, {}),
-    });
-  }));
-
-  app.put("/drawings/:id", optionalAuth, asyncHandler(async (req, res) => {
-    const principal = await getRequestPrincipal(req);
-
-    const { id } = req.params;
-    const access = await getDrawingAccess({ prisma, principal, drawingId: id });
-    if (!canEditDrawing(access)) {
-      if (respondWithAuthErrorIfPresent(req, res)) return;
-      return res.status(404).json({ error: "Drawing not found" });
-    }
-
-    const existingDrawing = await prisma.drawing.findUnique({ where: { id } });
-    if (!existingDrawing) return res.status(404).json({ error: "Drawing not found" });
-
-    const parsed = drawingUpdateSchema.safeParse(req.body);
-    if (!parsed.success) {
-      if (config.nodeEnv === "development") {
-        console.error("[API] Validation failed", { id, errors: parsed.error.issues });
-      }
-      return respondWithValidationErrors(res, parsed.error.issues);
-    }
-
-    const payload = parsed.data as {
-      name?: string;
-      collectionId?: string | null;
-      elements?: unknown[];
-      appState?: Record<string, unknown>;
-      preview?: string | null;
-      files?: Record<string, unknown>;
-      version?: number;
-    };
-    const ownerUserId = existingDrawing.userId;
-    const trashCollectionId = getUserTrashCollectionId(ownerUserId);
-    const isSceneUpdate =
-      payload.elements !== undefined ||
-      payload.appState !== undefined ||
-      payload.files !== undefined;
-    const data: Prisma.DrawingUpdateInput = isSceneUpdate
-      ? { version: { increment: 1 } }
-      : {};
-
-    if (payload.name !== undefined) data.name = payload.name;
-    if (payload.elements !== undefined) data.elements = JSON.stringify(payload.elements);
-    if (payload.appState !== undefined) data.appState = JSON.stringify(payload.appState);
-    if (payload.files !== undefined) data.files = JSON.stringify(payload.files);
-    if (payload.preview !== undefined) data.preview = payload.preview;
-
-    if (payload.collectionId !== undefined) {
-      if (!isOwnerAccess(access)) {
-        return res.status(403).json({
-          error: "Forbidden",
-          message: "Only the owner can move drawings between collections",
-        });
-      }
-      if (payload.collectionId === "trash") {
-        await ensureTrashCollection(prisma, ownerUserId);
-        (data as Prisma.DrawingUncheckedUpdateInput).collectionId = trashCollectionId;
-      } else if (payload.collectionId) {
-        const collection = await prisma.collection.findFirst({
-          where: { id: payload.collectionId, userId: ownerUserId },
-        });
-        if (!collection) return res.status(404).json({ error: "Collection not found" });
-        (data as Prisma.DrawingUncheckedUpdateInput).collectionId = payload.collectionId;
+          creatorName: d.user?.name ?? null,
+          user: undefined,
+        }));
       } else {
-        (data as Prisma.DrawingUncheckedUpdateInput).collectionId = null;
+        responsePayload = (drawings as any[]).map((d: any) => ({
+          ...d,
+          collectionId: toPublicTrashCollectionId(d.collectionId, req.user!.id),
+          creatorName: d.user?.name ?? null,
+          user: undefined,
+        }));
       }
-    }
 
-    const updateWhere: Prisma.DrawingWhereInput = { id };
-    if (isSceneUpdate && payload.version !== undefined) {
-      updateWhere.version = payload.version;
-    }
+      const finalResponse = {
+        drawings: responsePayload,
+        totalCount,
+        limit: parsedLimit,
+        offset: parsedOffset,
+      };
 
-    const updateResult = await prisma.drawing.updateMany({
-      where: updateWhere,
-      data,
-    });
-    if (updateResult.count === 0) {
-      if (isSceneUpdate && payload.version !== undefined) {
-        const latestDrawing = await prisma.drawing.findFirst({
-          where: { id },
-          select: { version: true },
-        });
-        return res.status(409).json({
-          error: "Conflict",
-          code: "VERSION_CONFLICT",
-          message: "Drawing has changed since this editor state was loaded.",
-          currentVersion: latestDrawing?.version ?? null,
-        });
-      }
-      return res.status(404).json({ error: "Drawing not found" });
-    }
+      const body = cacheDrawingsResponse(cacheKey, finalResponse);
+      res.setHeader("X-Cache", "MISS");
+      res.setHeader("Content-Type", "application/json");
+      return res.send(body);
+    }),
+  );
 
-    const updatedDrawing = await prisma.drawing.findFirst({
-      where: { id },
-    });
-    if (!updatedDrawing) {
-      return res.status(404).json({ error: "Drawing not found" });
-    }
-    invalidateDrawingsCache();
+  // Shared with me list (does not mix into /drawings cache semantics)
+  // Must be registered before `/drawings/:id` so it doesn't get treated as a drawing id.
+  app.get(
+    "/drawings/shared",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
 
-    return res.json({
-      ...updatedDrawing,
-      collectionId: toPublicTrashCollectionId(updatedDrawing.collectionId, ownerUserId),
-      elements: parseJsonField(updatedDrawing.elements, []),
-      appState: parseJsonField(updatedDrawing.appState, {}),
-      files: parseJsonField(updatedDrawing.files, {}),
-      accessLevel: access,
-    });
-  }));
+      const { search, includeData, limit, offset, sortField, sortDirection } =
+        req.query;
+      const searchTerm =
+        typeof search === "string" && search.trim().length > 0
+          ? search.trim()
+          : undefined;
 
-  app.delete("/drawings/:id", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-    const { id } = req.params;
+      const shouldIncludeData =
+        typeof includeData === "string"
+          ? includeData.toLowerCase() === "true" || includeData === "1"
+          : false;
+      const parsedSortField: SortField =
+        sortField === "name" ||
+        sortField === "createdAt" ||
+        sortField === "updatedAt"
+          ? sortField
+          : "updatedAt";
+      const parsedSortDirection: SortDirection =
+        sortDirection === "asc" || sortDirection === "desc"
+          ? sortDirection
+          : parsedSortField === "name"
+            ? "asc"
+            : "desc";
 
-    const drawing = await prisma.drawing.findFirst({ where: { id, userId: req.user.id } });
-    if (!drawing) return res.status(404).json({ error: "Drawing not found" });
+      const rawLimit = limit ? Number.parseInt(limit as string, 10) : undefined;
+      const rawOffset = offset
+        ? Number.parseInt(offset as string, 10)
+        : undefined;
+      const parsedLimit =
+        rawLimit !== undefined && Number.isFinite(rawLimit)
+          ? Math.min(Math.max(rawLimit, 1), MAX_PAGE_SIZE)
+          : undefined;
+      const parsedOffset =
+        rawOffset !== undefined && Number.isFinite(rawOffset)
+          ? Math.max(rawOffset, 0)
+          : undefined;
 
-    const deleteResult = await prisma.drawing.deleteMany({
-      where: { id, userId: req.user.id },
-    });
-    if (deleteResult.count === 0) {
-      return res.status(404).json({ error: "Drawing not found" });
-    }
-    invalidateDrawingsCache();
+      const orderBy: Prisma.DrawingOrderByWithRelationInput =
+        parsedSortField === "name"
+          ? { name: parsedSortDirection }
+          : parsedSortField === "createdAt"
+            ? { createdAt: parsedSortDirection }
+            : { updatedAt: parsedSortDirection };
 
-    if (config.enableAuditLogging) {
-      await logAuditEvent({
-        userId: req.user.id,
-        action: "drawing_deleted",
-        resource: `drawing:${id}`,
-        ipAddress: req.ip || req.connection.remoteAddress || undefined,
-        userAgent: req.headers["user-agent"] || undefined,
-        details: { drawingId: id, drawingName: drawing.name },
+      // Get collection IDs shared with this user to exclude drawings already visible via collection sharing
+      const sharedCollectionIds = await prisma.collectionShare.findMany({
+        where: { granteeUserId: req.user.id },
+        select: { collectionId: true },
       });
-    }
+      const sharedColIds = sharedCollectionIds.map((s) => s.collectionId);
 
-    return res.json({ success: true });
-  }));
+      const whereDrawing: Prisma.DrawingWhereInput = {
+        // "Shared with me" should only include drawings owned by someone else.
+        // Some deployments keep an owner self-permission row for access control; exclude those.
+        userId: { not: req.user.id },
+        permissions: {
+          some: {
+            granteeUserId: req.user.id,
+          },
+        },
+        // Exclude drawings already accessible via a shared collection
+        ...(sharedColIds.length > 0 && {
+          NOT: {
+            collectionId: { in: sharedColIds },
+          },
+        }),
+      };
+      if (searchTerm) {
+        whereDrawing.name = { contains: searchTerm };
+      }
 
-  app.post("/drawings/:id/duplicate", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const summarySelect: Prisma.DrawingSelect = {
+        id: true,
+        name: true,
+        collectionId: true,
+        preview: true,
+        version: true,
+        createdAt: true,
+        updatedAt: true,
+        userId: true,
+        permissions: {
+          where: { granteeUserId: req.user.id },
+          select: { permission: true },
+        },
+      };
 
-    const { id } = req.params;
-    const original = await prisma.drawing.findFirst({ where: { id, userId: req.user.id } });
-    if (!original) return res.status(404).json({ error: "Original drawing not found" });
-    let duplicatedCollectionId = original.collectionId;
-    if (isTrashCollectionId(original.collectionId, req.user.id)) {
-      await ensureTrashCollection(prisma, req.user.id);
-      duplicatedCollectionId = getUserTrashCollectionId(req.user.id);
-    }
+      const queryOptions: Prisma.DrawingFindManyArgs = {
+        where: whereDrawing,
+        orderBy,
+      };
+      if (parsedLimit !== undefined) queryOptions.take = parsedLimit;
+      if (parsedOffset !== undefined) queryOptions.skip = parsedOffset;
+      if (!shouldIncludeData) queryOptions.select = summarySelect;
 
-    const newDrawing = await prisma.drawing.create({
-      data: {
-        name: `${original.name} (Copy)`,
-        elements: original.elements,
-        appState: original.appState,
-        files: original.files,
-        userId: req.user.id,
-        collectionId: duplicatedCollectionId,
-        version: 1,
-      },
-    });
-    invalidateDrawingsCache();
+      const [drawings, totalCount] = await Promise.all([
+        prisma.drawing.findMany(queryOptions),
+        prisma.drawing.count({ where: whereDrawing }),
+      ]);
 
-    return res.json({
-      ...newDrawing,
-      collectionId: toPublicTrashCollectionId(newDrawing.collectionId, req.user.id),
-      elements: parseJsonField(newDrawing.elements, []),
-      appState: parseJsonField(newDrawing.appState, {}),
-      files: parseJsonField(newDrawing.files, {}),
-    });
-  }));
+      const normalize = (d: any) => {
+        const rawPerm = Array.isArray(d?.permissions)
+          ? d.permissions[0]?.permission
+          : null;
+        const perm = normalizeDrawingPermission(rawPerm) ?? "view";
+        const { permissions: _permissions, ...rest } = d;
+        return {
+          ...rest,
+          // Collections are owner-scoped; don't leak the owner's collection ids to viewers.
+          collectionId: null,
+          accessLevel: perm,
+        };
+      };
+
+      let responsePayload: any[] = drawings as any[];
+      if (shouldIncludeData) {
+        responsePayload = (drawings as any[]).map((d: any) => {
+          const normalized = normalize(d);
+          return {
+            ...normalized,
+            elements: parseJsonField(d.elements, []),
+            appState: parseJsonField(d.appState, {}),
+            files: parseJsonField(d.files, {}),
+          };
+        });
+      } else {
+        responsePayload = (drawings as any[]).map((d: any) => normalize(d));
+      }
+
+      return res.json({
+        drawings: responsePayload,
+        totalCount,
+        limit: parsedLimit,
+        offset: parsedOffset,
+      });
+    }),
+  );
+
+  app.get(
+    "/drawings/:id",
+    optionalAuth,
+    asyncHandler(async (req, res) => {
+      const principal = await getRequestPrincipal(req);
+
+      const { id } = req.params;
+      const access = await getDrawingAccess({
+        prisma,
+        principal,
+        drawingId: id,
+      });
+      if (!canViewDrawing(access)) {
+        if (respondWithAuthErrorIfPresent(req, res)) return;
+        return res.status(404).json({
+          error: "Drawing not found",
+          message: "Drawing does not exist",
+        });
+      }
+
+      const drawing = await prisma.drawing.findUnique({ where: { id } });
+      if (!drawing) {
+        return res.status(404).json({
+          error: "Drawing not found",
+          message: "Drawing does not exist",
+        });
+      }
+
+      const isOwner =
+        principal?.kind === "user" && principal.userId === drawing.userId;
+      return res.json({
+        ...drawing,
+        // Collections (and trash mapping) are owner-scoped. For shared/public access, avoid leaking
+        // owner collection ids like `trash:<ownerId>` and avoid implying the viewer can organize it.
+        collectionId: isOwner
+          ? toPublicTrashCollectionId(drawing.collectionId, drawing.userId)
+          : null,
+        elements: parseJsonField(drawing.elements, []),
+        appState: parseJsonField(drawing.appState, {}),
+        files: parseJsonField(drawing.files, {}),
+        accessLevel: access,
+      });
+    }),
+  );
+
+  app.post(
+    "/drawings",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+
+      const isImportedDrawing = req.headers["x-imported-file"] === "true";
+      if (isImportedDrawing && !validateImportedDrawing(req.body)) {
+        return res.status(400).json({
+          error: "Invalid imported drawing file",
+          message:
+            "The imported file contains potentially malicious content or invalid structure",
+        });
+      }
+
+      const parsed = drawingCreateSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return respondWithValidationErrors(res, parsed.error.issues);
+      }
+
+      const payload = parsed.data as {
+        name?: string;
+        collectionId?: string | null;
+        elements: unknown[];
+        appState: Record<string, unknown>;
+        preview?: string | null;
+        files?: Record<string, unknown>;
+      };
+      const drawingName = payload.name ?? "Untitled Drawing";
+      const targetCollectionIdRaw =
+        payload.collectionId === undefined ? null : payload.collectionId;
+      const targetCollectionId =
+        toInternalTrashCollectionId(targetCollectionIdRaw, req.user.id) ?? null;
+
+      if (
+        targetCollectionId &&
+        !isTrashCollectionId(targetCollectionId, req.user.id)
+      ) {
+        const collection = await prisma.collection.findFirst({
+          where: { id: targetCollectionId },
+        });
+        if (!collection)
+          return res.status(404).json({ error: "Collection not found" });
+
+        // If the collection belongs to someone else, check the user has editor access
+        if (collection.userId !== req.user.id) {
+          const share = await prisma.collectionShare.findFirst({
+            where: {
+              collectionId: targetCollectionId,
+              granteeUserId: req.user.id,
+              role: "edit",
+            },
+          });
+          if (!share)
+            return res
+              .status(403)
+              .json({ error: "No edit access to this collection" });
+        }
+      } else if (targetCollectionIdRaw === "trash") {
+        await ensureTrashCollection(prisma, req.user.id);
+      }
+
+      const newDrawing = await prisma.drawing.create({
+        data: {
+          name: drawingName,
+          elements: JSON.stringify(payload.elements),
+          appState: JSON.stringify(payload.appState),
+          userId: req.user.id,
+          collectionId: targetCollectionId,
+          preview: payload.preview ?? null,
+          files: JSON.stringify(payload.files ?? {}),
+        },
+      });
+      invalidateDrawingsCache();
+
+      return res.json({
+        ...newDrawing,
+        collectionId: toPublicTrashCollectionId(
+          newDrawing.collectionId,
+          req.user.id,
+        ),
+        elements: parseJsonField(newDrawing.elements, []),
+        appState: parseJsonField(newDrawing.appState, {}),
+        files: parseJsonField(newDrawing.files, {}),
+      });
+    }),
+  );
+
+  app.put(
+    "/drawings/:id",
+    optionalAuth,
+    asyncHandler(async (req, res) => {
+      const principal = await getRequestPrincipal(req);
+
+      const { id } = req.params;
+      const access = await getDrawingAccess({
+        prisma,
+        principal,
+        drawingId: id,
+      });
+      if (!canEditDrawing(access)) {
+        if (respondWithAuthErrorIfPresent(req, res)) return;
+        return res.status(404).json({
+          error: "Drawing not found",
+          message: "Drawing does not exist",
+        });
+      }
+
+      const existingDrawing = await prisma.drawing.findUnique({
+        where: { id },
+      });
+      if (!existingDrawing)
+        return res.status(404).json({ error: "Drawing not found" });
+
+      const parsed = drawingUpdateSchema.safeParse(req.body);
+      if (!parsed.success) {
+        if (config.nodeEnv === "development") {
+          console.error("[API] Validation failed", {
+            id,
+            errors: parsed.error.issues,
+          });
+        }
+        return respondWithValidationErrors(res, parsed.error.issues);
+      }
+
+      const payload = parsed.data as {
+        name?: string;
+        collectionId?: string | null;
+        elements?: unknown[];
+        appState?: Record<string, unknown>;
+        preview?: string | null;
+        files?: Record<string, unknown>;
+        version?: number;
+      };
+      const ownerUserId = existingDrawing.userId;
+      const trashCollectionId = getUserTrashCollectionId(ownerUserId);
+      const isSceneUpdate =
+        payload.elements !== undefined ||
+        payload.appState !== undefined ||
+        payload.files !== undefined;
+      const data: Prisma.DrawingUpdateInput = isSceneUpdate
+        ? { version: { increment: 1 } }
+        : {};
+
+      if (payload.name !== undefined) data.name = payload.name;
+      if (payload.elements !== undefined)
+        data.elements = JSON.stringify(payload.elements);
+      if (payload.appState !== undefined)
+        data.appState = JSON.stringify(payload.appState);
+      if (payload.files !== undefined)
+        data.files = JSON.stringify(payload.files);
+      if (payload.preview !== undefined) data.preview = payload.preview;
+
+      if (payload.collectionId !== undefined) {
+        if (!isOwnerAccess(access)) {
+          return res.status(403).json({
+            error: "Forbidden",
+            message: "Only the owner can move drawings between collections",
+          });
+        }
+        if (payload.collectionId === "trash") {
+          await ensureTrashCollection(prisma, ownerUserId);
+          (data as Prisma.DrawingUncheckedUpdateInput).collectionId =
+            trashCollectionId;
+        } else if (payload.collectionId) {
+          const collection = await prisma.collection.findFirst({
+            where: { id: payload.collectionId, userId: ownerUserId },
+          });
+          if (!collection)
+            return res.status(404).json({ error: "Collection not found" });
+          (data as Prisma.DrawingUncheckedUpdateInput).collectionId =
+            payload.collectionId;
+        } else {
+          (data as Prisma.DrawingUncheckedUpdateInput).collectionId = null;
+        }
+      }
+
+      const updateWhere: Prisma.DrawingWhereInput = { id };
+      if (isSceneUpdate && payload.version !== undefined) {
+        updateWhere.version = payload.version;
+      }
+
+      const updateResult = await prisma.drawing.updateMany({
+        where: updateWhere,
+        data,
+      });
+      if (updateResult.count === 0) {
+        if (isSceneUpdate && payload.version !== undefined) {
+          const latestDrawing = await prisma.drawing.findFirst({
+            where: { id },
+            select: { version: true },
+          });
+          return res.status(409).json({
+            error: "Conflict",
+            code: "VERSION_CONFLICT",
+            message: "Drawing has changed since this editor state was loaded.",
+            currentVersion: latestDrawing?.version ?? null,
+          });
+        }
+        return res.status(404).json({ error: "Drawing not found" });
+      }
+
+      const updatedDrawing = await prisma.drawing.findFirst({
+        where: { id },
+      });
+      if (!updatedDrawing) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
+      invalidateDrawingsCache();
+
+      return res.json({
+        ...updatedDrawing,
+        collectionId: toPublicTrashCollectionId(
+          updatedDrawing.collectionId,
+          ownerUserId,
+        ),
+        elements: parseJsonField(updatedDrawing.elements, []),
+        appState: parseJsonField(updatedDrawing.appState, {}),
+        files: parseJsonField(updatedDrawing.files, {}),
+        accessLevel: access,
+      });
+    }),
+  );
+
+  app.delete(
+    "/drawings/:id",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const { id } = req.params;
+
+      const drawing = await prisma.drawing.findFirst({
+        where: { id, userId: req.user.id },
+      });
+      if (!drawing) return res.status(404).json({ error: "Drawing not found" });
+
+      const deleteResult = await prisma.drawing.deleteMany({
+        where: { id, userId: req.user.id },
+      });
+      if (deleteResult.count === 0) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
+      invalidateDrawingsCache();
+
+      if (config.enableAuditLogging) {
+        await logAuditEvent({
+          userId: req.user.id,
+          action: "drawing_deleted",
+          resource: `drawing:${id}`,
+          ipAddress: req.ip || req.connection.remoteAddress || undefined,
+          userAgent: req.headers["user-agent"] || undefined,
+          details: { drawingId: id, drawingName: drawing.name },
+        });
+      }
+
+      return res.json({ success: true });
+    }),
+  );
+
+  app.post(
+    "/drawings/:id/duplicate",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+
+      const { id } = req.params;
+      const original = await prisma.drawing.findFirst({
+        where: { id, userId: req.user.id },
+      });
+      if (!original)
+        return res.status(404).json({ error: "Original drawing not found" });
+      let duplicatedCollectionId = original.collectionId;
+      if (isTrashCollectionId(original.collectionId, req.user.id)) {
+        await ensureTrashCollection(prisma, req.user.id);
+        duplicatedCollectionId = getUserTrashCollectionId(req.user.id);
+      }
+
+      const newDrawing = await prisma.drawing.create({
+        data: {
+          name: `${original.name} (Copy)`,
+          elements: original.elements,
+          appState: original.appState,
+          files: original.files,
+          userId: req.user.id,
+          collectionId: duplicatedCollectionId,
+          version: 1,
+        },
+      });
+      invalidateDrawingsCache();
+
+      return res.json({
+        ...newDrawing,
+        collectionId: toPublicTrashCollectionId(
+          newDrawing.collectionId,
+          req.user.id,
+        ),
+        elements: parseJsonField(newDrawing.elements, []),
+        appState: parseJsonField(newDrawing.appState, {}),
+        files: parseJsonField(newDrawing.files, {}),
+      });
+    }),
+  );
 
   // Owner-only: resolve users by name/email in the context of a drawing you own (reduces enumeration risk).
-  app.get("/drawings/:id/share-resolve", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+  app.get(
+    "/drawings/:id/share-resolve",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
 
-    const { id } = req.params;
-    const qRaw = typeof req.query.q === "string" ? req.query.q.trim() : "";
-    const q = qRaw.toLowerCase();
-    if (q.length < 3) return res.json({ users: [] });
+      const { id } = req.params;
+      const qRaw = typeof req.query.q === "string" ? req.query.q.trim() : "";
+      const q = qRaw.toLowerCase();
+      if (q.length < 3) return res.json({ users: [] });
 
-    const drawing = await prisma.drawing.findUnique({ where: { id }, select: { userId: true } });
-    if (!drawing || drawing.userId !== req.user.id) {
-      return res.status(404).json({ error: "Drawing not found" });
-    }
+      const drawing = await prisma.drawing.findUnique({
+        where: { id },
+        select: { userId: true },
+      });
+      if (!drawing || drawing.userId !== req.user.id) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
 
-    const users = await prisma.user.findMany({
-      where: {
-        isActive: true,
-        id: { not: req.user.id },
-        OR: [
-          { email: { contains: q } },
-          { name: { contains: q } },
-          { username: { contains: q } },
-        ],
-      },
-      select: { id: true, name: true, email: true },
-      take: 10,
-    });
+      const users = await prisma.user.findMany({
+        where: {
+          isActive: true,
+          id: { not: req.user.id },
+          OR: [
+            { email: { contains: q } },
+            { name: { contains: q } },
+            { username: { contains: q } },
+          ],
+        },
+        select: { id: true, name: true, email: true },
+        take: 10,
+      });
 
-    return res.json({ users });
-  }));
+      return res.json({ users });
+    }),
+  );
 
-  app.get("/drawings/:id/sharing", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-    const { id } = req.params;
+  app.get(
+    "/drawings/:id/sharing",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const { id } = req.params;
 
-    const drawing = await prisma.drawing.findUnique({ where: { id }, select: { userId: true } });
-    if (!drawing || drawing.userId !== req.user.id) {
-      return res.status(404).json({ error: "Drawing not found" });
-    }
+      const drawing = await prisma.drawing.findUnique({
+        where: { id },
+        select: { userId: true },
+      });
+      if (!drawing || drawing.userId !== req.user.id) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
 
-    const [permissions, linkShares] = await Promise.all([
-      prisma.drawingPermission.findMany({
-        where: { drawingId: id },
+      const [permissions, linkShares] = await Promise.all([
+        prisma.drawingPermission.findMany({
+          where: { drawingId: id },
+          select: {
+            id: true,
+            granteeUserId: true,
+            permission: true,
+            createdAt: true,
+            updatedAt: true,
+            granteeUser: { select: { id: true, name: true, email: true } },
+          },
+          orderBy: { createdAt: "desc" },
+        }),
+        prisma.drawingLinkShare.findMany({
+          where: { drawingId: id },
+          select: {
+            id: true,
+            permission: true,
+            expiresAt: true,
+            revokedAt: true,
+            createdAt: true,
+            updatedAt: true,
+            lastUsedAt: true,
+          },
+          orderBy: { createdAt: "desc" },
+        }),
+      ]);
+
+      return res.json({ permissions, linkShares });
+    }),
+  );
+
+  app.post(
+    "/drawings/:id/permissions",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const { id } = req.params;
+
+      const drawing = await prisma.drawing.findUnique({
+        where: { id },
+        select: { userId: true },
+      });
+      if (!drawing || drawing.userId !== req.user.id) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
+
+      const granteeUserId =
+        typeof req.body?.granteeUserId === "string"
+          ? req.body.granteeUserId
+          : null;
+      const permission = normalizeDrawingPermission(req.body?.permission);
+      if (!granteeUserId || !permission) {
+        return res.status(400).json({
+          error: "Validation error",
+          message: "Invalid grantee or permission",
+        });
+      }
+      if (granteeUserId === req.user.id) {
+        return res.status(400).json({
+          error: "Validation error",
+          message: "Cannot share with yourself",
+        });
+      }
+
+      const user = await prisma.user.findUnique({
+        where: { id: granteeUserId },
+        select: { id: true, isActive: true },
+      });
+      if (!user || !user.isActive) {
+        return res.status(404).json({ error: "User not found" });
+      }
+
+      const saved = await prisma.drawingPermission.upsert({
+        where: {
+          drawingId_granteeUserId: { drawingId: id, granteeUserId },
+        },
+        update: { permission, createdByUserId: req.user.id },
+        create: {
+          drawingId: id,
+          granteeUserId,
+          permission,
+          createdByUserId: req.user.id,
+        },
         select: {
           id: true,
           granteeUserId: true,
@@ -644,221 +900,198 @@ export const registerDrawingRoutes = (
           updatedAt: true,
           granteeUser: { select: { id: true, name: true, email: true } },
         },
-        orderBy: { createdAt: "desc" },
-      }),
-      prisma.drawingLinkShare.findMany({
-        where: { drawingId: id },
+      });
+
+      invalidateDrawingsCache();
+
+      if (config.enableAuditLogging) {
+        await logAuditEvent({
+          userId: req.user.id,
+          action: "drawing_shared_user_upsert",
+          resource: `drawing:${id}`,
+          ipAddress: req.ip || req.connection.remoteAddress || undefined,
+          userAgent: req.headers["user-agent"] || undefined,
+          details: { drawingId: id, granteeUserId, permission },
+        });
+      }
+
+      return res.json({ permission: saved });
+    }),
+  );
+
+  app.delete(
+    "/drawings/:id/permissions/:permId",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const { id, permId } = req.params;
+
+      const drawing = await prisma.drawing.findUnique({
+        where: { id },
+        select: { userId: true },
+      });
+      if (!drawing || drawing.userId !== req.user.id) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
+
+      await prisma.drawingPermission.deleteMany({
+        where: { id: permId, drawingId: id },
+      });
+      invalidateDrawingsCache();
+
+      if (config.enableAuditLogging) {
+        await logAuditEvent({
+          userId: req.user.id,
+          action: "drawing_shared_user_revoke",
+          resource: `drawing:${id}`,
+          ipAddress: req.ip || req.connection.remoteAddress || undefined,
+          userAgent: req.headers["user-agent"] || undefined,
+          details: { drawingId: id, permissionId: permId },
+        });
+      }
+
+      return res.json({ success: true });
+    }),
+  );
+
+  app.post(
+    "/drawings/:id/link-shares",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const { id } = req.params;
+
+      const drawing = await prisma.drawing.findUnique({
+        where: { id },
+        select: { userId: true },
+      });
+      if (!drawing || drawing.userId !== req.user.id) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
+
+      const permission = normalizeDrawingPermission(req.body?.permission);
+      if (!permission) {
+        return res
+          .status(400)
+          .json({ error: "Validation error", message: "Invalid permission" });
+      }
+
+      const rawExpiresAt =
+        typeof req.body?.expiresAt === "string" ? req.body.expiresAt : null;
+      const expiresAtText = (rawExpiresAt || "").trim();
+      const requestedExpiresAt =
+        expiresAtText.length > 0 ? new Date(expiresAtText) : null;
+      const hasValidRequestedExpiry = Boolean(
+        requestedExpiresAt && Number.isFinite(requestedExpiresAt.getTime()),
+      );
+
+      const now = Date.now();
+      const maxTtlMs = resolveMaxTtlMs();
+      const defaultTtlMs = resolveDefaultTtlMs(permission);
+
+      let expiresAt: Date | null = null;
+      // View links can be truly non-expiring unless an explicit expiry is provided.
+      // Edit links default to an expiry window when none is provided.
+      if (
+        permission === "view" &&
+        !hasValidRequestedExpiry &&
+        expiresAtText.length === 0
+      ) {
+        expiresAt = null;
+      } else {
+        const candidateTtlMs =
+          hasValidRequestedExpiry && requestedExpiresAt
+            ? requestedExpiresAt.getTime() - now
+            : defaultTtlMs;
+        const ttlMs = Math.min(Math.max(candidateTtlMs, 60_000), maxTtlMs);
+        expiresAt = new Date(now + ttlMs);
+      }
+
+      // Passphrase support is currently disabled. We keep passphraseHash nullable for backwards compatibility.
+      const passphraseHashValue: string | null = null;
+
+      // Enforce a single active "anyone with the link" policy per drawing. The public link is the drawing id,
+      // so multiple active link-share rows would be confusing and could unintentionally widen access.
+      await prisma.drawingLinkShare.updateMany({
+        where: { drawingId: id, revokedAt: null },
+        data: { revokedAt: new Date() },
+      });
+
+      // Token is generated only to satisfy the current schema's tokenHash requirement.
+      // Link access is based on drawing id + active policy (no secret token in the URL).
+      const tokenHash = hashShareLinkToken(buildShareLinkToken());
+
+      const created = await prisma.drawingLinkShare.create({
+        data: {
+          drawingId: id,
+          permission,
+          tokenHash,
+          passphraseHash: passphraseHashValue,
+          expiresAt,
+          createdByUserId: req.user.id,
+        },
         select: {
           id: true,
           permission: true,
           expiresAt: true,
           revokedAt: true,
           createdAt: true,
-          updatedAt: true,
-          lastUsedAt: true,
         },
-        orderBy: { createdAt: "desc" },
-      }),
-    ]);
-
-    return res.json({ permissions, linkShares });
-  }));
-
-  app.post("/drawings/:id/permissions", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-    const { id } = req.params;
-
-    const drawing = await prisma.drawing.findUnique({ where: { id }, select: { userId: true } });
-    if (!drawing || drawing.userId !== req.user.id) {
-      return res.status(404).json({ error: "Drawing not found" });
-    }
-
-    const granteeUserId = typeof req.body?.granteeUserId === "string" ? req.body.granteeUserId : null;
-    const permission = normalizeDrawingPermission(req.body?.permission);
-    if (!granteeUserId || !permission) {
-      return res.status(400).json({ error: "Validation error", message: "Invalid grantee or permission" });
-    }
-    if (granteeUserId === req.user.id) {
-      return res.status(400).json({ error: "Validation error", message: "Cannot share with yourself" });
-    }
-
-    const user = await prisma.user.findUnique({
-      where: { id: granteeUserId },
-      select: { id: true, isActive: true },
-    });
-    if (!user || !user.isActive) {
-      return res.status(404).json({ error: "User not found" });
-    }
-
-    const saved = await prisma.drawingPermission.upsert({
-      where: {
-        drawingId_granteeUserId: { drawingId: id, granteeUserId },
-      },
-      update: { permission, createdByUserId: req.user.id },
-      create: { drawingId: id, granteeUserId, permission, createdByUserId: req.user.id },
-      select: {
-        id: true,
-        granteeUserId: true,
-        permission: true,
-        createdAt: true,
-        updatedAt: true,
-        granteeUser: { select: { id: true, name: true, email: true } },
-      },
-    });
-
-    invalidateDrawingsCache();
-
-    if (config.enableAuditLogging) {
-      await logAuditEvent({
-        userId: req.user.id,
-        action: "drawing_shared_user_upsert",
-        resource: `drawing:${id}`,
-        ipAddress: req.ip || req.connection.remoteAddress || undefined,
-        userAgent: req.headers["user-agent"] || undefined,
-        details: { drawingId: id, granteeUserId, permission },
       });
-    }
 
-    return res.json({ permission: saved });
-  }));
+      if (config.enableAuditLogging) {
+        await logAuditEvent({
+          userId: req.user.id,
+          action: "drawing_link_share_created",
+          resource: `drawing:${id}`,
+          ipAddress: req.ip || req.connection.remoteAddress || undefined,
+          userAgent: req.headers["user-agent"] || undefined,
+          details: {
+            drawingId: id,
+            permission,
+            expiresAt: expiresAt ? expiresAt.toISOString() : null,
+          },
+        });
+      }
 
-  app.delete("/drawings/:id/permissions/:permId", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-    const { id, permId } = req.params;
+      return res.json({ share: created });
+    }),
+  );
 
-    const drawing = await prisma.drawing.findUnique({ where: { id }, select: { userId: true } });
-    if (!drawing || drawing.userId !== req.user.id) {
-      return res.status(404).json({ error: "Drawing not found" });
-    }
+  app.delete(
+    "/drawings/:id/link-shares/:shareId",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+      const { id, shareId } = req.params;
 
-    await prisma.drawingPermission.deleteMany({
-      where: { id: permId, drawingId: id },
-    });
-    invalidateDrawingsCache();
-
-    if (config.enableAuditLogging) {
-      await logAuditEvent({
-        userId: req.user.id,
-        action: "drawing_shared_user_revoke",
-        resource: `drawing:${id}`,
-        ipAddress: req.ip || req.connection.remoteAddress || undefined,
-        userAgent: req.headers["user-agent"] || undefined,
-        details: { drawingId: id, permissionId: permId },
+      const drawing = await prisma.drawing.findUnique({
+        where: { id },
+        select: { userId: true },
       });
-    }
+      if (!drawing || drawing.userId !== req.user.id) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
 
-    return res.json({ success: true });
-  }));
-
-  app.post("/drawings/:id/link-shares", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-    const { id } = req.params;
-
-    const drawing = await prisma.drawing.findUnique({ where: { id }, select: { userId: true } });
-    if (!drawing || drawing.userId !== req.user.id) {
-      return res.status(404).json({ error: "Drawing not found" });
-    }
-
-    const permission = normalizeDrawingPermission(req.body?.permission);
-    if (!permission) {
-      return res.status(400).json({ error: "Validation error", message: "Invalid permission" });
-    }
-
-    const rawExpiresAt = typeof req.body?.expiresAt === "string" ? req.body.expiresAt : null;
-    const expiresAtText = (rawExpiresAt || "").trim();
-    const requestedExpiresAt = expiresAtText.length > 0 ? new Date(expiresAtText) : null;
-    const hasValidRequestedExpiry = Boolean(requestedExpiresAt && Number.isFinite(requestedExpiresAt.getTime()));
-
-    const now = Date.now();
-    const maxTtlMs = resolveMaxTtlMs();
-    const defaultTtlMs = resolveDefaultTtlMs(permission);
-
-    let expiresAt: Date | null = null;
-    // View links can be truly non-expiring unless an explicit expiry is provided.
-    // Edit links default to an expiry window when none is provided.
-    if (permission === "view" && !hasValidRequestedExpiry && expiresAtText.length === 0) {
-      expiresAt = null;
-    } else {
-      const candidateTtlMs = hasValidRequestedExpiry && requestedExpiresAt
-        ? requestedExpiresAt.getTime() - now
-        : defaultTtlMs;
-      const ttlMs = Math.min(Math.max(candidateTtlMs, 60_000), maxTtlMs);
-      expiresAt = new Date(now + ttlMs);
-    }
-
-    // Passphrase support is currently disabled. We keep passphraseHash nullable for backwards compatibility.
-    const passphraseHashValue: string | null = null;
-
-    // Enforce a single active "anyone with the link" policy per drawing. The public link is the drawing id,
-    // so multiple active link-share rows would be confusing and could unintentionally widen access.
-    await prisma.drawingLinkShare.updateMany({
-      where: { drawingId: id, revokedAt: null },
-      data: { revokedAt: new Date() },
-    });
-
-    // Token is generated only to satisfy the current schema's tokenHash requirement.
-    // Link access is based on drawing id + active policy (no secret token in the URL).
-    const tokenHash = hashShareLinkToken(buildShareLinkToken());
-
-    const created = await prisma.drawingLinkShare.create({
-      data: {
-        drawingId: id,
-        permission,
-        tokenHash,
-        passphraseHash: passphraseHashValue,
-        expiresAt,
-        createdByUserId: req.user.id,
-      },
-      select: {
-        id: true,
-        permission: true,
-        expiresAt: true,
-        revokedAt: true,
-        createdAt: true,
-      },
-    });
-
-    if (config.enableAuditLogging) {
-      await logAuditEvent({
-        userId: req.user.id,
-        action: "drawing_link_share_created",
-        resource: `drawing:${id}`,
-        ipAddress: req.ip || req.connection.remoteAddress || undefined,
-        userAgent: req.headers["user-agent"] || undefined,
-        details: { drawingId: id, permission, expiresAt: expiresAt ? expiresAt.toISOString() : null },
+      await prisma.drawingLinkShare.updateMany({
+        where: { id: shareId, drawingId: id, revokedAt: null },
+        data: { revokedAt: new Date() },
       });
-    }
 
-    return res.json({ share: created });
-  }));
+      if (config.enableAuditLogging) {
+        await logAuditEvent({
+          userId: req.user.id,
+          action: "drawing_link_share_revoked",
+          resource: `drawing:${id}`,
+          ipAddress: req.ip || req.connection.remoteAddress || undefined,
+          userAgent: req.headers["user-agent"] || undefined,
+          details: { drawingId: id, shareId },
+        });
+      }
 
-  app.delete("/drawings/:id/link-shares/:shareId", requireAuth, asyncHandler(async (req, res) => {
-    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
-    const { id, shareId } = req.params;
-
-    const drawing = await prisma.drawing.findUnique({ where: { id }, select: { userId: true } });
-    if (!drawing || drawing.userId !== req.user.id) {
-      return res.status(404).json({ error: "Drawing not found" });
-    }
-
-    await prisma.drawingLinkShare.updateMany({
-      where: { id: shareId, drawingId: id, revokedAt: null },
-      data: { revokedAt: new Date() },
-    });
-
-    if (config.enableAuditLogging) {
-      await logAuditEvent({
-        userId: req.user.id,
-        action: "drawing_link_share_revoked",
-        resource: `drawing:${id}`,
-        ipAddress: req.ip || req.connection.remoteAddress || undefined,
-        userAgent: req.headers["user-agent"] || undefined,
-        details: { drawingId: id, shareId },
-      });
-    }
-
-    return res.json({ success: true });
-  }));
+      return res.json({ success: true });
+    }),
+  );
 
   // Legacy share-token exchange endpoint removed: link access is based on drawing id + active policy.
 };

--- a/backend/src/routes/dashboard/drawings.ts
+++ b/backend/src/routes/dashboard/drawings.ts
@@ -20,7 +20,7 @@ import {
 
 export const registerDrawingRoutes = (
   app: express.Express,
-  deps: DashboardRouteDeps,,
+  deps: DashboardRouteDeps,
 ) => {
   const {
     prisma,
@@ -629,10 +629,10 @@ export const registerDrawingRoutes = (
         }
       }
 
-        const updateWhere: Prisma.DrawingWhereInput = { id };
-        if (isSceneUpdate && payload.version !== undefined) {
-          updateWhere.version = payload.version;
-        }
+      const updateWhere: Prisma.DrawingWhereInput = { id };
+      if (isSceneUpdate && payload.version !== undefined) {
+        updateWhere.version = payload.version;
+      }
 
       const versionConflictError = new Error("VERSION_CONFLICT");
       let updatedDrawing: typeof existingDrawing | null = null;
@@ -661,12 +661,12 @@ export const registerDrawingRoutes = (
             return tx.drawing.findFirst({ where: { id } });
           });
         } else {
-            const updateResult = await prisma.drawing.updateMany({
-              where: updateWhere,
-              data,
-            });
-            if (updateResult.count === 0) {
-              return res.status(404).json({ error: "Drawing not found" });
+          const updateResult = await prisma.drawing.updateMany({
+            where: updateWhere,
+            data,
+          });
+          if (updateResult.count === 0) {
+            return res.status(404).json({ error: "Drawing not found" });
           }
           updatedDrawing = await prisma.drawing.findFirst({
             where: { id },
@@ -678,26 +678,26 @@ export const registerDrawingRoutes = (
           (error instanceof Error &&
             error.message === versionConflictError.message)
         ) {
-            const latestDrawing = await prisma.drawing.findFirst({
-              where: { id },
-              select: { version: true },
-            });
+          const latestDrawing = await prisma.drawing.findFirst({
+            where: { id },
+            select: { version: true },
+          });
           if (isSceneUpdate && payload.version !== undefined) {
-              return res.status(409).json({
-                error: "Conflict",
-                code: "VERSION_CONFLICT",
-                message:
+            return res.status(409).json({
+              error: "Conflict",
+              code: "VERSION_CONFLICT",
+              message:
                 "Drawing has changed since this editor state was loaded.",
-                currentVersion: latestDrawing?.version ?? null,
-              });
-            }
+              currentVersion: latestDrawing?.version ?? null,
+            });
           }
-            throw error;
-          }
-        if (!updatedDrawing) {
-          return res.status(404).json({ error: "Drawing not found" });
         }
-        invalidateDrawingsCache();
+        throw error;
+      }
+      if (!updatedDrawing) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
+      invalidateDrawingsCache();
 
       return res.json({
         ...updatedDrawing,


### PR DESCRIPTION
PR request for the feature of collection sharing for backend changes only
This pull request introduces support for sharing collections with other users, including view and edit roles, and adds comprehensive integration tests for collection sharing. It also adds the new `CollectionShare` model to the Prisma schema and migration files, updates relationships in existing models, and makes minor code formatting improvements.

**Collection Sharing Feature:**

* Added a new `CollectionShare` model and corresponding database migration to support sharing collections with users, including fields for `role`, `createdByUserId`, and unique constraints. [[1]](diffhunk://#diff-e6ff872913d724778dfc0faaec3894ecb5fe93c848f53f7f9de6fd9ec16208afR1-R21) [[2]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR135-R153)
* Updated the `User` and `Collection` models to include relations to `CollectionShare`, enabling tracking of shares for both collections and users. [[1]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR25) [[2]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR56)

**Integration Tests:**

* Added a comprehensive integration test suite (`collection-sharing.integration.ts`) to verify collection sharing, access control for view/edit roles, revocation of access, and behavior when collections are deleted.

**Schema and Code Cleanups:**

* Removed inline comments from Prisma schema fields and normalized field formatting for consistency. [[1]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfL64-R69) [[2]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfL103-R105) [[3]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfL117-R119) [[4]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfL164-R186)
* Applied code formatting improvements in `sharing.ts` for readability, including consistent parameter formatting and line breaks. [[1]](diffhunk://#diff-6a80d226a11115779f7c7fbab368ecf2c640954d135c08a1097a0ec3f6b7f61cL10-R21) [[2]](diffhunk://#diff-6a80d226a11115779f7c7fbab368ecf2c640954d135c08a1097a0ec3f6b7f61cL42-R46) [[3]](diffhunk://#diff-6a80d226a11115779f7c7fbab368ecf2c640954d135c08a1097a0ec3f6b7f61cL57-R61) [[4]](diffhunk://#diff-6a80d226a11115779f7c7fbab368ecf2c640954d135c08a1097a0ec3f6b7f61cL96-R111)