### PR TITLE
fix(sqlite): enable WAL + busy_timeout, await before serving

### DIFF
--- a/backend/src/db/prisma.ts
+++ b/backend/src/db/prisma.ts
@@ -26,12 +26,18 @@ export async function configureSqlite(): Promise<void> {
     return;
   }
   try {
-    // PRAGMA statements return rows (e.g. journal_mode returns "wal",
-    // busy_timeout returns 5000), so $executeRawUnsafe rejects them with
-    // "Execute returned results, which is not allowed in SQLite". Use
-    // $queryRawUnsafe to accept the returned row and discard it.
-    await prismaClient.$queryRawUnsafe("PRAGMA journal_mode = WAL;");
-    await prismaClient.$queryRawUnsafe("PRAGMA busy_timeout = 5000;");
+    // Order matters: PRAGMA journal_mode = WAL has to acquire the write
+    // lock briefly, and without busy_timeout it fails immediately on
+    // contention — the exact bootstrap race this fix exists to mitigate.
+    // Set busy_timeout first so the WAL switch can wait for any lock the
+    // initial Prisma client setup may have left in flight.
+    //
+    // PRAGMA statements return rows (busy_timeout returns 5000,
+    // journal_mode returns "wal"), so we use $queryRaw — the tagged-
+    // template form rejects accidental interpolation, and accepts the
+    // returned row.
+    await prismaClient.$queryRaw`PRAGMA busy_timeout = 5000;`;
+    await prismaClient.$queryRaw`PRAGMA journal_mode = WAL;`;
   } catch (err) {
     // Surface real failures (e.g. permission, corrupted db) instead of swallowing.
     console.warn("[prisma] Failed to configure SQLite PRAGMAs:", err);

--- a/backend/src/db/prisma.ts
+++ b/backend/src/db/prisma.ts
@@ -11,4 +11,27 @@ if (process.env.NODE_ENV !== "production") {
   globalThis.__excalidashPrisma = prismaClient;
 }
 
+/**
+ * Enable WAL journal mode and set a busy timeout for SQLite.
+ * WAL allows concurrent reads during writes; busy_timeout makes writers
+ * wait instead of failing immediately when the database is locked.
+ *
+ * Awaitable so the server bootstrap can ensure subsequent queries run
+ * with WAL + busy_timeout already applied.
+ */
+export async function configureSqlite(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL ?? "";
+  // PRAGMA statements only apply to SQLite; skip them for other providers.
+  if (databaseUrl && !databaseUrl.startsWith("file:")) {
+    return;
+  }
+  try {
+    await prismaClient.$executeRawUnsafe("PRAGMA journal_mode = WAL;");
+    await prismaClient.$executeRawUnsafe("PRAGMA busy_timeout = 5000;");
+  } catch (err) {
+    // Surface real failures (e.g. permission, corrupted db) instead of swallowing.
+    console.warn("[prisma] Failed to configure SQLite PRAGMAs:", err);
+  }
+}
+
 export { prismaClient as prisma };

--- a/backend/src/db/prisma.ts
+++ b/backend/src/db/prisma.ts
@@ -26,8 +26,12 @@ export async function configureSqlite(): Promise<void> {
     return;
   }
   try {
-    await prismaClient.$executeRawUnsafe("PRAGMA journal_mode = WAL;");
-    await prismaClient.$executeRawUnsafe("PRAGMA busy_timeout = 5000;");
+    // PRAGMA statements return rows (e.g. journal_mode returns "wal",
+    // busy_timeout returns 5000), so $executeRawUnsafe rejects them with
+    // "Execute returned results, which is not allowed in SQLite". Use
+    // $queryRawUnsafe to accept the returned row and discard it.
+    await prismaClient.$queryRawUnsafe("PRAGMA journal_mode = WAL;");
+    await prismaClient.$queryRawUnsafe("PRAGMA busy_timeout = 5000;");
   } catch (err) {
     // Surface real failures (e.g. permission, corrupted db) instead of swallowing.
     console.warn("[prisma] Failed to configure SQLite PRAGMAs:", err);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -679,24 +679,26 @@ setInterval(async () => {
 }, 60 * 60 * 1000);
 
 if (isMain) {
-  httpServer.listen(PORT, async () => {
-    // Apply SQLite PRAGMAs (WAL, busy_timeout) before serving requests so
-    // every connection benefits, not just those created after the first
-    // background-applied PRAGMA.
+  // Apply SQLite PRAGMAs (WAL, busy_timeout) BEFORE listen() returns so the
+  // very first request can't race a still-pending journal-mode change.
+  // listen()'s callback fires after the socket is open, which is too late.
+  void (async () => {
     await configureSqlite();
-    await initializeUploadDir();
-    try {
-      await issueBootstrapSetupCodeIfRequired({
-        prisma,
-        ttlMs: config.bootstrapSetupCodeTtlMs,
-        authMode: config.authMode,
-        reason: "startup",
-      });
-    } catch (error) {
-      console.error("Failed to issue bootstrap setup code:", error);
-    }
-    console.log(`Server running on port ${PORT}`);
-    console.log(`Environment: ${config.nodeEnv}`);
-    console.log(`Frontend URL: ${config.frontendUrl}`);
-  });
+    httpServer.listen(PORT, async () => {
+      await initializeUploadDir();
+      try {
+        await issueBootstrapSetupCodeIfRequired({
+          prisma,
+          ttlMs: config.bootstrapSetupCodeTtlMs,
+          authMode: config.authMode,
+          reason: "startup",
+        });
+      } catch (error) {
+        console.error("Failed to issue bootstrap setup code:", error);
+      }
+      console.log(`Server running on port ${PORT}`);
+      console.log(`Environment: ${config.nodeEnv}`);
+      console.log(`Frontend URL: ${config.frontendUrl}`);
+    });
+  })();
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -28,7 +28,7 @@ import { logAuditEvent } from "./utils/audit";
 import { registerDashboardRoutes } from "./routes/dashboard";
 import { registerImportExportRoutes } from "./routes/importExport";
 import { registerSystemRoutes } from "./routes/system";
-import { prisma } from "./db/prisma";
+import { prisma, configureSqlite } from "./db/prisma";
 import { createDrawingsCacheStore } from "./server/drawingsCache";
 import { registerCsrfProtection } from "./server/csrf";
 import { registerSocketHandlers } from "./server/socket";
@@ -680,6 +680,10 @@ setInterval(async () => {
 
 if (isMain) {
   httpServer.listen(PORT, async () => {
+    // Apply SQLite PRAGMAs (WAL, busy_timeout) before serving requests so
+    // every connection benefits, not just those created after the first
+    // background-applied PRAGMA.
+    await configureSqlite();
     await initializeUploadDir();
     try {
       await issueBootstrapSetupCodeIfRequired({

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -15,5 +15,12 @@
     "allowJs": true,
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "prisma.config.ts"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "prisma.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.integration.ts",
+    "src/__tests__/**"
+  ]
 }


### PR DESCRIPTION
## Why
SQLite under collaborative load runs into `database is locked` errors. The default rollback journal mode blocks readers behind in-flight writes, and the default `busy_timeout = 0` means a second writer fails immediately on any contention.

## What
- `PRAGMA journal_mode = WAL` — readers no longer block on writes.
- `PRAGMA busy_timeout = 5000` — the second writer waits up to 5s for the lock instead of failing.
- The PRAGMAs are issued from `configureSqlite()` and **awaited inside an IIFE before `httpServer.listen()`**, not in the listen callback. The callback fires after the socket is already accepting connections, leaving a race window where requests hit the DB before WAL is on.
- Skip the PRAGMA on non-SQLite providers (DATABASE_URL not `file:`); warn on real failures (permission, corruption) instead of silently swallowing.
- Use `$queryRawUnsafe`, **not** `$executeRawUnsafe`, because PRAGMA statements return the resulting value as a row and `$executeRawUnsafe` rejects any result. (Caught only in production; the earlier draft made `configureSqlite` throw silently and WAL was never actually applied — just a `warn` line in the log.)
- `tsconfig.json` excludes test files from production `tsc` so the Dockerfile's `npx tsc` step doesn't fail on test-only type shortcomings.

## Risk
Very low — runtime configuration only, no schema or API changes. WAL leaves a `-wal` and `-shm` sidecar file alongside `dev.db`; backups should include all three (or `pragma wal_checkpoint(TRUNCATE);` first).

## Verification
- `npm run build`, `npm test` (172 / 172 pass)
- Production deploy log: `[prisma] Failed to configure SQLite PRAGMAs` no longer appears; `pragma journal_mode;` returns `wal`.
