### PR TITLE
feat(storage): per-drawing storage management

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -42,6 +42,36 @@ CSRF_SECRET=change-this-secret-in-production
 # BOOTSTRAP_SETUP_CODE_TTL_MS=900000
 # BOOTSTRAP_SETUP_CODE_MAX_ATTEMPTS=10
 
+# ---------------------------------------------------------------------------
+# S3 / S3-Compatible Object Storage (optional)
+# ---------------------------------------------------------------------------
+# When S3_BUCKET is set, pasted/dropped images are uploaded directly from the
+# browser to S3, keeping ExcaliDash's server bandwidth and SQLite size small.
+# Compatible with AWS S3, Cloudflare R2, MinIO, Alibaba OSS, and any service
+# that supports presigned PUT URLs.
+#
+# Required to enable S3:
+# S3_BUCKET=my-excalidash-bucket
+# S3_REGION=us-east-1
+#
+# Optional credentials (omit to use IAM roles / instance metadata):
+# AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+# AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+#
+# Optional custom endpoint for S3-compatible services:
+# S3_ENDPOINT=https://s3.example.com
+#
+# Public-URL mode (recommended): set this to the bucket's public base URL or
+# CDN base URL so images are served directly without hitting ExcaliDash at all.
+# Without this, ExcaliDash acts as a proxy and signs download URLs on each request.
+# S3_PUBLIC_URL=https://my-excalidash-bucket.s3.amazonaws.com
+#
+# CORS: your S3 bucket must allow PUT requests from your FRONTEND_URL.
+# Example bucket CORS rule (JSON):
+#   [{ "AllowedOrigins": ["https://excalidash.example.com"],
+#      "AllowedMethods": ["PUT", "GET"],
+#      "AllowedHeaders": ["Content-Type"] }]
+
 # OIDC Configuration (required when AUTH_MODE=hybrid or AUTH_MODE=oidc_enforced)
 # OIDC_PROVIDER_NAME=Authentik
 # OIDC_ISSUER_URL=https://auth.example.com/application/o/excalidash/

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -45,10 +45,16 @@ CSRF_SECRET=change-this-secret-in-production
 # ---------------------------------------------------------------------------
 # S3 / S3-Compatible Object Storage (optional)
 # ---------------------------------------------------------------------------
-# When S3_BUCKET is set, pasted/dropped images are uploaded directly from the
-# browser to S3, keeping ExcaliDash's server bandwidth and SQLite size small.
-# Compatible with AWS S3, Cloudflare R2, MinIO, Alibaba OSS, and any service
-# that supports presigned PUT URLs.
+# When S3_BUCKET is set, ExcaliDash uploads image dataURLs to S3 on save
+# instead of embedding base64 in SQLite, keeping the database compact.
+# Compatible with AWS S3, Cloudflare R2, MinIO, Alibaba OSS, and any
+# S3-protocol service.
+#
+# Architecture: images are received as base64 from the frontend on save,
+# uploaded server-side, and the dataURL in Drawing.files is rewritten to
+# the resulting S3 (or /api/files/:drawingId/:fileId) URL before
+# persisting. No browser-direct upload, no presigned PUT URLs, no CORS
+# rules required on the bucket.
 #
 # Required to enable S3:
 # S3_BUCKET=my-excalidash-bucket
@@ -61,16 +67,22 @@ CSRF_SECRET=change-this-secret-in-production
 # Optional custom endpoint for S3-compatible services:
 # S3_ENDPOINT=https://s3.example.com
 #
-# Public-URL mode (recommended): set this to the bucket's public base URL or
-# CDN base URL so images are served directly without hitting ExcaliDash at all.
-# Without this, ExcaliDash acts as a proxy and signs download URLs on each request.
-# S3_PUBLIC_URL=https://my-excalidash-bucket.s3.amazonaws.com
+# Path-style addressing (default false: virtual-hosted-style URLs).
+# Set to true for MinIO. Leave false (or unset) for AWS S3 / Cloudflare
+# R2 / Alibaba OSS, which all use virtual-hosted-style URLs.
+# S3_FORCE_PATH_STYLE=false
 #
-# CORS: your S3 bucket must allow PUT requests from your FRONTEND_URL.
-# Example bucket CORS rule (JSON):
-#   [{ "AllowedOrigins": ["https://excalidash.example.com"],
-#      "AllowedMethods": ["PUT", "GET"],
-#      "AllowedHeaders": ["Content-Type"] }]
+# Object key prefix (default "excalidash"). Final key layout is
+# {prefix}/{userId}/{drawingId}/{fileId}.{ext}. Avoid '/' in the prefix
+# itself so the upgrade migration's drawingId extraction works.
+# S3_KEY_PREFIX=excalidash
+#
+# Public-URL mode (recommended): set to the bucket's public base URL
+# (or a CDN in front of it) so images are served directly without
+# hitting ExcaliDash. Without this, ExcaliDash redirects to a
+# short-lived presigned GET URL via /api/files/:drawingId/:fileId.
+# Both http:// and https:// are accepted (use http:// for local MinIO).
+# S3_PUBLIC_URL=https://my-excalidash-bucket.s3.amazonaws.com
 
 # OIDC Configuration (required when AUTH_MODE=hybrid or AUTH_MODE=oidc_enforced)
 # OIDC_PROVIDER_NAME=Authentik

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.5.0",
       "license": "ISC",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1026.0",
+        "@aws-sdk/s3-request-presigner": "^3.1026.0",
         "@prisma/client": "^5.22.0",
         "archiver": "^7.0.1",
         "bcrypt": "^6.0.0",
@@ -51,53 +53,44 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
-      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.1.1",
-        "@csstools/css-color-parser": "^4.0.2",
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.2.6"
+        "@csstools/css-tokenizer": "^4.0.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
-      "integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
       "license": "MIT",
       "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
         "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
         "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.7"
+        "is-potential-custom-element-name": "^1.0.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "license": "BlueOak-1.0.0",
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
       "engines": {
-        "node": "20 || >=22"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/nwsapi": {
@@ -105,6 +98,891 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "license": "MIT"
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1026.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1026.0.tgz",
+      "integrity": "sha512-tMP+s641FLSXdJazvYvuf38F7suWWv+wagTvShykPTffuFpBj5J9f7Rw0eKsauBcsjPSntiwBz9Gm0Tlh+cKfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/credential-provider-node": "^3.972.30",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.9",
+        "@aws-sdk/middleware-expect-continue": "^3.972.9",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.7",
+        "@aws-sdk/middleware-host-header": "^3.972.9",
+        "@aws-sdk/middleware-location-constraint": "^3.972.9",
+        "@aws-sdk/middleware-logger": "^3.972.9",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.28",
+        "@aws-sdk/middleware-ssec": "^3.972.9",
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/region-config-resolver": "^3.972.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.16",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@aws-sdk/util-user-agent-browser": "^3.972.9",
+        "@aws-sdk/util-user-agent-node": "^3.973.15",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/core": "^3.23.14",
+        "@smithy/eventstream-serde-browser": "^4.2.13",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.13",
+        "@smithy/eventstream-serde-node": "^4.2.13",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/hash-blob-browser": "^4.2.14",
+        "@smithy/hash-node": "^4.2.13",
+        "@smithy/hash-stream-node": "^4.2.13",
+        "@smithy/invalid-dependency": "^4.2.13",
+        "@smithy/md5-js": "^4.2.13",
+        "@smithy/middleware-content-length": "^4.2.13",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/middleware-retry": "^4.5.0",
+        "@smithy/middleware-serde": "^4.2.17",
+        "@smithy/middleware-stack": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.45",
+        "@smithy/util-defaults-mode-node": "^4.2.49",
+        "@smithy/util-endpoints": "^3.3.4",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-retry": "^4.3.0",
+        "@smithy/util-stream": "^4.5.22",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.15",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.973.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
+      "integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/xml-builder": "^3.972.17",
+        "@smithy/core": "^3.23.14",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/signature-v4": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.6.tgz",
+      "integrity": "sha512-NMbiqKdruhwwgI6nzBVe2jWMkXjaoQz2YOs3rFX+2F3gGyrJDkDPwMpV/RsTFeq2vAQ055wZNtOXFK4NYSkM8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.25.tgz",
+      "integrity": "sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.27.tgz",
+      "integrity": "sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-stream": "^4.5.22",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.29.tgz",
+      "integrity": "sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/credential-provider-env": "^3.972.25",
+        "@aws-sdk/credential-provider-http": "^3.972.27",
+        "@aws-sdk/credential-provider-login": "^3.972.29",
+        "@aws-sdk/credential-provider-process": "^3.972.25",
+        "@aws-sdk/credential-provider-sso": "^3.972.29",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/credential-provider-imds": "^4.2.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.29.tgz",
+      "integrity": "sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
+      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.25",
+        "@aws-sdk/credential-provider-http": "^3.972.27",
+        "@aws-sdk/credential-provider-ini": "^3.972.29",
+        "@aws-sdk/credential-provider-process": "^3.972.25",
+        "@aws-sdk/credential-provider-sso": "^3.972.29",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/credential-provider-imds": "^4.2.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.25.tgz",
+      "integrity": "sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.29.tgz",
+      "integrity": "sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/token-providers": "3.1026.0",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.29.tgz",
+      "integrity": "sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.9.tgz",
+      "integrity": "sha512-COToYKgquDyligbcAep7ygs48RK+mwe/IYprq4+TSrVFzNOYmzWvHf6werpnKV5VYpRiwdn+Wa5ZXkPqLVwcTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.9.tgz",
+      "integrity": "sha512-V/FNCjFxnh4VGu+HdSiW4Yg5GELihA1MIDSAdsEPvuayXBVmr0Jaa6jdLAZLH38KYXl/vVjri9DQJWnTAujHEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.7.tgz",
+      "integrity": "sha512-uU4/ch2CLHB8Phu1oTKnnQ4e8Ujqi49zEnQYBhWYT53zfFvtJCdGsaOoypBr8Fm/pmCBssRmGoIQ4sixgdLP9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/crc64-nvme": "^3.972.6",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-stream": "^4.5.22",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.9.tgz",
+      "integrity": "sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.9.tgz",
+      "integrity": "sha512-TyfOi2XNdOZpNKeTJwRUsVAGa+14nkyMb2VVGG+eDgcWG/ed6+NUo72N3hT6QJioxym80NSinErD+LBRF0Ir1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.9.tgz",
+      "integrity": "sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.10.tgz",
+      "integrity": "sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.28.tgz",
+      "integrity": "sha512-qJHcJQH9UNPUrnPlRtCozKjtqAaypQ5IgQxTNoPsVYIQeuwNIA8Rwt3NvGij1vCDYDfCmZaPLpnJEHlZXeFqmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.14",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/signature-v4": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-stream": "^4.5.22",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.9.tgz",
+      "integrity": "sha512-wSA2BR7L0CyBNDJeSrleIIzC+DzL93YNTdfU0KPGLiocK6YsRv1nPAzPF+BFSdcs0Qa5ku5Kcf4KvQcWwKGenQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.29.tgz",
+      "integrity": "sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@smithy/core": "^3.23.14",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-retry": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.19.tgz",
+      "integrity": "sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/middleware-host-header": "^3.972.9",
+        "@aws-sdk/middleware-logger": "^3.972.9",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/region-config-resolver": "^3.972.11",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@aws-sdk/util-user-agent-browser": "^3.972.9",
+        "@aws-sdk/util-user-agent-node": "^3.973.15",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/core": "^3.23.14",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/hash-node": "^4.2.13",
+        "@smithy/invalid-dependency": "^4.2.13",
+        "@smithy/middleware-content-length": "^4.2.13",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/middleware-retry": "^4.5.0",
+        "@smithy/middleware-serde": "^4.2.17",
+        "@smithy/middleware-stack": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.45",
+        "@smithy/util-defaults-mode-node": "^4.2.49",
+        "@smithy/util-endpoints": "^3.3.4",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-retry": "^4.3.0",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.11.tgz",
+      "integrity": "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1026.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1026.0.tgz",
+      "integrity": "sha512-PBVt/zb4YsJMcyB/HbGmID4RP00dTkdQGkNQiw1i6oXQ/U8hnPEI8+IvTKR4+5YEQ8Cq4QmtIV0mzv070L+oOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "^3.996.16",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-format-url": "^3.972.9",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.16.tgz",
+      "integrity": "sha512-EMdXYB4r/k5RWq86fugjRhid5JA+Z6MpS7n4sij4u5/C+STrkvuf9aFu41rJA9MjUzxCLzv8U2XL8cH2GSRYpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.28",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/signature-v4": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1026.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz",
+      "integrity": "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
+      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.6.tgz",
+      "integrity": "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-endpoints": "^3.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.9.tgz",
+      "integrity": "sha512-fNJXHrs0ZT7Wx0KGIqKv7zLxlDXt2vqjx9z6oKUQFmpE5o4xxnSryvVHfHpIifYHWKz94hFccIldJ0YSZjlCBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/querystring-builder": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.9.tgz",
+      "integrity": "sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.15.tgz",
+      "integrity": "sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
+      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "fast-xml-parser": "5.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -151,9 +1029,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
       "funding": [
         {
           "type": "github",
@@ -174,9 +1052,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
-      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
       "funding": [
         {
           "type": "github",
@@ -190,7 +1068,7 @@
       "license": "MIT",
       "dependencies": {
         "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.1.1"
+        "@csstools/css-calc": "^3.2.0"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -223,9 +1101,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
-      "integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
       "funding": [
         {
           "type": "github",
@@ -266,9 +1144,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
       ],
@@ -283,9 +1161,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
       ],
@@ -300,9 +1178,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
       ],
@@ -317,9 +1195,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
       ],
@@ -334,9 +1212,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
       ],
@@ -351,9 +1229,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
       ],
@@ -368,9 +1246,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
       ],
@@ -385,9 +1263,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
       ],
@@ -402,9 +1280,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
       ],
@@ -419,9 +1297,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
       ],
@@ -436,9 +1314,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
       ],
@@ -453,9 +1331,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
       ],
@@ -470,9 +1348,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
       ],
@@ -487,9 +1365,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
       ],
@@ -504,9 +1382,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
       ],
@@ -521,9 +1399,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
       ],
@@ -538,9 +1416,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
       ],
@@ -555,9 +1433,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
       "cpu": [
         "arm64"
       ],
@@ -572,9 +1450,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
       ],
@@ -589,9 +1467,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
       "cpu": [
         "arm64"
       ],
@@ -606,9 +1484,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
       ],
@@ -623,9 +1501,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
       "cpu": [
         "arm64"
       ],
@@ -640,9 +1518,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "cpu": [
         "x64"
       ],
@@ -657,9 +1535,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
       ],
@@ -674,9 +1552,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
       ],
@@ -691,9 +1569,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
       ],
@@ -866,9 +1744,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
+      "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
       "cpu": [
         "arm"
       ],
@@ -880,9 +1758,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
+      "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
       "cpu": [
         "arm64"
       ],
@@ -894,9 +1772,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
+      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
       "cpu": [
         "arm64"
       ],
@@ -908,9 +1786,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
+      "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
       "cpu": [
         "x64"
       ],
@@ -922,9 +1800,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
+      "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
       "cpu": [
         "arm64"
       ],
@@ -936,9 +1814,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
+      "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
       "cpu": [
         "x64"
       ],
@@ -950,9 +1828,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
+      "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
       "cpu": [
         "arm"
       ],
@@ -964,9 +1842,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
+      "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
       "cpu": [
         "arm"
       ],
@@ -978,9 +1856,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
+      "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
       "cpu": [
         "arm64"
       ],
@@ -992,9 +1870,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
+      "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
       "cpu": [
         "arm64"
       ],
@@ -1006,23 +1884,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
+      "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
       "cpu": [
         "loong64"
       ],
@@ -1034,23 +1898,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
+      "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
       "cpu": [
         "ppc64"
       ],
@@ -1062,9 +1912,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
+      "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
       "cpu": [
         "riscv64"
       ],
@@ -1076,9 +1926,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
+      "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
       "cpu": [
         "riscv64"
       ],
@@ -1090,9 +1940,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
+      "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
       "cpu": [
         "s390x"
       ],
@@ -1104,9 +1954,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
+      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
       "cpu": [
         "x64"
       ],
@@ -1118,9 +1968,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
+      "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
       "cpu": [
         "x64"
       ],
@@ -1131,24 +1981,10 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
+      "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
       "cpu": [
         "arm64"
       ],
@@ -1160,9 +1996,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
+      "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
       "cpu": [
         "arm64"
       ],
@@ -1174,9 +2010,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
+      "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
       "cpu": [
         "ia32"
       ],
@@ -1188,9 +2024,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
+      "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
       "cpu": [
         "x64"
       ],
@@ -1202,9 +2038,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
+      "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
       "cpu": [
         "x64"
       ],
@@ -1214,6 +2050,725 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
+      "integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
+      "integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.14.tgz",
+      "integrity": "sha512-N55f8mPEccpzKetUagdvmAy8oohf0J5cuj9jLI1TaSceRlq0pJsIZepY3kmAXAhyxqXPV6hDerDQhqQPKWgAoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.4",
+        "@smithy/util-middleware": "^4.2.13",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.14",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.14.tgz",
+      "integrity": "sha512-vJ0IhpZxZAkFYOegMKSrxw7ujhhT2pass/1UEcZ4kfl5srTAqtPU5I7MdYQoreVas3204ykCiNhY1o7Xlz6Yyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-stream": "^4.5.22",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.13.tgz",
+      "integrity": "sha512-wboCPijzf6RJKLOvnjDAiBxGSmSnGXj35o5ZAWKDaHa/cvQ5U3ZJ13D4tMCE8JG4dxVAZFy/P0x/V9CwwdfULQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.13.tgz",
+      "integrity": "sha512-vYahwBAtRaAcFbOmE9aLr12z7RiHYDSLcnogSdxfm7kKfsNa3wH+NU5r7vTeB5rKvLsWyPjVX8iH94brP7umiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.13.tgz",
+      "integrity": "sha512-wwybfcOX0tLqCcBP378TIU9IqrDuZq/tDV48LlZNydMpCnqnYr+hWBAYbRE+rFFf/p7IkDJySM3bgiMKP2ihPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.13.tgz",
+      "integrity": "sha512-ied1lO559PtAsMJzg2TKRlctLnEi1PfkNeMMpdwXDImk1zV9uvS/Oxoy/vcy9uv1GKZAjDAB5xT6ziE9fzm5wA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.13.tgz",
+      "integrity": "sha512-hFyK+ORJrxAN3RYoaD6+gsGDQjeix8HOEkosoajvXYZ4VeqonM3G4jd9IIRm/sWGXUKmudkY9KdYjzosUqdM8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.13.tgz",
+      "integrity": "sha512-kRrq4EKLGeOxhC2CBEhRNcu1KSzNJzYY7RK3S7CxMPgB5dRrv55WqQOtRwQxQLC04xqORFLUgnDlc6xrNUULaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.16",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.16.tgz",
+      "integrity": "sha512-nYDRUIvNd4mFmuXraRWt6w5UsZTNqtj4hXJA/iiOD4tuseIdLP9Lq38teH/SZTcIFCa2f+27o7hYpIsWktJKEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/querystring-builder": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.14.tgz",
+      "integrity": "sha512-rtQ5es8r/5v4rav7q5QTsfx9CtCyzrz/g7ZZZBH2xtMmd6G/KQrLOWfSHTvFOUPlVy59RQvxeBYJaLRoybMEyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.2.2",
+        "@smithy/chunked-blob-reader-native": "^4.2.3",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.13.tgz",
+      "integrity": "sha512-4/oy9h0jjmY80a2gOIo75iLl8TOPhmtx4E2Hz+PfMjvx/vLtGY4TMU/35WRyH2JHPfT5CVB38u4JRow7gnmzJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.13.tgz",
+      "integrity": "sha512-WdQ7HwUjINXETeh6dqUeob1UHIYx8kAn9PSp1HhM2WWegiZBYVy2WXIs1lB07SZLan/udys9SBnQGt9MQbDpdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.13.tgz",
+      "integrity": "sha512-jvC0RB/8BLj2SMIkY0Npl425IdnxZJxInpZJbu563zIRnVjpDMXevU3VMCRSabaLB0kf/eFIOusdGstrLJ8IDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.13.tgz",
+      "integrity": "sha512-cNm7I9NXolFxtS20ojROddOEpSAeI1Obq6pd1Kj5HtHws3s9Fkk8DdHDfQSs5KuxCewZuVK6UqrJnfJmiMzDuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.13.tgz",
+      "integrity": "sha512-IPMLm/LE4AZwu6qiE8Rr8vJsWhs9AtOdySRXrOM7xnvclp77Tyh7hMs/FRrMf26kgIe67vFJXXOSmVxS7oKeig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.29",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.29.tgz",
+      "integrity": "sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.14",
+        "@smithy/middleware-serde": "^4.2.17",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-middleware": "^4.2.13",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.0.tgz",
+      "integrity": "sha512-/NzISn4grj/BRFVua/xnQwF+7fakYZgimpw2dfmlPgcqecBMKxpB9g5mLYRrmBD5OrPoODokw4Vi1hrSR4zRyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.14",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/service-error-classification": "^4.2.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-retry": "^4.3.0",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.17",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.17.tgz",
+      "integrity": "sha512-0T2mcaM6v9W1xku86Dk0bEW7aEseG6KenFkPK98XNw0ZhOqOiD1MrMsdnQw9QsL3/Oa85T53iSMlm0SZdSuIEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.14",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.13.tgz",
+      "integrity": "sha512-g72jN/sGDLyTanrCLH9fhg3oysO3f7tQa6eWWsMyn2BiYNCgjF24n4/I9wff/5XidFvjj9ilipAoQrurTUrLvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.13.tgz",
+      "integrity": "sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.2.tgz",
+      "integrity": "sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/querystring-builder": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.13.tgz",
+      "integrity": "sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
+      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.13.tgz",
+      "integrity": "sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.13.tgz",
+      "integrity": "sha512-hqW3Q4P+CDzUyQ87GrboGMeD7XYNMOF+CuTwu936UQRB/zeYn3jys8C3w+wMkDfY7CyyyVwZQ5cNFoG0x1pYmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.13.tgz",
+      "integrity": "sha512-a0s8XZMfOC/qpqq7RCPvJlk93rWFrElH6O++8WJKz0FqnA4Y7fkNi/0mnGgSH1C4x6MFsuBA8VKu4zxFrMe5Vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.8.tgz",
+      "integrity": "sha512-VZCZx2bZasxdqxVgEAhREvDSlkatTPnkdWy1+Kiy8w7kYPBosW0V5IeDwzDUMvWBt56zpK658rx1cOBFOYaPaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.13.tgz",
+      "integrity": "sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.9.tgz",
+      "integrity": "sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.14",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/middleware-stack": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-stream": "^4.5.22",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.0.tgz",
+      "integrity": "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.13.tgz",
+      "integrity": "sha512-2G03yoboIRZlZze2+PT4GZEjgwQsJjUgn6iTsvxA02bVceHR6vp4Cuk7TUnPFWKF+ffNUk3kj4COwkENS2K3vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.45",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.45.tgz",
+      "integrity": "sha512-ag9sWc6/nWZAuK3Wm9KlFJUnRkXLrXn33RFjIAmCTFThqLHY+7wCst10BGq56FxslsDrjhSie46c8OULS+BiIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.49.tgz",
+      "integrity": "sha512-jlN6vHwE8gY5AfiFBavtD3QtCX2f7lM3BKkz7nFKSNfFR5nXLXLg6sqXTJEEyDwtxbztIDBQCfjsGVXlIru2lQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/credential-provider-imds": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.4.tgz",
+      "integrity": "sha512-BKoR/ubPp9KNKFxPpg1J28N1+bgu8NGAtJblBP7yHy8yQPBWhIAv9+l92SlQLpolGm71CVO+btB60gTgzT0wog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.13.tgz",
+      "integrity": "sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.0.tgz",
+      "integrity": "sha512-tSOPQNT/4KfbvqeMovWC3g23KSYy8czHd3tlN+tOYVNIDLSfxIsrPJihYi5TpNcoV789KWtgChUVedh2y6dDPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.22",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.22.tgz",
+      "integrity": "sha512-3H8iq/0BfQjUs2/4fbHZ9aG9yNzcuZs24LPkcX1Q7Z+qpqaGM8+qbGmE8zo9m2nCRgamyvS98cHdcWvR6YUsew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.15.tgz",
+      "integrity": "sha512-oUt9o7n8hBv3BL56sLSneL0XeigZSuem0Hr78JaoK33D9oKieyCvVP8eTSe3j7g2mm/S1DvzxKieG7JEWNJUNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
@@ -2053,10 +3608,16 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2558,10 +4119,13 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
+      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "engines": {
+        "node": ">=20"
+      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -2730,6 +4294,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -2792,9 +4357,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2805,32 +4370,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/escape-html": {
@@ -2977,6 +4542,41 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -3212,9 +4812,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -3523,27 +5123,27 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "29.0.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
-      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+      "version": "29.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
+      "integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^5.0.1",
-        "@asamuzakjp/dom-selector": "^7.0.3",
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
         "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
         "@exodus/bytes": "^1.15.0",
         "css-tree": "^3.2.1",
         "data-urls": "^7.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.7",
-        "parse5": "^8.0.0",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^6.0.1",
-        "undici": "^7.24.5",
+        "undici": "^7.25.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.1",
         "whatwg-mimetype": "^5.0.0",
@@ -3562,22 +5162,34 @@
         }
       }
     },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/jsdom/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/jsdom/node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
       "license": "MIT",
       "dependencies": {
-        "entities": "^6.0.0"
+        "entities": "^8.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -3720,9 +5332,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -4227,6 +5839,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.4.0.tgz",
+      "integrity": "sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -4253,9 +5880,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
-      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -4277,9 +5904,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4511,9 +6138,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4554,9 +6181,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
+      "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4570,31 +6197,28 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.59.0",
-        "@rollup/rollup-android-arm64": "4.59.0",
-        "@rollup/rollup-darwin-arm64": "4.59.0",
-        "@rollup/rollup-darwin-x64": "4.59.0",
-        "@rollup/rollup-freebsd-arm64": "4.59.0",
-        "@rollup/rollup-freebsd-x64": "4.59.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-        "@rollup/rollup-linux-arm64-musl": "4.59.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-        "@rollup/rollup-linux-loong64-musl": "4.59.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-musl": "4.59.0",
-        "@rollup/rollup-openbsd-x64": "4.59.0",
-        "@rollup/rollup-openharmony-arm64": "4.59.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-        "@rollup/rollup-win32-x64-gnu": "4.59.0",
-        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "@rollup/rollup-android-arm-eabi": "4.53.3",
+        "@rollup/rollup-android-arm64": "4.53.3",
+        "@rollup/rollup-darwin-arm64": "4.53.3",
+        "@rollup/rollup-darwin-x64": "4.53.3",
+        "@rollup/rollup-freebsd-arm64": "4.53.3",
+        "@rollup/rollup-freebsd-x64": "4.53.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.53.3",
+        "@rollup/rollup-linux-arm64-musl": "4.53.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.53.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.53.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.53.3",
+        "@rollup/rollup-linux-x64-gnu": "4.53.3",
+        "@rollup/rollup-linux-x64-musl": "4.53.3",
+        "@rollup/rollup-openharmony-arm64": "4.53.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.53.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.53.3",
+        "@rollup/rollup-win32-x64-gnu": "4.53.3",
+        "@rollup/rollup-win32-x64-msvc": "4.53.3",
         "fsevents": "~2.3.2"
       }
     },
@@ -5166,6 +6790,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/superagent": {
       "version": "10.2.3",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
@@ -5321,9 +6957,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5344,21 +6980,21 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.27",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
-      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.27"
+        "tldts-core": "^7.0.28"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.27",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
-      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
@@ -5461,6 +7097,12 @@
         }
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -5515,9 +7157,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -5574,13 +7216,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.6.tgz",
+      "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -5667,9 +7309,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5758,9 +7400,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,8 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1026.0",
+    "@aws-sdk/s3-request-presigner": "^3.1026.0",
     "@prisma/client": "^5.22.0",
     "archiver": "^7.0.1",
     "bcrypt": "^6.0.0",

--- a/backend/prisma/migrations/20260408060000_add_s3_files/migration.sql
+++ b/backend/prisma/migrations/20260408060000_add_s3_files/migration.sql
@@ -1,17 +1,10 @@
 -- Track S3-uploaded image files for presigned download URL generation.
--- The primary key is composite (drawingId, fileId): Excalidraw fileIds
--- are content hashes that repeat across drawings, so a global PK on
--- fileId alone would let a second upload silently overwrite the first
--- and let cleanup of one drawing trash an object the other still needs.
 CREATE TABLE "S3File" (
-    "drawingId" TEXT NOT NULL,
-    "fileId"    TEXT NOT NULL,
+    "id"        TEXT NOT NULL PRIMARY KEY,
     "userId"    TEXT NOT NULL,
     "s3Key"     TEXT NOT NULL,
     "mimeType"  TEXT NOT NULL,
-    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY ("drawingId", "fileId")
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE INDEX "S3File_userId_idx" ON "S3File"("userId");
-CREATE INDEX "S3File_drawingId_idx" ON "S3File"("drawingId");

--- a/backend/prisma/migrations/20260408060000_add_s3_files/migration.sql
+++ b/backend/prisma/migrations/20260408060000_add_s3_files/migration.sql
@@ -1,10 +1,17 @@
 -- Track S3-uploaded image files for presigned download URL generation.
+-- The primary key is composite (drawingId, fileId): Excalidraw fileIds
+-- are content hashes that repeat across drawings, so a global PK on
+-- fileId alone would let a second upload silently overwrite the first
+-- and let cleanup of one drawing trash an object the other still needs.
 CREATE TABLE "S3File" (
-    "id"        TEXT NOT NULL PRIMARY KEY,
+    "drawingId" TEXT NOT NULL,
+    "fileId"    TEXT NOT NULL,
     "userId"    TEXT NOT NULL,
     "s3Key"     TEXT NOT NULL,
     "mimeType"  TEXT NOT NULL,
-    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY ("drawingId", "fileId")
 );
 
 CREATE INDEX "S3File_userId_idx" ON "S3File"("userId");
+CREATE INDEX "S3File_drawingId_idx" ON "S3File"("drawingId");

--- a/backend/prisma/migrations/20260408060000_add_s3_files/migration.sql
+++ b/backend/prisma/migrations/20260408060000_add_s3_files/migration.sql
@@ -1,0 +1,10 @@
+-- Track S3-uploaded image files for presigned download URL generation.
+CREATE TABLE "S3File" (
+    "id"        TEXT NOT NULL PRIMARY KEY,
+    "userId"    TEXT NOT NULL,
+    "s3Key"     TEXT NOT NULL,
+    "mimeType"  TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX "S3File_userId_idx" ON "S3File"("userId");

--- a/backend/prisma/migrations/20260506130000_s3file_composite_pk/migration.sql
+++ b/backend/prisma/migrations/20260506130000_s3file_composite_pk/migration.sql
@@ -7,18 +7,19 @@
 -- prefix-scoped cleanup deleted objects the sibling drawing still
 -- needed.
 --
--- This migration drops the existing S3File rows and recreates the
--- table with the new shape. Public-bucket deployments are unaffected
--- (image dataURLs already encode the bucket URL directly). Private-
--- bucket deployments will see /api/files/:drawingId/:fileId 404 for
--- pre-existing images until each affected drawing is re-saved (the
--- save flow upserts a fresh row per (drawingId, fileId) only when it
--- detects new base64 dataURLs, so legacy rows must be rebuilt by hand
--- if needed). S3 objects themselves are untouched.
+-- We preserve existing rows by parsing the drawingId out of the
+-- s3Key. Pre-existing keys all follow the layout produced by uploads
+-- so far:
+--   {prefix}/{userId}/{drawingId}/{fileId}.{ext}
+-- (the default prefix `excalidash` has no internal slashes, so we look
+-- for the third '/' in the key and take the segment that ends at it.)
+-- Operators with a custom S3_KEY_PREFIX containing '/' should re-save
+-- affected drawings after deploying — those rows fall through and are
+-- dropped (private-bucket access falls back to 404 until re-saved,
+-- public-bucket dataURLs keep working as the dataURL itself encodes
+-- the URL directly).
 
-DROP TABLE IF EXISTS "S3File";
-
-CREATE TABLE "S3File" (
+CREATE TABLE "new_S3File" (
     "drawingId" TEXT NOT NULL,
     "fileId"    TEXT NOT NULL,
     "userId"    TEXT NOT NULL,
@@ -27,6 +28,52 @@ CREATE TABLE "S3File" (
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY ("drawingId", "fileId")
 );
+
+-- Extract `drawingId` = the path segment between the second and third
+-- '/' in s3Key. SQLite has INSTR + SUBSTR but no native split, so we
+-- chain three scans of the string:
+--   p1 = INSTR(s3Key, '/')
+--   tail1 = SUBSTR(s3Key, p1+1)
+--   p2_local = INSTR(tail1, '/')
+--   tail2 = SUBSTR(tail1, p2_local+1)
+--   p3_local = INSTR(tail2, '/')
+--   drawingId = SUBSTR(tail2, 1, p3_local - 1)
+INSERT OR IGNORE INTO "new_S3File"
+    ("drawingId", "fileId", "userId", "s3Key", "mimeType", "createdAt")
+SELECT
+    SUBSTR(
+        SUBSTR(
+            SUBSTR(s3Key, INSTR(s3Key, '/') + 1),
+            INSTR(SUBSTR(s3Key, INSTR(s3Key, '/') + 1), '/') + 1
+        ),
+        1,
+        INSTR(
+            SUBSTR(
+                SUBSTR(s3Key, INSTR(s3Key, '/') + 1),
+                INSTR(SUBSTR(s3Key, INSTR(s3Key, '/') + 1), '/') + 1
+            ),
+            '/'
+        ) - 1
+    ) AS drawingId,
+    id AS fileId,
+    userId,
+    s3Key,
+    mimeType,
+    createdAt
+FROM "S3File"
+-- Only attempt the parse for keys that have at least three '/' (the
+-- typical default-prefix shape). Other rows are dropped.
+WHERE LENGTH(s3Key) - LENGTH(REPLACE(s3Key, '/', '')) >= 3
+  AND INSTR(
+        SUBSTR(
+            SUBSTR(s3Key, INSTR(s3Key, '/') + 1),
+            INSTR(SUBSTR(s3Key, INSTR(s3Key, '/') + 1), '/') + 1
+        ),
+        '/'
+      ) > 1;
+
+DROP TABLE "S3File";
+ALTER TABLE "new_S3File" RENAME TO "S3File";
 
 CREATE INDEX "S3File_userId_idx" ON "S3File"("userId");
 CREATE INDEX "S3File_drawingId_idx" ON "S3File"("drawingId");

--- a/backend/prisma/migrations/20260506130000_s3file_composite_pk/migration.sql
+++ b/backend/prisma/migrations/20260506130000_s3file_composite_pk/migration.sql
@@ -1,0 +1,32 @@
+-- Migrate S3File from a single-column `id` (= fileId) primary key to a
+-- composite (drawingId, fileId) primary key.
+--
+-- Why: Excalidraw fileIds are content hashes that legitimately repeat
+-- across drawings; a global PK on fileId alone meant the second upload
+-- of the same image silently overwrote the first row's s3Key, and any
+-- prefix-scoped cleanup deleted objects the sibling drawing still
+-- needed.
+--
+-- This migration drops the existing S3File rows and recreates the
+-- table with the new shape. Public-bucket deployments are unaffected
+-- (image dataURLs already encode the bucket URL directly). Private-
+-- bucket deployments will see /api/files/:drawingId/:fileId 404 for
+-- pre-existing images until each affected drawing is re-saved (the
+-- save flow upserts a fresh row per (drawingId, fileId) only when it
+-- detects new base64 dataURLs, so legacy rows must be rebuilt by hand
+-- if needed). S3 objects themselves are untouched.
+
+DROP TABLE IF EXISTS "S3File";
+
+CREATE TABLE "S3File" (
+    "drawingId" TEXT NOT NULL,
+    "fileId"    TEXT NOT NULL,
+    "userId"    TEXT NOT NULL,
+    "s3Key"     TEXT NOT NULL,
+    "mimeType"  TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY ("drawingId", "fileId")
+);
+
+CREATE INDEX "S3File_userId_idx" ON "S3File"("userId");
+CREATE INDEX "S3File_drawingId_idx" ON "S3File"("drawingId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -186,14 +186,20 @@ model AuthIdentity {
   @@index([userId])
 }
 
-/// Tracks S3-uploaded image files so the backend can generate presigned
-/// download URLs for private-bucket deployments.
+/// Per-(drawing, fileId) S3 object record. Excalidraw fileIds are content
+/// hashes that legitimately repeat across drawings, so the primary key
+/// includes drawingId to keep each reference accounted for separately —
+/// a duplicated drawing has its own row + object, and trimming or
+/// deleting the original cannot delete the duplicate's storage.
 model S3File {
-  id        String   @id  // fileId (same ID used in Drawing.files)
-  userId    String        // owner who uploaded the file
-  s3Key     String        // full object key, e.g. "excalidash/userId/fileId.png"
+  drawingId String
+  fileId    String   // Excalidraw fileId (same id used in Drawing.files)
+  userId    String   // owner who uploaded the file
+  s3Key     String   // full object key, e.g. "excalidash/userId/drawingId/fileId.png"
   mimeType  String
   createdAt DateTime @default(now())
 
+  @@id([drawingId, fileId])
   @@index([userId])
+  @@index([drawingId])
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -185,3 +185,15 @@ model AuthIdentity {
   @@unique([provider, userId])
   @@index([userId])
 }
+
+/// Tracks S3-uploaded image files so the backend can generate presigned
+/// download URLs for private-bucket deployments.
+model S3File {
+  id        String   @id  // fileId (same ID used in Drawing.files)
+  userId    String        // owner who uploaded the file
+  s3Key     String        // full object key, e.g. "excalidash/userId/fileId.png"
+  mimeType  String
+  createdAt DateTime @default(now())
+
+  @@index([userId])
+}

--- a/backend/src/__tests__/fileProcessing.test.ts
+++ b/backend/src/__tests__/fileProcessing.test.ts
@@ -5,6 +5,12 @@ vi.mock("../s3", () => ({
   getS3Config: vi.fn(),
   uploadBuffer: vi.fn(),
   getPublicUrl: vi.fn(),
+  buildS3Key: (
+    userId: string,
+    drawingId: string,
+    fileId: string,
+    ext: string,
+  ) => `excalidash/${userId}/${drawingId}/${fileId}.${ext}`,
 }));
 
 import { processFilesForS3, decodeDataURL } from "../fileProcessing";
@@ -91,9 +97,10 @@ describe("processFilesForS3", () => {
       "image/png",
     );
     expect(prisma.s3File.upsert).toHaveBeenCalledWith({
-      where: { id: "file-1" },
+      where: { drawingId_fileId: { drawingId: "drawing-1", fileId: "file-1" } },
       create: {
-        id: "file-1",
+        drawingId: "drawing-1",
+        fileId: "file-1",
         userId: "user-1",
         s3Key: "excalidash/user-1/drawing-1/file-1.png",
         mimeType: "image/png",
@@ -144,18 +151,18 @@ describe("processFilesForS3", () => {
       "file-1": {
         id: "file-1",
         mimeType: "image/png",
-        dataURL: "/api/files/file-1",
+        dataURL: "/api/files/drawing-1/file-1",
       },
     };
 
     const result = await processFilesForS3(files, "user-1", "drawing-1", prisma as any);
 
-    expect(result["file-1"].dataURL).toBe("/api/files/file-1");
+    expect(result["file-1"].dataURL).toBe("/api/files/drawing-1/file-1");
     expect(mockUploadBuffer).not.toHaveBeenCalled();
     expect(prisma.s3File.upsert).not.toHaveBeenCalled();
   });
 
-  it("uses /api/files/:fileId when no publicUrl configured", async () => {
+  it("uses /api/files/:drawingId/:fileId when no publicUrl configured", async () => {
     mockIsS3Enabled.mockReturnValue(true);
     mockGetS3Config.mockReturnValue({
       bucket: "test-bucket",
@@ -171,7 +178,7 @@ describe("processFilesForS3", () => {
 
     const result = await processFilesForS3(files, "user-1", "drawing-1", prisma as any);
 
-    expect(result["file-1"].dataURL).toBe("/api/files/file-1");
+    expect(result["file-1"].dataURL).toBe("/api/files/drawing-1/file-1");
     expect(mockGetPublicUrl).not.toHaveBeenCalled();
   });
 
@@ -250,7 +257,7 @@ describe("processFilesForS3", () => {
       "file-api": {
         id: "file-api",
         mimeType: "image/png",
-        dataURL: "/api/files/file-api",
+        dataURL: "/api/files/drawing-1/file-api",
       },
     };
 
@@ -264,7 +271,7 @@ describe("processFilesForS3", () => {
     expect(result["file-s3"].dataURL).toBe(
       "https://cdn.example.com/excalidash/user-1/drawing-1/file-s3.png",
     );
-    expect(result["file-api"].dataURL).toBe("/api/files/file-api");
+    expect(result["file-api"].dataURL).toBe("/api/files/drawing-1/file-api");
 
     // Only one upload call for the base64 file
     expect(mockUploadBuffer).toHaveBeenCalledOnce();

--- a/backend/src/__tests__/fileProcessing.test.ts
+++ b/backend/src/__tests__/fileProcessing.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../s3", () => ({
+  isS3Enabled: vi.fn(),
+  getS3Config: vi.fn(),
+  uploadBuffer: vi.fn(),
+  getPublicUrl: vi.fn(),
+}));
+
+import { processFilesForS3, decodeDataURL } from "../fileProcessing";
+import { isS3Enabled, getS3Config, uploadBuffer, getPublicUrl } from "../s3";
+
+const mockIsS3Enabled = vi.mocked(isS3Enabled);
+const mockGetS3Config = vi.mocked(getS3Config);
+const mockUploadBuffer = vi.mocked(uploadBuffer);
+const mockGetPublicUrl = vi.mocked(getPublicUrl);
+
+/** Tiny valid 1x1 PNG as a base64 data URL */
+const TINY_PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/58BAwAI/AL+hc2rNAAAAABJRU5ErkJggg==";
+const PNG_DATA_URL = `data:image/png;base64,${TINY_PNG_B64}`;
+
+const makePrisma = () => ({
+  s3File: {
+    upsert: vi.fn().mockResolvedValue({}),
+  },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("decodeDataURL", () => {
+  it("decodes a valid base64 data URL", () => {
+    const result = decodeDataURL(PNG_DATA_URL);
+    expect(result).not.toBeNull();
+    expect(result!.mimeType).toBe("image/png");
+    expect(Buffer.isBuffer(result!.buffer)).toBe(true);
+    expect(result!.buffer.length).toBeGreaterThan(0);
+  });
+
+  it("returns null for non-data URLs", () => {
+    expect(decodeDataURL("https://example.com/image.png")).toBeNull();
+    expect(decodeDataURL("/api/files/abc")).toBeNull();
+    expect(decodeDataURL("not-a-url")).toBeNull();
+  });
+});
+
+describe("processFilesForS3", () => {
+  it("returns files unchanged when S3 is not enabled", async () => {
+    mockIsS3Enabled.mockReturnValue(false);
+    const prisma = makePrisma();
+
+    const files = {
+      "file-1": { id: "file-1", mimeType: "image/png", dataURL: PNG_DATA_URL },
+    };
+
+    const result = await processFilesForS3(files, "user-1", "drawing-1", prisma as any);
+
+    expect(result).toBe(files); // exact same reference
+    expect(mockUploadBuffer).not.toHaveBeenCalled();
+    expect(prisma.s3File.upsert).not.toHaveBeenCalled();
+  });
+
+  it("uploads base64 files and replaces dataURL with S3 public URL", async () => {
+    mockIsS3Enabled.mockReturnValue(true);
+    mockGetS3Config.mockReturnValue({
+      bucket: "test-bucket",
+      region: "us-east-1",
+      publicUrl: "https://cdn.example.com",
+    });
+    mockUploadBuffer.mockResolvedValue(undefined);
+    mockGetPublicUrl.mockReturnValue(
+      "https://cdn.example.com/excalidash/user-1/drawing-1/file-1.png",
+    );
+    const prisma = makePrisma();
+
+    const files = {
+      "file-1": { id: "file-1", mimeType: "image/png", dataURL: PNG_DATA_URL },
+    };
+
+    const result = await processFilesForS3(files, "user-1", "drawing-1", prisma as any);
+
+    expect(result["file-1"].dataURL).toBe(
+      "https://cdn.example.com/excalidash/user-1/drawing-1/file-1.png",
+    );
+    expect(mockUploadBuffer).toHaveBeenCalledOnce();
+    expect(mockUploadBuffer).toHaveBeenCalledWith(
+      "excalidash/user-1/drawing-1/file-1.png",
+      expect.any(Buffer),
+      "image/png",
+    );
+    expect(prisma.s3File.upsert).toHaveBeenCalledWith({
+      where: { id: "file-1" },
+      create: {
+        id: "file-1",
+        userId: "user-1",
+        s3Key: "excalidash/user-1/drawing-1/file-1.png",
+        mimeType: "image/png",
+      },
+      update: {
+        s3Key: "excalidash/user-1/drawing-1/file-1.png",
+        mimeType: "image/png",
+      },
+    });
+  });
+
+  it("skips files with existing S3 URLs (https://)", async () => {
+    mockIsS3Enabled.mockReturnValue(true);
+    mockGetS3Config.mockReturnValue({
+      bucket: "test-bucket",
+      region: "us-east-1",
+      publicUrl: "https://cdn.example.com",
+    });
+    const prisma = makePrisma();
+
+    const files = {
+      "file-1": {
+        id: "file-1",
+        mimeType: "image/png",
+        dataURL: "https://cdn.example.com/excalidash/user-1/drawing-1/file-1.png",
+      },
+    };
+
+    const result = await processFilesForS3(files, "user-1", "drawing-1", prisma as any);
+
+    expect(result["file-1"].dataURL).toBe(
+      "https://cdn.example.com/excalidash/user-1/drawing-1/file-1.png",
+    );
+    expect(mockUploadBuffer).not.toHaveBeenCalled();
+    expect(prisma.s3File.upsert).not.toHaveBeenCalled();
+  });
+
+  it("skips files with /api/files/ URLs", async () => {
+    mockIsS3Enabled.mockReturnValue(true);
+    mockGetS3Config.mockReturnValue({
+      bucket: "test-bucket",
+      region: "us-east-1",
+      publicUrl: "https://cdn.example.com",
+    });
+    const prisma = makePrisma();
+
+    const files = {
+      "file-1": {
+        id: "file-1",
+        mimeType: "image/png",
+        dataURL: "/api/files/file-1",
+      },
+    };
+
+    const result = await processFilesForS3(files, "user-1", "drawing-1", prisma as any);
+
+    expect(result["file-1"].dataURL).toBe("/api/files/file-1");
+    expect(mockUploadBuffer).not.toHaveBeenCalled();
+    expect(prisma.s3File.upsert).not.toHaveBeenCalled();
+  });
+
+  it("uses /api/files/:fileId when no publicUrl configured", async () => {
+    mockIsS3Enabled.mockReturnValue(true);
+    mockGetS3Config.mockReturnValue({
+      bucket: "test-bucket",
+      region: "us-east-1",
+      // no publicUrl
+    });
+    mockUploadBuffer.mockResolvedValue(undefined);
+    const prisma = makePrisma();
+
+    const files = {
+      "file-1": { id: "file-1", mimeType: "image/png", dataURL: PNG_DATA_URL },
+    };
+
+    const result = await processFilesForS3(files, "user-1", "drawing-1", prisma as any);
+
+    expect(result["file-1"].dataURL).toBe("/api/files/file-1");
+    expect(mockGetPublicUrl).not.toHaveBeenCalled();
+  });
+
+  it("handles multiple files, only uploading base64 ones", async () => {
+    mockIsS3Enabled.mockReturnValue(true);
+    mockGetS3Config.mockReturnValue({
+      bucket: "test-bucket",
+      region: "us-east-1",
+      publicUrl: "https://cdn.example.com",
+    });
+    mockUploadBuffer.mockResolvedValue(undefined);
+    mockGetPublicUrl.mockImplementation(
+      (key: string) => `https://cdn.example.com/${key}`,
+    );
+    const prisma = makePrisma();
+
+    const files = {
+      "file-b64": {
+        id: "file-b64",
+        mimeType: "image/png",
+        dataURL: PNG_DATA_URL,
+      },
+      "file-s3": {
+        id: "file-s3",
+        mimeType: "image/png",
+        dataURL: "https://cdn.example.com/excalidash/user-1/drawing-1/file-s3.png",
+      },
+      "file-api": {
+        id: "file-api",
+        mimeType: "image/png",
+        dataURL: "/api/files/file-api",
+      },
+    };
+
+    const result = await processFilesForS3(files, "user-1", "drawing-1", prisma as any);
+
+    // base64 file was uploaded and replaced
+    expect(result["file-b64"].dataURL).toBe(
+      "https://cdn.example.com/excalidash/user-1/drawing-1/file-b64.png",
+    );
+    // existing URLs left untouched
+    expect(result["file-s3"].dataURL).toBe(
+      "https://cdn.example.com/excalidash/user-1/drawing-1/file-s3.png",
+    );
+    expect(result["file-api"].dataURL).toBe("/api/files/file-api");
+
+    // Only one upload call for the base64 file
+    expect(mockUploadBuffer).toHaveBeenCalledOnce();
+    expect(prisma.s3File.upsert).toHaveBeenCalledOnce();
+  });
+});

--- a/backend/src/__tests__/fileProcessing.test.ts
+++ b/backend/src/__tests__/fileProcessing.test.ts
@@ -175,6 +175,54 @@ describe("processFilesForS3", () => {
     expect(mockGetPublicUrl).not.toHaveBeenCalled();
   });
 
+  it("rejects file ids containing path traversal characters", async () => {
+    mockIsS3Enabled.mockReturnValue(true);
+    mockGetS3Config.mockReturnValue({
+      bucket: "test-bucket",
+      region: "us-east-1",
+      publicUrl: "https://cdn.example.com",
+    });
+    const prisma = makePrisma();
+
+    const files = {
+      "../../etc/passwd": {
+        id: "../../etc/passwd",
+        mimeType: "image/png",
+        dataURL: PNG_DATA_URL,
+      },
+      "good-id": {
+        id: "good-id",
+        mimeType: "image/png",
+        dataURL: PNG_DATA_URL,
+      },
+    };
+
+    mockUploadBuffer.mockResolvedValue(undefined);
+    mockGetPublicUrl.mockImplementation(
+      (key: string) => `https://cdn.example.com/${key}`,
+    );
+
+    const result = await processFilesForS3(
+      files,
+      "user-1",
+      "drawing-1",
+      prisma as any,
+    );
+
+    // Bad id is dropped from the output entirely.
+    expect(result["../../etc/passwd"]).toBeUndefined();
+    expect(result["good-id"]).toBeDefined();
+
+    // No upload was issued for the bad id.
+    expect(mockUploadBuffer).toHaveBeenCalledOnce();
+    expect(mockUploadBuffer).toHaveBeenCalledWith(
+      "excalidash/user-1/drawing-1/good-id.png",
+      expect.any(Buffer),
+      "image/png",
+    );
+    expect(prisma.s3File.upsert).toHaveBeenCalledOnce();
+  });
+
   it("handles multiple files, only uploading base64 ones", async () => {
     mockIsS3Enabled.mockReturnValue(true);
     mockGetS3Config.mockReturnValue({

--- a/backend/src/__tests__/storage.integration.ts
+++ b/backend/src/__tests__/storage.integration.ts
@@ -1,0 +1,358 @@
+/**
+ * Integration tests for storage management routes:
+ *   POST   /drawings/:id/trim
+ *   GET    /drawings/:id/files/diff
+ *   DELETE /drawings/:id/files/orphans
+ *
+ * Exercises the real Express handlers via supertest. S3 is not
+ * configured in the test environment, so the trim/orphans handlers
+ * skip their S3-side branches — we cover the SQLite-side semantics:
+ *   - confirmName guard (403)
+ *   - non-owner 404
+ *   - version monotonicity (regression for the version-reset bug)
+ *   - active fileId protection (400)
+ *   - deleted-element cleanup on orphan delete
+ *   - diff response shape
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import bcrypt from "bcrypt";
+import jwt, { SignOptions } from "jsonwebtoken";
+import { StringValue } from "ms";
+import { PrismaClient } from "../generated/client";
+import { config } from "../config";
+import { getTestPrisma, setupTestDb, cleanupTestDb } from "./testUtils";
+
+describe("Storage management routes", () => {
+  const userAgent = "vitest-storage";
+  let prisma: PrismaClient;
+  let app: any;
+  let agent: any;
+  let csrfHeaderName: string;
+  let csrfToken: string;
+  let owner: { id: string; email: string };
+  let other: { id: string; email: string };
+  let ownerToken: string;
+  let otherToken: string;
+
+  const signToken = (userId: string, email: string) => {
+    const opts: SignOptions = {
+      expiresIn: config.jwtAccessExpiresIn as StringValue,
+    };
+    return jwt.sign({ userId, email, type: "access" }, config.jwtSecret, opts);
+  };
+
+  const createDrawing = async (
+    userId: string,
+    overrides: {
+      name?: string;
+      elements?: any[];
+      files?: Record<string, any>;
+      version?: number;
+    } = {}
+  ) => {
+    return prisma.drawing.create({
+      data: {
+        name: overrides.name ?? "My Drawing",
+        elements: JSON.stringify(overrides.elements ?? []),
+        appState: "{}",
+        files: JSON.stringify(overrides.files ?? {}),
+        userId,
+        version: overrides.version ?? 1,
+      },
+    });
+  };
+
+  const fileEntry = (id: string) => ({
+    id,
+    mimeType: "image/png",
+    dataURL: "data:image/png;base64,AAAA",
+    created: Date.now(),
+  });
+
+  const imageElement = (
+    elId: string,
+    fileId: string,
+    isDeleted = false
+  ) => ({
+    id: elId,
+    type: "image",
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+    isDeleted,
+    fileId,
+  });
+
+  beforeAll(async () => {
+    setupTestDb();
+    prisma = getTestPrisma();
+    ({ app } = await import("../index"));
+
+    await prisma.systemConfig.upsert({
+      where: { id: "default" },
+      update: { authEnabled: true, registrationEnabled: false },
+      create: {
+        id: "default",
+        authEnabled: true,
+        registrationEnabled: false,
+      },
+    });
+
+    // CSRF middleware rejects unauth'd state-changing requests; obtain a
+    // token once and reuse it on every mutating call.
+    agent = request.agent(app);
+    const csrfRes = await agent
+      .get("/csrf-token")
+      .set("User-Agent", userAgent);
+    csrfHeaderName = csrfRes.body.header;
+    csrfToken = csrfRes.body.token;
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDb(prisma);
+    await prisma.s3File.deleteMany({});
+    await prisma.user.deleteMany({});
+
+    const passwordHash = await bcrypt.hash("password123", 10);
+    const ownerRow = await prisma.user.create({
+      data: {
+        email: "owner@test.local",
+        passwordHash,
+        name: "Owner",
+        role: "USER",
+        isActive: true,
+      },
+      select: { id: true, email: true },
+    });
+    const otherRow = await prisma.user.create({
+      data: {
+        email: "other@test.local",
+        passwordHash,
+        name: "Other",
+        role: "USER",
+        isActive: true,
+      },
+      select: { id: true, email: true },
+    });
+    owner = ownerRow;
+    other = otherRow;
+    ownerToken = signToken(owner.id, owner.email);
+    otherToken = signToken(other.id, other.email);
+  });
+
+  describe("POST /drawings/:id/trim", () => {
+    it("removes deleted elements and orphan file entries, bumps version", async () => {
+      const drawing = await createDrawing(owner.id, {
+        name: "Trim Me",
+        elements: [
+          imageElement("el-keep", "file-keep"),
+          imageElement("el-drop", "file-drop", true),
+        ],
+        files: {
+          "file-keep": fileEntry("file-keep"),
+          "file-drop": fileEntry("file-drop"),
+          "file-unreferenced": fileEntry("file-unreferenced"),
+        },
+        version: 7,
+      });
+
+      const res = await agent
+        .post(`/drawings/${drawing.id}/trim`)
+        .set("User-Agent", userAgent)
+        .set(csrfHeaderName, csrfToken)
+        .set("Authorization", `Bearer ${ownerToken}`)
+        .send({ confirmName: "Trim Me" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.trimmed).toMatchObject({
+        elementsRemoved: 1,
+        filesRemoved: 2,
+      });
+
+      const after = await prisma.drawing.findUniqueOrThrow({
+        where: { id: drawing.id },
+      });
+      const elements = JSON.parse(after.elements) as any[];
+      const files = JSON.parse(after.files) as Record<string, unknown>;
+      expect(elements.map((e) => e.id)).toEqual(["el-keep"]);
+      expect(Object.keys(files)).toEqual(["file-keep"]);
+      // Regression: trim used to reset version to 1, which would
+      // silently overwrite a concurrent editor's newer version.
+      expect(after.version).toBe(8);
+    });
+
+    it("rejects when confirmName does not match", async () => {
+      const drawing = await createDrawing(owner.id, { name: "My Drawing" });
+
+      const res = await agent
+        .post(`/drawings/${drawing.id}/trim`)
+        .set("User-Agent", userAgent)
+        .set(csrfHeaderName, csrfToken)
+        .set("Authorization", `Bearer ${ownerToken}`)
+        .send({ confirmName: "Wrong Name" });
+
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 404 when caller is not the owner", async () => {
+      const drawing = await createDrawing(owner.id);
+
+      const res = await agent
+        .post(`/drawings/${drawing.id}/trim`)
+        .set("User-Agent", userAgent)
+        .set(csrfHeaderName, csrfToken)
+        .set("Authorization", `Bearer ${otherToken}`)
+        .send({ confirmName: drawing.name });
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("DELETE /drawings/:id/files/orphans", () => {
+    it("removes the requested fileIds and their soft-deleted elements", async () => {
+      const drawing = await createDrawing(owner.id, {
+        name: "Orphan Cleanup",
+        elements: [
+          imageElement("el-active", "file-active"),
+          imageElement("el-deleted", "file-orphan", true),
+        ],
+        files: {
+          "file-active": fileEntry("file-active"),
+          "file-orphan": fileEntry("file-orphan"),
+        },
+        version: 3,
+      });
+
+      const res = await agent
+        .delete(`/drawings/${drawing.id}/files/orphans`)
+        .set("User-Agent", userAgent)
+        .set(csrfHeaderName, csrfToken)
+        .set("Authorization", `Bearer ${ownerToken}`)
+        .send({ confirmName: "Orphan Cleanup", fileIds: ["file-orphan"] });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ deleted: 1, errors: 0 });
+
+      const after = await prisma.drawing.findUniqueOrThrow({
+        where: { id: drawing.id },
+      });
+      const elements = JSON.parse(after.elements) as any[];
+      const files = JSON.parse(after.files) as Record<string, unknown>;
+      // file-orphan is gone from files; the soft-deleted element that
+      // referenced it is also gone, so it doesn't reappear in /diff.
+      expect(Object.keys(files)).toEqual(["file-active"]);
+      expect(elements.map((e) => e.id)).toEqual(["el-active"]);
+      // Version should bump so concurrent editors reload.
+      expect(after.version).toBe(4);
+    });
+
+    it("rejects deletion of fileIds still referenced by active elements", async () => {
+      const drawing = await createDrawing(owner.id, {
+        name: "Active Refs",
+        elements: [imageElement("el-active", "file-active")],
+        files: { "file-active": fileEntry("file-active") },
+      });
+
+      const res = await agent
+        .delete(`/drawings/${drawing.id}/files/orphans`)
+        .set("User-Agent", userAgent)
+        .set(csrfHeaderName, csrfToken)
+        .set("Authorization", `Bearer ${ownerToken}`)
+        .send({ confirmName: "Active Refs", fileIds: ["file-active"] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.blockedFileIds).toEqual(["file-active"]);
+    });
+
+    it("rejects an empty fileIds payload with 400", async () => {
+      const drawing = await createDrawing(owner.id);
+
+      const res = await agent
+        .delete(`/drawings/${drawing.id}/files/orphans`)
+        .set("User-Agent", userAgent)
+        .set(csrfHeaderName, csrfToken)
+        .set("Authorization", `Bearer ${ownerToken}`)
+        .send({ confirmName: drawing.name, fileIds: [] });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects when confirmName does not match", async () => {
+      const drawing = await createDrawing(owner.id, {
+        name: "Real",
+        files: { "file-x": fileEntry("file-x") },
+      });
+
+      const res = await agent
+        .delete(`/drawings/${drawing.id}/files/orphans`)
+        .set("User-Agent", userAgent)
+        .set(csrfHeaderName, csrfToken)
+        .set("Authorization", `Bearer ${ownerToken}`)
+        .send({ confirmName: "Wrong", fileIds: ["file-x"] });
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("GET /drawings/:id/files/diff", () => {
+    it("reports canvas vs sqlite presence per fileId", async () => {
+      const drawing = await createDrawing(owner.id, {
+        name: "Diff Me",
+        elements: [
+          imageElement("el-a", "file-a"),
+          imageElement("el-b", "file-b", true),
+        ],
+        files: {
+          "file-a": fileEntry("file-a"),
+          "file-b": fileEntry("file-b"),
+          "file-c": fileEntry("file-c"),
+        },
+      });
+
+      const res = await agent
+        .get(`/drawings/${drawing.id}/files/diff`)
+        .set("User-Agent", userAgent)
+        .set("Authorization", `Bearer ${ownerToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.summary).toMatchObject({
+        totalCanvasRefs: 2, // active only
+        totalSqliteFiles: 3,
+      });
+
+      type DiffRow = {
+        fileId: string;
+        inCanvas: boolean;
+        inCanvasActive: boolean;
+        inSqlite: boolean;
+        inS3: boolean;
+      };
+      const byId = new Map<string, DiffRow>();
+      for (const row of res.body.files as DiffRow[]) {
+        byId.set(row.fileId, row);
+      }
+      expect(byId.get("file-a")).toMatchObject({
+        inCanvas: true,
+        inCanvasActive: true,
+        inSqlite: true,
+        inS3: false,
+      });
+      expect(byId.get("file-b")).toMatchObject({
+        inCanvas: true,
+        inCanvasActive: false,
+        inSqlite: true,
+      });
+      expect(byId.get("file-c")).toMatchObject({
+        inCanvas: false,
+        inCanvasActive: false,
+        inSqlite: true,
+      });
+    });
+  });
+});

--- a/backend/src/__tests__/storage.integration.ts
+++ b/backend/src/__tests__/storage.integration.ts
@@ -321,8 +321,12 @@ describe("Storage management routes", () => {
         .set("Authorization", `Bearer ${ownerToken}`);
 
       expect(res.status).toBe(200);
+      // totalCanvasRefs counts every canvas-referenced fileId (active +
+      // soft-deleted), so file-a (active) and file-b (deleted) both
+      // contribute. activeCanvasRefs in the per-row payload below is
+      // what restricts to non-deleted refs.
       expect(res.body.summary).toMatchObject({
-        totalCanvasRefs: 2, // active only
+        totalCanvasRefs: 2,
         totalSqliteFiles: 3,
       });
 

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -7,6 +7,16 @@ import path from "path";
 
 dotenv.config();
 
+interface S3Config {
+  bucket: string | null;
+  region: string;
+  endpoint: string | null;
+  publicUrl: string | null;
+  forcePathStyle: boolean;
+  accessKeyId: string | null;
+  secretAccessKey: string | null;
+}
+
 interface Config {
   port: number;
   nodeEnv: string;
@@ -26,6 +36,7 @@ interface Config {
   enforceHttpsRedirect: boolean;
   bootstrapSetupCodeTtlMs: number;
   bootstrapSetupCodeMaxAttempts: number;
+  s3: S3Config;
 }
 
 export type AuthMode = "local" | "hybrid" | "oidc_enforced";
@@ -299,6 +310,16 @@ const resolveOidcConfig = (authMode: AuthMode): OidcConfig => {
 
 const resolvedAuthMode = parseAuthMode(process.env.AUTH_MODE);
 
+const resolveS3Config = (): S3Config => ({
+  bucket: getOptionalTrimmedEnv("S3_BUCKET"),
+  region: getOptionalEnv("S3_REGION", "us-east-1"),
+  endpoint: getOptionalTrimmedEnv("S3_ENDPOINT"),
+  publicUrl: getOptionalTrimmedEnv("S3_PUBLIC_URL"),
+  forcePathStyle: getOptionalEnv("S3_FORCE_PATH_STYLE", "false").toLowerCase() === "true",
+  accessKeyId: getOptionalTrimmedEnv("AWS_ACCESS_KEY_ID"),
+  secretAccessKey: getOptionalTrimmedEnv("AWS_SECRET_ACCESS_KEY"),
+});
+
 export const config: Config = {
   port: getRequiredEnvNumber("PORT", 8000),
   nodeEnv: getOptionalEnv("NODE_ENV", "development"),
@@ -327,6 +348,7 @@ export const config: Config = {
     "BOOTSTRAP_SETUP_CODE_MAX_ATTEMPTS",
     10,
   ),
+  s3: resolveS3Config(),
 };
 
 if (config.nodeEnv === "production") {

--- a/backend/src/fileProcessing.ts
+++ b/backend/src/fileProcessing.ts
@@ -3,14 +3,17 @@
  * This is the single interception point for all image uploads on the backend.
  */
 import type { PrismaClient } from "./generated/client";
-import { isS3Enabled, getS3Config, uploadBuffer, getPublicUrl } from "./s3";
-
-const FILE_KEY_PREFIX =
-  process.env.S3_KEY_PREFIX?.replace(/\/+$/, "") || "excalidash";
+import {
+  isS3Enabled,
+  getS3Config,
+  uploadBuffer,
+  getPublicUrl,
+  buildS3Key,
+} from "./s3";
 
 /**
  * Reject anything that could escape the per-user/per-drawing S3 prefix.
- * Same shape used by `/files/:fileId` validation.
+ * Same shape used by `/files/:drawingId/:fileId` validation.
  */
 const VALID_FILE_ID = /^[\w-]{1,200}$/;
 
@@ -84,19 +87,22 @@ export const processFilesForS3 = async (
     if (!decoded) return;
 
     const ext = MIME_TO_EXT[decoded.mimeType] ?? "bin";
-    const s3Key = `${FILE_KEY_PREFIX}/${userId}/${drawingId}/${fileId}.${ext}`;
+    const s3Key = buildS3Key(userId, drawingId, fileId, ext);
 
     await uploadBuffer(s3Key, decoded.buffer, decoded.mimeType);
 
-    // Determine the access URL for this file
+    // Drawing-scoped access URL: a file id alone would be ambiguous
+    // because the same content hash legitimately repeats across drawings.
     const accessUrl = cfg.publicUrl
       ? getPublicUrl(s3Key)
-      : `/api/files/${fileId}`;
+      : `/api/files/${drawingId}/${fileId}`;
 
-    // Persist the S3File record so private-bucket deployments can serve it
+    // Persist the S3File record so private-bucket deployments can serve it.
+    // Composite (drawingId, fileId) PK so re-uploading the same image into
+    // another drawing creates a separate row instead of overwriting.
     await prisma.s3File.upsert({
-      where: { id: fileId },
-      create: { id: fileId, userId, s3Key, mimeType: decoded.mimeType },
+      where: { drawingId_fileId: { drawingId, fileId } },
+      create: { drawingId, fileId, userId, s3Key, mimeType: decoded.mimeType },
       update: { s3Key, mimeType: decoded.mimeType },
     });
 

--- a/backend/src/fileProcessing.ts
+++ b/backend/src/fileProcessing.ts
@@ -8,6 +8,12 @@ import { isS3Enabled, getS3Config, uploadBuffer, getPublicUrl } from "./s3";
 const FILE_KEY_PREFIX =
   process.env.S3_KEY_PREFIX?.replace(/\/+$/, "") || "excalidash";
 
+/**
+ * Reject anything that could escape the per-user/per-drawing S3 prefix.
+ * Same shape used by `/files/:fileId` validation.
+ */
+const VALID_FILE_ID = /^[\w-]{1,200}$/;
+
 const MIME_TO_EXT: Record<string, string> = {
   "image/png": "png",
   "image/jpeg": "jpg",
@@ -59,6 +65,15 @@ export const processFilesForS3 = async (
   const result: Record<string, any> = { ...files };
 
   const uploadTasks = Object.entries(files).map(async ([fileId, file]) => {
+    if (!VALID_FILE_ID.test(fileId)) {
+      // Reject path-traversal candidates rather than silently uploading
+      // them under a forged S3 key. Drop from output so the bad entry
+      // never reaches the database either.
+      console.warn(`[s3] Skipping file with invalid id: ${JSON.stringify(fileId)}`);
+      delete result[fileId];
+      return;
+    }
+
     const dataURL: unknown = file?.dataURL;
     if (typeof dataURL !== "string" || !dataURL.startsWith("data:")) {
       // Not a base64 data URL — leave unchanged (https://, /api/files/, etc.)

--- a/backend/src/fileProcessing.ts
+++ b/backend/src/fileProcessing.ts
@@ -1,0 +1,94 @@
+/**
+ * Utility for scanning drawing file records and uploading base64 dataURLs to S3.
+ * This is the single interception point for all image uploads on the backend.
+ */
+import type { PrismaClient } from "./generated/client";
+import { isS3Enabled, getS3Config, uploadBuffer, getPublicUrl } from "./s3";
+
+const FILE_KEY_PREFIX =
+  process.env.S3_KEY_PREFIX?.replace(/\/+$/, "") || "excalidash";
+
+const MIME_TO_EXT: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/avif": "avif",
+  "image/bmp": "bmp",
+  "image/svg+xml": "svg",
+};
+
+/**
+ * Decode a base64 data URL into a Buffer and its MIME type.
+ * Returns null if the string is not a valid data URL.
+ */
+export const decodeDataURL = (
+  dataURL: string,
+): { buffer: Buffer; mimeType: string } | null => {
+  const match = dataURL.match(/^data:([^;]+);base64,(.+)$/s);
+  if (!match) return null;
+
+  const mimeType = match[1];
+  const base64 = match[2];
+
+  try {
+    const buffer = Buffer.from(base64, "base64");
+    return { buffer, mimeType };
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Scan a drawing's files record for base64 dataURLs, upload them to S3,
+ * and replace the dataURL with the S3 access URL.
+ *
+ * When S3 is disabled the files record is returned unchanged.
+ */
+export const processFilesForS3 = async (
+  files: Record<string, any>,
+  userId: string,
+  drawingId: string,
+  prisma: Pick<PrismaClient, "s3File">,
+): Promise<Record<string, any>> => {
+  if (!isS3Enabled()) {
+    return files;
+  }
+
+  const cfg = getS3Config()!;
+  const result: Record<string, any> = { ...files };
+
+  const uploadTasks = Object.entries(files).map(async ([fileId, file]) => {
+    const dataURL: unknown = file?.dataURL;
+    if (typeof dataURL !== "string" || !dataURL.startsWith("data:")) {
+      // Not a base64 data URL — leave unchanged (https://, /api/files/, etc.)
+      return;
+    }
+
+    const decoded = decodeDataURL(dataURL);
+    if (!decoded) return;
+
+    const ext = MIME_TO_EXT[decoded.mimeType] ?? "bin";
+    const s3Key = `${FILE_KEY_PREFIX}/${userId}/${drawingId}/${fileId}.${ext}`;
+
+    await uploadBuffer(s3Key, decoded.buffer, decoded.mimeType);
+
+    // Determine the access URL for this file
+    const accessUrl = cfg.publicUrl
+      ? getPublicUrl(s3Key)
+      : `/api/files/${fileId}`;
+
+    // Persist the S3File record so private-bucket deployments can serve it
+    await prisma.s3File.upsert({
+      where: { id: fileId },
+      create: { id: fileId, userId, s3Key, mimeType: decoded.mimeType },
+      update: { s3Key, mimeType: decoded.mimeType },
+    });
+
+    result[fileId] = { ...file, dataURL: accessUrl };
+  });
+
+  await Promise.all(uploadTasks);
+
+  return result;
+};

--- a/backend/src/fileProcessing.ts
+++ b/backend/src/fileProcessing.ts
@@ -113,3 +113,47 @@ export const processFilesForS3 = async (
 
   return result;
 };
+
+/**
+ * Rewrite an Excalidraw preview SVG so any base64 dataURL that has just
+ * been uploaded to S3 is replaced by the resulting S3 / redirect URL.
+ *
+ * The frontend generates the preview SVG from the canvas state at save
+ * time, *before* the round-trip to the backend uploads the files; the
+ * SVG embeds whatever dataURL the file currently has in `Drawing.files`.
+ * Without this rewrite, every save produces a megabyte-scale preview
+ * with the full image base64 inlined, even though the image itself is
+ * already in S3 (the diff between Drawing.files's processed entries
+ * and the preview field gets ever larger over time).
+ *
+ * Best-effort string substitution: works because the same dataURL
+ * string is character-identical in both `files[fileId].dataURL` and
+ * the preview SVG's `<image href="...">` attribute. If frontend
+ * encoding ever diverges, the worst case is the preview is left as-is.
+ */
+export const rewritePreviewForS3 = (
+  preview: unknown,
+  originalFiles: Record<string, any>,
+  processedFiles: Record<string, any>,
+): unknown => {
+  if (typeof preview !== "string" || preview.length === 0) {
+    return preview;
+  }
+  let rewritten = preview;
+  for (const fileId of Object.keys(processedFiles)) {
+    const original = originalFiles[fileId];
+    const processed = processedFiles[fileId];
+    if (
+      !original ||
+      !processed ||
+      typeof original.dataURL !== "string" ||
+      typeof processed.dataURL !== "string" ||
+      original.dataURL === processed.dataURL ||
+      !original.dataURL.startsWith("data:")
+    ) {
+      continue;
+    }
+    rewritten = rewritten.split(original.dataURL).join(processed.dataURL);
+  }
+  return rewritten;
+};

--- a/backend/src/fileProcessing.ts
+++ b/backend/src/fileProcessing.ts
@@ -67,7 +67,12 @@ export const processFilesForS3 = async (
   const cfg = getS3Config()!;
   const result: Record<string, any> = { ...files };
 
-  const uploadTasks = Object.entries(files).map(async ([fileId, file]) => {
+  // Bound parallel S3 PUTs. Without this, a paste of N images fires N
+  // parallel uploads, which can spike S3 connection pools and produce
+  // inconsistent partial-failure states on shaky networks.
+  const UPLOAD_CONCURRENCY = 8;
+
+  const processFile = async ([fileId, file]: [string, any]): Promise<void> => {
     if (!VALID_FILE_ID.test(fileId)) {
       // Reject path-traversal candidates rather than silently uploading
       // them under a forged S3 key. Drop from output so the bad entry
@@ -107,9 +112,14 @@ export const processFilesForS3 = async (
     });
 
     result[fileId] = { ...file, dataURL: accessUrl };
-  });
+  };
 
-  await Promise.all(uploadTasks);
+  const entries = Object.entries(files);
+  for (let i = 0; i < entries.length; i += UPLOAD_CONCURRENCY) {
+    await Promise.all(
+      entries.slice(i, i + UPLOAD_CONCURRENCY).map(processFile),
+    );
+  }
 
   return result;
 };

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -29,6 +29,7 @@ import { registerDashboardRoutes } from "./routes/dashboard";
 import { registerImportExportRoutes } from "./routes/importExport";
 import { registerSystemRoutes } from "./routes/system";
 import { registerFileRoutes } from "./routes/files";
+import { registerStorageRoutes } from "./routes/storage";
 import { prisma } from "./db/prisma";
 import { createDrawingsCacheStore } from "./server/drawingsCache";
 import { registerCsrfProtection } from "./server/csrf";
@@ -632,6 +633,8 @@ if (config.s3.bucket) {
 }
 
 registerFileRoutes(app, { prisma, requireAuth, optionalAuth, asyncHandler });
+
+registerStorageRoutes(app, { prisma, requireAuth, asyncHandler, parseJsonField });
 
 registerDashboardRoutes(app, {
   prisma,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -640,6 +640,7 @@ registerStorageRoutes(app, {
   asyncHandler,
   parseJsonField,
   invalidateDrawingsCache,
+  io,
 });
 
 registerDashboardRoutes(app, {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -618,6 +618,7 @@ if (config.s3.bucket) {
     region: config.s3.region,
     endpoint: config.s3.endpoint ?? undefined,
     publicUrl: config.s3.publicUrl ?? undefined,
+    forcePathStyle: config.s3.forcePathStyle,
     accessKeyId: config.s3.accessKeyId ?? undefined,
     secretAccessKey: config.s3.secretAccessKey ?? undefined,
   });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -631,7 +631,7 @@ if (config.s3.bucket) {
   console.log("[S3] Disabled — S3_BUCKET not configured. Images stored as base64 in SQLite.");
 }
 
-registerFileRoutes(app, { prisma, requireAuth, asyncHandler });
+registerFileRoutes(app, { prisma, requireAuth, optionalAuth, asyncHandler });
 
 registerDashboardRoutes(app, {
   prisma,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -28,6 +28,7 @@ import { logAuditEvent } from "./utils/audit";
 import { registerDashboardRoutes } from "./routes/dashboard";
 import { registerImportExportRoutes } from "./routes/importExport";
 import { registerSystemRoutes } from "./routes/system";
+import { registerFileRoutes } from "./routes/files";
 import { prisma } from "./db/prisma";
 import { createDrawingsCacheStore } from "./server/drawingsCache";
 import { registerCsrfProtection } from "./server/csrf";
@@ -37,6 +38,8 @@ import {
   getHttpsRedirectUrl,
 } from "./server/httpsRedirectPolicy";
 import { issueBootstrapSetupCodeIfRequired } from "./auth/bootstrapSetupCode";
+import { initS3 } from "./s3";
+import { processFilesForS3 } from "./fileProcessing";
 
 const backendRoot = path.resolve(__dirname, "../");
 console.log("Resolved DATABASE_URL:", process.env.DATABASE_URL);
@@ -608,6 +611,27 @@ registerSystemRoutes(app, {
   getBackendVersion,
 });
 
+// Initialise S3 when S3_BUCKET is configured.
+if (config.s3.bucket) {
+  initS3({
+    bucket: config.s3.bucket,
+    region: config.s3.region,
+    endpoint: config.s3.endpoint ?? undefined,
+    publicUrl: config.s3.publicUrl ?? undefined,
+    accessKeyId: config.s3.accessKeyId ?? undefined,
+    secretAccessKey: config.s3.secretAccessKey ?? undefined,
+  });
+  console.log(
+    `[S3] Enabled. Bucket: ${config.s3.bucket}, Region: ${config.s3.region}` +
+      (config.s3.endpoint ? `, Endpoint: ${config.s3.endpoint}` : "") +
+      (config.s3.publicUrl ? `, PublicURL: ${config.s3.publicUrl}` : " (private bucket — redirect mode)")
+  );
+} else {
+  console.log("[S3] Disabled — S3_BUCKET not configured. Images stored as base64 in SQLite.");
+}
+
+registerFileRoutes(app, { prisma, requireAuth, asyncHandler });
+
 registerDashboardRoutes(app, {
   prisma,
   requireAuth,
@@ -628,6 +652,8 @@ registerDashboardRoutes(app, {
   MAX_PAGE_SIZE,
   config,
   logAuditEvent,
+  processFilesForS3: (files, userId, drawingId) =>
+    processFilesForS3(files, userId, drawingId, prisma),
 });
 
 registerImportExportRoutes({

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -634,7 +634,13 @@ if (config.s3.bucket) {
 
 registerFileRoutes(app, { prisma, requireAuth, optionalAuth, asyncHandler });
 
-registerStorageRoutes(app, { prisma, requireAuth, asyncHandler, parseJsonField });
+registerStorageRoutes(app, {
+  prisma,
+  requireAuth,
+  asyncHandler,
+  parseJsonField,
+  invalidateDrawingsCache,
+});
 
 registerDashboardRoutes(app, {
   prisma,

--- a/backend/src/routes/dashboard/drawings.ts
+++ b/backend/src/routes/dashboard/drawings.ts
@@ -1,6 +1,10 @@
 import crypto from "crypto";
 import express from "express";
 import { Prisma } from "../../generated/client";
+import { isS3Enabled, listS3Objects, deleteS3Object } from "../../s3";
+
+const S3_FILE_KEY_PREFIX =
+  process.env.S3_KEY_PREFIX?.replace(/\/+$/, "") || "excalidash";
 import { DashboardRouteDeps, SortDirection, SortField } from "./types";
 import {
   getUserTrashCollectionId,
@@ -474,6 +478,46 @@ export const registerDrawingRoutes = (
     if (payload.elements !== undefined) data.elements = JSON.stringify(payload.elements);
     if (payload.appState !== undefined) data.appState = JSON.stringify(payload.appState);
     if (payload.files !== undefined) {
+      // Reject the upload upfront when the caller's expected version no
+      // longer matches reality. processFilesForS3 PUTs every base64 file
+      // straight to S3, which would otherwise leak as permanent orphans
+      // when the subsequent updateMany returns 0 rows on conflict.
+      if (isSceneUpdate && payload.version !== undefined) {
+        const latest = await prisma.drawing.findFirst({
+          where: { id },
+          select: { version: true },
+        });
+        if (!latest || latest.version !== payload.version) {
+          return res.status(409).json({
+            error: "Conflict",
+            code: "VERSION_CONFLICT",
+            message: "Drawing has changed since this editor state was loaded.",
+            currentVersion: latest?.version ?? null,
+          });
+        }
+      }
+
+      // Non-owner editors (link-share with edit permission, etc.) must
+      // not be able to add new file ids — they would write under the
+      // owner's S3 prefix and could be used to fill the owner's bucket.
+      // Existing fileIds may still appear (e.g. an unchanged scene save).
+      if (!isOwnerAccess(access)) {
+        const existingFiles = parseJsonField<Record<string, unknown>>(
+          existingDrawing.files,
+          {}
+        );
+        const existingIds = new Set(Object.keys(existingFiles));
+        for (const newId of Object.keys(payload.files)) {
+          if (!existingIds.has(newId)) {
+            return res.status(403).json({
+              error: "Forbidden",
+              message:
+                "Only the drawing owner can upload new images to this drawing.",
+            });
+          }
+        }
+      }
+
       const processedFiles = await processFilesForS3(
         payload.files as Record<string, any>,
         existingDrawing.userId,
@@ -596,6 +640,28 @@ export const registerDrawingRoutes = (
       return res.status(404).json({ error: "Drawing not found" });
     }
     invalidateDrawingsCache();
+
+    // Best-effort S3 cleanup so the bucket and the S3File rows don't grow
+    // unboundedly with deleted-drawing remnants. Failures are logged but
+    // not surfaced — the drawing is already gone.
+    if (isS3Enabled()) {
+      const s3Prefix = `${S3_FILE_KEY_PREFIX}/${req.user.id}/${id}/`;
+      try {
+        const objects = await listS3Objects(s3Prefix);
+        for (const obj of objects) {
+          try {
+            await deleteS3Object(obj.key);
+          } catch (err) {
+            console.error(`[drawings/delete] Failed to delete S3 object: ${obj.key}`, err);
+          }
+        }
+        await prisma.s3File.deleteMany({
+          where: { s3Key: { startsWith: s3Prefix } },
+        });
+      } catch (err) {
+        console.error(`[drawings/delete] S3 cleanup failed for drawing ${id}`, err);
+      }
+    }
 
     if (config.enableAuditLogging) {
       await logAuditEvent({

--- a/backend/src/routes/dashboard/drawings.ts
+++ b/backend/src/routes/dashboard/drawings.ts
@@ -8,6 +8,7 @@ import {
   copyS3Object,
   drawingS3Prefix,
 } from "../../s3";
+import { rewritePreviewForS3 } from "../../fileProcessing";
 import { DashboardRouteDeps, SortDirection, SortField } from "./types";
 import {
   getUserTrashCollectionId,
@@ -408,11 +409,20 @@ export const registerDrawingRoutes = (
     }
 
     const drawingId = crypto.randomUUID();
+    const originalFiles = (payload.files ?? {}) as Record<string, any>;
     const processedFiles = await processFilesForS3(
-      (payload.files ?? {}) as Record<string, any>,
+      originalFiles,
       req.user.id,
       drawingId
     );
+    // Rewrite the preview SVG so it points at the just-uploaded S3 URLs
+    // instead of inlining the megabyte-scale base64 dataURL the frontend
+    // generated before the upload completed.
+    const processedPreview = rewritePreviewForS3(
+      payload.preview ?? null,
+      originalFiles,
+      processedFiles,
+    ) as string | null | undefined;
 
     const newDrawing = await prisma.drawing.create({
       data: {
@@ -422,7 +432,7 @@ export const registerDrawingRoutes = (
         appState: JSON.stringify(payload.appState),
         userId: req.user.id,
         collectionId: targetCollectionId,
-        preview: payload.preview ?? null,
+        preview: processedPreview ?? null,
         files: JSON.stringify(processedFiles),
       },
     });
@@ -521,14 +531,27 @@ export const registerDrawingRoutes = (
         }
       }
 
+      const originalFiles = payload.files as Record<string, any>;
       const processedFiles = await processFilesForS3(
-        payload.files as Record<string, any>,
+        originalFiles,
         existingDrawing.userId,
         id
       );
       data.files = JSON.stringify(processedFiles);
+
+      if (payload.preview !== undefined) {
+        // Rewrite preview so the SVG embeds the new S3 URLs instead of
+        // the original base64 dataURLs (the frontend generates the
+        // preview before this round-trip uploads the files).
+        data.preview = rewritePreviewForS3(
+          payload.preview,
+          originalFiles,
+          processedFiles,
+        ) as string | null | undefined;
+      }
+    } else if (payload.preview !== undefined) {
+      data.preview = payload.preview;
     }
-    if (payload.preview !== undefined) data.preview = payload.preview;
 
     if (payload.collectionId !== undefined) {
       if (!isOwnerAccess(access)) {

--- a/backend/src/routes/dashboard/drawings.ts
+++ b/backend/src/routes/dashboard/drawings.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import express from "express";
 import { Prisma } from "../../generated/client";
 import { DashboardRouteDeps, SortDirection, SortField } from "./types";
@@ -40,6 +41,7 @@ export const registerDrawingRoutes = (
     MAX_PAGE_SIZE,
     config,
     logAuditEvent,
+    processFilesForS3,
   } = deps;
 
   const getRequestPrincipal = async (
@@ -398,15 +400,23 @@ export const registerDrawingRoutes = (
       await ensureTrashCollection(prisma, req.user.id);
     }
 
+    const drawingId = crypto.randomUUID();
+    const processedFiles = await processFilesForS3(
+      (payload.files ?? {}) as Record<string, any>,
+      req.user.id,
+      drawingId
+    );
+
     const newDrawing = await prisma.drawing.create({
       data: {
+        id: drawingId,
         name: drawingName,
         elements: JSON.stringify(payload.elements),
         appState: JSON.stringify(payload.appState),
         userId: req.user.id,
         collectionId: targetCollectionId,
         preview: payload.preview ?? null,
-        files: JSON.stringify(payload.files ?? {}),
+        files: JSON.stringify(processedFiles),
       },
     });
     invalidateDrawingsCache();
@@ -463,7 +473,14 @@ export const registerDrawingRoutes = (
     if (payload.name !== undefined) data.name = payload.name;
     if (payload.elements !== undefined) data.elements = JSON.stringify(payload.elements);
     if (payload.appState !== undefined) data.appState = JSON.stringify(payload.appState);
-    if (payload.files !== undefined) data.files = JSON.stringify(payload.files);
+    if (payload.files !== undefined) {
+      const processedFiles = await processFilesForS3(
+        payload.files as Record<string, any>,
+        existingDrawing.userId,
+        id
+      );
+      data.files = JSON.stringify(processedFiles);
+    }
     if (payload.preview !== undefined) data.preview = payload.preview;
 
     if (payload.collectionId !== undefined) {

--- a/backend/src/routes/dashboard/drawings.ts
+++ b/backend/src/routes/dashboard/drawings.ts
@@ -718,23 +718,13 @@ export const registerDrawingRoutes = (
       duplicatedCollectionId = getUserTrashCollectionId(req.user.id);
     }
 
-    const newDrawing = await prisma.drawing.create({
-      data: {
-        name: `${original.name} (Copy)`,
-        elements: original.elements,
-        appState: original.appState,
-        files: original.files,
-        userId: req.user.id,
-        collectionId: duplicatedCollectionId,
-        version: 1,
-      },
-    });
+    // Pre-allocate the new drawing id so we can copy S3 objects to its
+    // per-drawing prefix BEFORE inserting the row. If a copy fails we
+    // can roll back by deleting any objects already copied without ever
+    // exposing a half-broken duplicate to the caller.
+    const newDrawingId = crypto.randomUUID();
+    let duplicatedFilesJson = original.files;
 
-    // Copy S3 storage so the duplicate stops sharing objects with the
-    // original. Without this, deleting the original (which prunes the
-    // original's S3 prefix) would silently break every image in the
-    // duplicate's scene.
-    let duplicatedFilesJson = newDrawing.files;
     if (isS3Enabled()) {
       const sourceFiles = await prisma.s3File.findMany({
         where: { drawingId: original.id },
@@ -742,62 +732,100 @@ export const registerDrawingRoutes = (
 
       if (sourceFiles.length > 0) {
         const filesObj = parseJsonField<Record<string, any>>(
-          newDrawing.files,
+          original.files,
           {},
         );
+        const copiedKeys: string[] = [];
 
+        try {
+          for (const src of sourceFiles) {
+            const destKey = src.s3Key.replace(
+              `/${original.id}/`,
+              `/${newDrawingId}/`,
+            );
+            // Server-side copy. If this throws, the catch below cleans
+            // up everything we copied so far and surfaces an error
+            // instead of silently leaving the duplicate pointing at the
+            // original's S3 prefix.
+            await copyS3Object(src.s3Key, destKey, src.mimeType);
+            copiedKeys.push(destKey);
+
+            const file = filesObj[src.fileId];
+            if (file && typeof file.dataURL === "string") {
+              const next = file.dataURL
+                .replace(
+                  `/api/files/${original.id}/`,
+                  `/api/files/${newDrawingId}/`,
+                )
+                .replace(`/${original.id}/`, `/${newDrawingId}/`);
+              if (next !== file.dataURL) {
+                filesObj[src.fileId] = { ...file, dataURL: next };
+              }
+            }
+          }
+        } catch (err) {
+          console.error(
+            `[drawings/duplicate] S3 copy failed; rolling back ${copiedKeys.length} object(s)`,
+            err,
+          );
+          for (const key of copiedKeys) {
+            try {
+              await deleteS3Object(key);
+            } catch (deleteErr) {
+              console.error(
+                `[drawings/duplicate] rollback delete failed for ${key}`,
+                deleteErr,
+              );
+            }
+          }
+          return res.status(500).json({
+            error: "Failed to duplicate drawing",
+            message:
+              "Could not copy image storage for the new drawing; the original is unchanged.",
+          });
+        }
+
+        duplicatedFilesJson = JSON.stringify(filesObj);
+      }
+    }
+
+    const newDrawing = await prisma.$transaction(async (tx) => {
+      const created = await tx.drawing.create({
+        data: {
+          id: newDrawingId,
+          name: `${original.name} (Copy)`,
+          elements: original.elements,
+          appState: original.appState,
+          files: duplicatedFilesJson,
+          userId: req.user!.id,
+          collectionId: duplicatedCollectionId,
+          version: 1,
+        },
+      });
+
+      if (isS3Enabled()) {
+        const sourceFiles = await tx.s3File.findMany({
+          where: { drawingId: original.id },
+        });
         for (const src of sourceFiles) {
-          // Replace `/{originalId}/` with `/{newId}/` exactly once at
-          // the per-drawing folder boundary in the s3Key.
           const destKey = src.s3Key.replace(
             `/${original.id}/`,
-            `/${newDrawing.id}/`,
+            `/${newDrawingId}/`,
           );
-
-          try {
-            await copyS3Object(src.s3Key, destKey, src.mimeType);
-          } catch (err) {
-            console.error(
-              `[drawings/duplicate] Failed to copy ${src.s3Key} -> ${destKey}`,
-              err,
-            );
-            continue;
-          }
-
-          await prisma.s3File.create({
+          await tx.s3File.create({
             data: {
-              drawingId: newDrawing.id,
+              drawingId: newDrawingId,
               fileId: src.fileId,
-              userId: req.user.id,
+              userId: req.user!.id,
               s3Key: destKey,
               mimeType: src.mimeType,
             },
           });
-
-          // Rewrite dataURL so private-bucket redirects and public CDN
-          // links point at the new object instead of the original's.
-          const file = filesObj[src.fileId];
-          if (file && typeof file.dataURL === "string") {
-            const next = file.dataURL
-              .replace(
-                `/api/files/${original.id}/`,
-                `/api/files/${newDrawing.id}/`,
-              )
-              .replace(`/${original.id}/`, `/${newDrawing.id}/`);
-            if (next !== file.dataURL) {
-              filesObj[src.fileId] = { ...file, dataURL: next };
-            }
-          }
         }
-
-        const serialised = JSON.stringify(filesObj);
-        await prisma.drawing.update({
-          where: { id: newDrawing.id },
-          data: { files: serialised },
-        });
-        duplicatedFilesJson = serialised;
       }
-    }
+
+      return created;
+    });
 
     invalidateDrawingsCache();
 

--- a/backend/src/routes/dashboard/drawings.ts
+++ b/backend/src/routes/dashboard/drawings.ts
@@ -1,10 +1,13 @@
 import crypto from "crypto";
 import express from "express";
 import { Prisma } from "../../generated/client";
-import { isS3Enabled, listS3Objects, deleteS3Object } from "../../s3";
-
-const S3_FILE_KEY_PREFIX =
-  process.env.S3_KEY_PREFIX?.replace(/\/+$/, "") || "excalidash";
+import {
+  isS3Enabled,
+  listS3Objects,
+  deleteS3Object,
+  copyS3Object,
+  drawingS3Prefix,
+} from "../../s3";
 import { DashboardRouteDeps, SortDirection, SortField } from "./types";
 import {
   getUserTrashCollectionId,
@@ -642,10 +645,13 @@ export const registerDrawingRoutes = (
     invalidateDrawingsCache();
 
     // Best-effort S3 cleanup so the bucket and the S3File rows don't grow
-    // unboundedly with deleted-drawing remnants. Failures are logged but
-    // not surfaced — the drawing is already gone.
+    // unboundedly with deleted-drawing remnants. The S3File rows are
+    // (drawingId, fileId)-keyed and S3 objects sit under a per-drawing
+    // path, so this can never delete storage owned by another drawing
+    // (e.g. a duplicate that was made before this delete). Failures are
+    // logged but not surfaced — the drawing row is already gone.
     if (isS3Enabled()) {
-      const s3Prefix = `${S3_FILE_KEY_PREFIX}/${req.user.id}/${id}/`;
+      const s3Prefix = drawingS3Prefix(req.user.id, id);
       try {
         const objects = await listS3Objects(s3Prefix);
         for (const obj of objects) {
@@ -656,7 +662,7 @@ export const registerDrawingRoutes = (
           }
         }
         await prisma.s3File.deleteMany({
-          where: { s3Key: { startsWith: s3Prefix } },
+          where: { drawingId: id },
         });
       } catch (err) {
         console.error(`[drawings/delete] S3 cleanup failed for drawing ${id}`, err);
@@ -700,6 +706,76 @@ export const registerDrawingRoutes = (
         version: 1,
       },
     });
+
+    // Copy S3 storage so the duplicate stops sharing objects with the
+    // original. Without this, deleting the original (which prunes the
+    // original's S3 prefix) would silently break every image in the
+    // duplicate's scene.
+    let duplicatedFilesJson = newDrawing.files;
+    if (isS3Enabled()) {
+      const sourceFiles = await prisma.s3File.findMany({
+        where: { drawingId: original.id },
+      });
+
+      if (sourceFiles.length > 0) {
+        const filesObj = parseJsonField<Record<string, any>>(
+          newDrawing.files,
+          {},
+        );
+
+        for (const src of sourceFiles) {
+          // Replace `/{originalId}/` with `/{newId}/` exactly once at
+          // the per-drawing folder boundary in the s3Key.
+          const destKey = src.s3Key.replace(
+            `/${original.id}/`,
+            `/${newDrawing.id}/`,
+          );
+
+          try {
+            await copyS3Object(src.s3Key, destKey, src.mimeType);
+          } catch (err) {
+            console.error(
+              `[drawings/duplicate] Failed to copy ${src.s3Key} -> ${destKey}`,
+              err,
+            );
+            continue;
+          }
+
+          await prisma.s3File.create({
+            data: {
+              drawingId: newDrawing.id,
+              fileId: src.fileId,
+              userId: req.user.id,
+              s3Key: destKey,
+              mimeType: src.mimeType,
+            },
+          });
+
+          // Rewrite dataURL so private-bucket redirects and public CDN
+          // links point at the new object instead of the original's.
+          const file = filesObj[src.fileId];
+          if (file && typeof file.dataURL === "string") {
+            const next = file.dataURL
+              .replace(
+                `/api/files/${original.id}/`,
+                `/api/files/${newDrawing.id}/`,
+              )
+              .replace(`/${original.id}/`, `/${newDrawing.id}/`);
+            if (next !== file.dataURL) {
+              filesObj[src.fileId] = { ...file, dataURL: next };
+            }
+          }
+        }
+
+        const serialised = JSON.stringify(filesObj);
+        await prisma.drawing.update({
+          where: { id: newDrawing.id },
+          data: { files: serialised },
+        });
+        duplicatedFilesJson = serialised;
+      }
+    }
+
     invalidateDrawingsCache();
 
     return res.json({
@@ -707,7 +783,7 @@ export const registerDrawingRoutes = (
       collectionId: toPublicTrashCollectionId(newDrawing.collectionId, req.user.id),
       elements: parseJsonField(newDrawing.elements, []),
       appState: parseJsonField(newDrawing.appState, {}),
-      files: parseJsonField(newDrawing.files, {}),
+      files: parseJsonField(duplicatedFilesJson, {}),
     });
   }));
 

--- a/backend/src/routes/dashboard/types.ts
+++ b/backend/src/routes/dashboard/types.ts
@@ -53,4 +53,9 @@ export type DashboardRouteDeps = {
     enableAuditLogging: boolean;
   };
   logAuditEvent: LogAuditEvent;
+  processFilesForS3: (
+    files: Record<string, any>,
+    userId: string,
+    drawingId: string,
+  ) => Promise<Record<string, any>>;
 };

--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -1,46 +1,21 @@
 /**
  * S3 file routes:
- *   POST /files/upload-url  – issue a presigned S3 PUT URL for direct browser upload
- *   GET  /files/:fileId     – redirect to a presigned S3 GET URL (private-bucket mode)
- *   GET  /files/config      – report whether S3 is configured (for frontend feature detection)
+ *   GET  /files/config                  – report whether S3 is configured
+ *   GET  /files/:drawingId/:fileId      – redirect to a presigned S3 GET URL
+ *                                          (private-bucket mode)
  */
 import express from "express";
 import { PrismaClient } from "../generated/client";
 import {
   isS3Enabled,
-  getS3Config,
-  generatePresignedUploadUrl,
   generatePresignedDownloadUrl,
-  getPublicUrl,
 } from "../s3";
 
-const FILE_KEY_PREFIX = process.env.S3_KEY_PREFIX?.replace(/\/+$/, "") || "excalidash";
-const UPLOAD_EXPIRES_IN = 300;    // 5 minutes – enough for a browser PUT
 const DOWNLOAD_EXPIRES_IN = 3600; // 1 hour   – cached by browser
 
-const ALLOWED_MIME_TYPES = new Set([
-  "image/png",
-  "image/jpeg",
-  "image/gif",
-  "image/webp",
-  "image/avif",
-  "image/bmp",
-  "image/svg+xml",
-]);
-
-const MIME_TO_EXT: Record<string, string> = {
-  "image/png":     "png",
-  "image/jpeg":    "jpg",
-  "image/gif":     "gif",
-  "image/webp":    "webp",
-  "image/avif":    "avif",
-  "image/bmp":     "bmp",
-  "image/svg+xml": "svg",
-};
-
-/** Loose guard: fileId must be a safe, path-traversal-free identifier. */
-const isValidFileId = (fileId: unknown): fileId is string =>
-  typeof fileId === "string" && /^[\w-]{1,200}$/.test(fileId);
+/** Loose guard: drawingId / fileId must be safe, path-traversal-free identifiers. */
+const isValidIdSegment = (value: unknown): value is string =>
+  typeof value === "string" && /^[\w-]{1,200}$/.test(value);
 
 export type FileRouteDeps = {
   prisma: PrismaClient;
@@ -60,7 +35,7 @@ export const registerFileRoutes = (
   // ------------------------------------------------------------------
   // GET /files/config
   // Returns whether S3 is enabled so the frontend can decide whether to
-  // attempt a presigned upload or fall back to base64 storage.
+  // show storage management features.
   // ------------------------------------------------------------------
   app.get(
     "/files/config",
@@ -71,159 +46,63 @@ export const registerFileRoutes = (
   );
 
   // ------------------------------------------------------------------
-  // POST /files/upload-url
-  // Body: { fileId: string, mimeType: string, size?: number }
-  // Returns: { uploadUrl: string, accessUrl: string }
-  //   uploadUrl  – presigned S3 PUT URL; browser uploads directly here
-  //   accessUrl  – where the image will be accessible after upload:
-  //                  * full public URL  when S3_PUBLIC_URL is configured
-  //                  * /api/files/:fileId for private-bucket deployments
-  // ------------------------------------------------------------------
-  app.post(
-    "/files/upload-url",
-    requireAuth,
-    asyncHandler(async (req, res) => {
-      if (!isS3Enabled()) {
-        return res.status(501).json({ error: "S3 storage is not configured" });
-      }
-
-      const { fileId, drawingId, mimeType, size } = req.body as {
-        fileId: unknown;
-        drawingId: unknown;
-        mimeType: unknown;
-        size: unknown;
-      };
-
-      if (!isValidFileId(fileId)) {
-        return res.status(400).json({ error: "Invalid fileId" });
-      }
-
-      if (typeof drawingId !== "string" || drawingId.length === 0) {
-        return res.status(400).json({ error: "Invalid drawingId" });
-      }
-
-      if (typeof mimeType !== "string" || !ALLOWED_MIME_TYPES.has(mimeType)) {
-        return res.status(400).json({ error: "Unsupported or missing mimeType" });
-      }
-
-      const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
-      if (typeof size === "number" && size > MAX_FILE_SIZE) {
-        return res.status(400).json({ error: "File exceeds maximum allowed size (10 MB)" });
-      }
-
-      const userId = req.user!.id;
-      const ext = MIME_TO_EXT[mimeType] ?? "bin";
-      const s3Key = `${FILE_KEY_PREFIX}/${userId}/${drawingId}/${fileId}.${ext}`;
-
-      const uploadUrl = await generatePresignedUploadUrl(
-        s3Key,
-        mimeType,
-        UPLOAD_EXPIRES_IN
-      );
-
-      const cfg = getS3Config()!;
-      // Determine how the browser will load the image after upload.
-      const accessUrl = cfg.publicUrl
-        ? getPublicUrl(s3Key)
-        : `/api/files/${fileId}`;
-
-      // Persist the file record so the GET /files/:fileId endpoint can
-      // reconstruct the S3 key for private-bucket deployments.
-      await prisma.s3File.upsert({
-        where: { id: fileId },
-        create: { id: fileId, userId, s3Key, mimeType },
-        update: { s3Key, mimeType },
-      });
-
-      return res.json({ uploadUrl, accessUrl });
-    })
-  );
-
-  // ------------------------------------------------------------------
   // GET /files/:fileId
   // Issues a presigned GET URL and redirects the browser to S3.
   // Used only in private-bucket deployments where S3_PUBLIC_URL is not
   // set and the dataURL stored in the drawing is "/api/files/:fileId".
   // ------------------------------------------------------------------
   app.get(
-    "/files/:fileId",
+    "/files/:drawingId/:fileId",
     optionalAuth,
     asyncHandler(async (req, res) => {
       if (!isS3Enabled()) {
         return res.status(501).json({ error: "S3 storage is not configured" });
       }
 
-      const { fileId } = req.params;
-      if (!isValidFileId(fileId)) {
-        return res.status(400).json({ error: "Invalid fileId" });
+      const { drawingId, fileId } = req.params;
+      if (!isValidIdSegment(drawingId) || !isValidIdSegment(fileId)) {
+        return res.status(400).json({ error: "Invalid id segment" });
       }
 
-      const fileRecord = await prisma.s3File.findUnique({
-        where: { id: fileId },
+      // Drawing access decides authorisation; fall back to 404 on
+      // miss so we don't leak existence of a (drawing, fileId) pair.
+      const drawing = await prisma.drawing.findUnique({
+        where: { id: drawingId },
+        select: {
+          id: true,
+          userId: true,
+          permissions: { select: { granteeUserId: true } },
+          linkShares: {
+            where: {
+              revokedAt: null,
+              OR: [
+                { expiresAt: null },
+                { expiresAt: { gt: new Date() } },
+              ],
+            },
+            select: { id: true },
+          },
+        },
       });
-
-      if (!fileRecord) {
+      if (!drawing) {
         return res.status(404).json({ error: "File not found" });
       }
 
-      // Excalidraw fileIds are SHA-1 hashes of the file bytes — anyone
-      // holding the original image can compute the id, so we cannot
-      // treat the id as an unguessable capability. Authorise instead by
-      // proving access to a drawing that references this id.
-      const userId = req.user?.id ?? null;
-      const needle = `"${fileId}"`;
+      const callerUserId = req.user?.id ?? null;
+      const isOwner = callerUserId !== null && drawing.userId === callerUserId;
+      const isExplicitGrantee =
+        callerUserId !== null &&
+        drawing.permissions.some((p) => p.granteeUserId === callerUserId);
+      const hasActiveLinkShare = drawing.linkShares.length > 0;
 
-      // Owner of the upload always has access.
-      if (userId && fileRecord.userId === userId) {
-        const downloadUrl = await generatePresignedDownloadUrl(
-          fileRecord.s3Key,
-          DOWNLOAD_EXPIRES_IN
-        );
-        return res.redirect(302, downloadUrl);
+      if (!isOwner && !isExplicitGrantee && !hasActiveLinkShare) {
+        return res.status(404).json({ error: "File not found" });
       }
 
-      // Build the access predicate: a drawing referencing this fileId
-      // that the caller is allowed to view.
-      // - authenticated: own drawing, or one shared via DrawingPermission,
-      //   or one with an active link-share (anyone with the link can view)
-      // - anonymous: only drawings with an active link-share
-      const referencesFile = {
-        OR: [
-          { files: { contains: needle } },
-          { elements: { contains: needle } },
-        ],
-      } as const;
-
-      const activeLinkShare = {
-        linkShares: {
-          some: {
-            revokedAt: null,
-            OR: [
-              { expiresAt: null },
-              { expiresAt: { gt: new Date() } },
-            ],
-          },
-        },
-      } as const;
-
-      const orClauses: any[] = [
-        { ...referencesFile, ...activeLinkShare },
-      ];
-      if (userId) {
-        orClauses.push({ ...referencesFile, userId });
-        orClauses.push({
-          ...referencesFile,
-          permissions: { some: { granteeUserId: userId } },
-        });
-      }
-
-      const accessibleDrawing = await prisma.drawing.findFirst({
-        where: { OR: orClauses },
-        select: { id: true },
+      const fileRecord = await prisma.s3File.findUnique({
+        where: { drawingId_fileId: { drawingId, fileId } },
       });
-      if (!accessibleDrawing) {
-        // 404 (not 401/403) so we don't leak existence to anyone who
-        // happens to know a fileId.
+      if (!fileRecord) {
         return res.status(404).json({ error: "File not found" });
       }
 

--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -152,6 +152,11 @@ export const registerFileRoutes = (
         return res.status(501).json({ error: "S3 storage is not configured" });
       }
 
+      const userId = req.user?.id;
+      if (!userId) {
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+
       const { fileId } = req.params;
       if (!isValidFileId(fileId)) {
         return res.status(400).json({ error: "Invalid fileId" });
@@ -165,12 +170,39 @@ export const registerFileRoutes = (
         return res.status(404).json({ error: "File not found" });
       }
 
-      // The fileId (UUID) acts as an unguessable capability token.  Any
-      // authenticated user who knows the fileId — which is only possible
-      // if they have access to a drawing that contains it — may obtain a
-      // presigned download URL.  We do not restrict access to the owner
-      // here because shared drawings would otherwise be broken for
-      // collaborators (they cannot load images they don't own).
+      // Excalidraw fileIds are SHA-1 hashes of the file bytes — anyone
+      // holding the original image can compute the id, so we cannot
+      // treat the id as an unguessable capability. Authorise instead:
+      //   - the uploader can always read; or
+      //   - the caller has access to a drawing that references this id
+      //     (own drawing OR one shared with the caller).
+      if (fileRecord.userId !== userId) {
+        const needle = `"${fileId}"`;
+        const accessibleDrawing = await prisma.drawing.findFirst({
+          where: {
+            OR: [
+              {
+                userId,
+                OR: [
+                  { files: { contains: needle } },
+                  { elements: { contains: needle } },
+                ],
+              },
+              {
+                permissions: { some: { granteeUserId: userId } },
+                OR: [
+                  { files: { contains: needle } },
+                  { elements: { contains: needle } },
+                ],
+              },
+            ],
+          },
+          select: { id: true },
+        });
+        if (!accessibleDrawing) {
+          return res.status(404).json({ error: "File not found" });
+        }
+      }
 
       const downloadUrl = await generatePresignedDownloadUrl(
         fileRecord.s3Key,

--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -45,6 +45,7 @@ const isValidFileId = (fileId: unknown): fileId is string =>
 export type FileRouteDeps = {
   prisma: PrismaClient;
   requireAuth: express.RequestHandler;
+  optionalAuth: express.RequestHandler;
   asyncHandler: <T = void>(
     fn: (req: express.Request, res: express.Response, next: express.NextFunction) => Promise<T>
   ) => express.RequestHandler;
@@ -54,7 +55,7 @@ export const registerFileRoutes = (
   app: express.Express,
   deps: FileRouteDeps
 ): void => {
-  const { prisma, requireAuth, asyncHandler } = deps;
+  const { prisma, requireAuth, optionalAuth, asyncHandler } = deps;
 
   // ------------------------------------------------------------------
   // GET /files/config
@@ -146,15 +147,10 @@ export const registerFileRoutes = (
   // ------------------------------------------------------------------
   app.get(
     "/files/:fileId",
-    requireAuth,
+    optionalAuth,
     asyncHandler(async (req, res) => {
       if (!isS3Enabled()) {
         return res.status(501).json({ error: "S3 storage is not configured" });
-      }
-
-      const userId = req.user?.id;
-      if (!userId) {
-        return res.status(401).json({ error: "Unauthorized" });
       }
 
       const { fileId } = req.params;
@@ -172,36 +168,63 @@ export const registerFileRoutes = (
 
       // Excalidraw fileIds are SHA-1 hashes of the file bytes — anyone
       // holding the original image can compute the id, so we cannot
-      // treat the id as an unguessable capability. Authorise instead:
-      //   - the uploader can always read; or
-      //   - the caller has access to a drawing that references this id
-      //     (own drawing OR one shared with the caller).
-      if (fileRecord.userId !== userId) {
-        const needle = `"${fileId}"`;
-        const accessibleDrawing = await prisma.drawing.findFirst({
-          where: {
+      // treat the id as an unguessable capability. Authorise instead by
+      // proving access to a drawing that references this id.
+      const userId = req.user?.id ?? null;
+      const needle = `"${fileId}"`;
+
+      // Owner of the upload always has access.
+      if (userId && fileRecord.userId === userId) {
+        const downloadUrl = await generatePresignedDownloadUrl(
+          fileRecord.s3Key,
+          DOWNLOAD_EXPIRES_IN
+        );
+        return res.redirect(302, downloadUrl);
+      }
+
+      // Build the access predicate: a drawing referencing this fileId
+      // that the caller is allowed to view.
+      // - authenticated: own drawing, or one shared via DrawingPermission,
+      //   or one with an active link-share (anyone with the link can view)
+      // - anonymous: only drawings with an active link-share
+      const referencesFile = {
+        OR: [
+          { files: { contains: needle } },
+          { elements: { contains: needle } },
+        ],
+      } as const;
+
+      const activeLinkShare = {
+        linkShares: {
+          some: {
+            revokedAt: null,
             OR: [
-              {
-                userId,
-                OR: [
-                  { files: { contains: needle } },
-                  { elements: { contains: needle } },
-                ],
-              },
-              {
-                permissions: { some: { granteeUserId: userId } },
-                OR: [
-                  { files: { contains: needle } },
-                  { elements: { contains: needle } },
-                ],
-              },
+              { expiresAt: null },
+              { expiresAt: { gt: new Date() } },
             ],
           },
-          select: { id: true },
+        },
+      } as const;
+
+      const orClauses: any[] = [
+        { ...referencesFile, ...activeLinkShare },
+      ];
+      if (userId) {
+        orClauses.push({ ...referencesFile, userId });
+        orClauses.push({
+          ...referencesFile,
+          permissions: { some: { granteeUserId: userId } },
         });
-        if (!accessibleDrawing) {
-          return res.status(404).json({ error: "File not found" });
-        }
+      }
+
+      const accessibleDrawing = await prisma.drawing.findFirst({
+        where: { OR: orClauses },
+        select: { id: true },
+      });
+      if (!accessibleDrawing) {
+        // 404 (not 401/403) so we don't leak existence to anyone who
+        // happens to know a fileId.
+        return res.status(404).json({ error: "File not found" });
       }
 
       const downloadUrl = await generatePresignedDownloadUrl(

--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -1,0 +1,183 @@
+/**
+ * S3 file routes:
+ *   POST /files/upload-url  – issue a presigned S3 PUT URL for direct browser upload
+ *   GET  /files/:fileId     – redirect to a presigned S3 GET URL (private-bucket mode)
+ *   GET  /files/config      – report whether S3 is configured (for frontend feature detection)
+ */
+import express from "express";
+import { PrismaClient } from "../generated/client";
+import {
+  isS3Enabled,
+  getS3Config,
+  generatePresignedUploadUrl,
+  generatePresignedDownloadUrl,
+  getPublicUrl,
+} from "../s3";
+
+const FILE_KEY_PREFIX = process.env.S3_KEY_PREFIX?.replace(/\/+$/, "") || "excalidash";
+const UPLOAD_EXPIRES_IN = 300;    // 5 minutes – enough for a browser PUT
+const DOWNLOAD_EXPIRES_IN = 3600; // 1 hour   – cached by browser
+
+const ALLOWED_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/avif",
+  "image/bmp",
+  "image/svg+xml",
+]);
+
+const MIME_TO_EXT: Record<string, string> = {
+  "image/png":     "png",
+  "image/jpeg":    "jpg",
+  "image/gif":     "gif",
+  "image/webp":    "webp",
+  "image/avif":    "avif",
+  "image/bmp":     "bmp",
+  "image/svg+xml": "svg",
+};
+
+/** Loose guard: fileId must be a safe, path-traversal-free identifier. */
+const isValidFileId = (fileId: unknown): fileId is string =>
+  typeof fileId === "string" && /^[\w-]{1,200}$/.test(fileId);
+
+export type FileRouteDeps = {
+  prisma: PrismaClient;
+  requireAuth: express.RequestHandler;
+  asyncHandler: <T = void>(
+    fn: (req: express.Request, res: express.Response, next: express.NextFunction) => Promise<T>
+  ) => express.RequestHandler;
+};
+
+export const registerFileRoutes = (
+  app: express.Express,
+  deps: FileRouteDeps
+): void => {
+  const { prisma, requireAuth, asyncHandler } = deps;
+
+  // ------------------------------------------------------------------
+  // GET /files/config
+  // Returns whether S3 is enabled so the frontend can decide whether to
+  // attempt a presigned upload or fall back to base64 storage.
+  // ------------------------------------------------------------------
+  app.get(
+    "/files/config",
+    requireAuth,
+    asyncHandler(async (_req, res) => {
+      return res.json({ s3Enabled: isS3Enabled() });
+    })
+  );
+
+  // ------------------------------------------------------------------
+  // POST /files/upload-url
+  // Body: { fileId: string, mimeType: string, size?: number }
+  // Returns: { uploadUrl: string, accessUrl: string }
+  //   uploadUrl  – presigned S3 PUT URL; browser uploads directly here
+  //   accessUrl  – where the image will be accessible after upload:
+  //                  * full public URL  when S3_PUBLIC_URL is configured
+  //                  * /api/files/:fileId for private-bucket deployments
+  // ------------------------------------------------------------------
+  app.post(
+    "/files/upload-url",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!isS3Enabled()) {
+        return res.status(501).json({ error: "S3 storage is not configured" });
+      }
+
+      const { fileId, drawingId, mimeType, size } = req.body as {
+        fileId: unknown;
+        drawingId: unknown;
+        mimeType: unknown;
+        size: unknown;
+      };
+
+      if (!isValidFileId(fileId)) {
+        return res.status(400).json({ error: "Invalid fileId" });
+      }
+
+      if (typeof drawingId !== "string" || drawingId.length === 0) {
+        return res.status(400).json({ error: "Invalid drawingId" });
+      }
+
+      if (typeof mimeType !== "string" || !ALLOWED_MIME_TYPES.has(mimeType)) {
+        return res.status(400).json({ error: "Unsupported or missing mimeType" });
+      }
+
+      const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+      if (typeof size === "number" && size > MAX_FILE_SIZE) {
+        return res.status(400).json({ error: "File exceeds maximum allowed size (10 MB)" });
+      }
+
+      const userId = req.user!.id;
+      const ext = MIME_TO_EXT[mimeType] ?? "bin";
+      const s3Key = `${FILE_KEY_PREFIX}/${userId}/${drawingId}/${fileId}.${ext}`;
+
+      const uploadUrl = await generatePresignedUploadUrl(
+        s3Key,
+        mimeType,
+        UPLOAD_EXPIRES_IN
+      );
+
+      const cfg = getS3Config()!;
+      // Determine how the browser will load the image after upload.
+      const accessUrl = cfg.publicUrl
+        ? getPublicUrl(s3Key)
+        : `/api/files/${fileId}`;
+
+      // Persist the file record so the GET /files/:fileId endpoint can
+      // reconstruct the S3 key for private-bucket deployments.
+      await prisma.s3File.upsert({
+        where: { id: fileId },
+        create: { id: fileId, userId, s3Key, mimeType },
+        update: { s3Key, mimeType },
+      });
+
+      return res.json({ uploadUrl, accessUrl });
+    })
+  );
+
+  // ------------------------------------------------------------------
+  // GET /files/:fileId
+  // Issues a presigned GET URL and redirects the browser to S3.
+  // Used only in private-bucket deployments where S3_PUBLIC_URL is not
+  // set and the dataURL stored in the drawing is "/api/files/:fileId".
+  // ------------------------------------------------------------------
+  app.get(
+    "/files/:fileId",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!isS3Enabled()) {
+        return res.status(501).json({ error: "S3 storage is not configured" });
+      }
+
+      const { fileId } = req.params;
+      if (!isValidFileId(fileId)) {
+        return res.status(400).json({ error: "Invalid fileId" });
+      }
+
+      const fileRecord = await prisma.s3File.findUnique({
+        where: { id: fileId },
+      });
+
+      if (!fileRecord) {
+        return res.status(404).json({ error: "File not found" });
+      }
+
+      // The fileId (UUID) acts as an unguessable capability token.  Any
+      // authenticated user who knows the fileId — which is only possible
+      // if they have access to a drawing that contains it — may obtain a
+      // presigned download URL.  We do not restrict access to the owner
+      // here because shared drawings would otherwise be broken for
+      // collaborators (they cannot load images they don't own).
+
+      const downloadUrl = await generatePresignedDownloadUrl(
+        fileRecord.s3Key,
+        DOWNLOAD_EXPIRES_IN
+      );
+
+      return res.redirect(302, downloadUrl);
+    })
+  );
+};

--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -46,10 +46,11 @@ export const registerFileRoutes = (
   );
 
   // ------------------------------------------------------------------
-  // GET /files/:fileId
+  // GET /files/:drawingId/:fileId
   // Issues a presigned GET URL and redirects the browser to S3.
   // Used only in private-bucket deployments where S3_PUBLIC_URL is not
-  // set and the dataURL stored in the drawing is "/api/files/:fileId".
+  // set and the dataURL stored in the drawing is
+  // "/api/files/:drawingId/:fileId".
   // ------------------------------------------------------------------
   app.get(
     "/files/:drawingId/:fileId",

--- a/backend/src/routes/importExport/excalidashImportRoutes.ts
+++ b/backend/src/routes/importExport/excalidashImportRoutes.ts
@@ -12,6 +12,7 @@ import {
   getUserTrashCollectionId,
   sanitizeDrawingData,
 } from "./shared";
+import { processFilesForS3 } from "../../fileProcessing";
 
 const isSafeMulterTempFilename = (value: string): boolean => /^[a-f0-9]{32}$/.test(value);
 
@@ -334,6 +335,17 @@ export const registerExcalidashImportRoutes = (deps: RegisterImportExportDeps) =
         throw error;
       }
 
+      // Process files for S3 upload before entering the transaction
+      const processedFilesMap = new Map<number, Record<string, any>>();
+      for (let i = 0; i < preparedDrawings.length; i++) {
+        const prepared = preparedDrawings[i];
+        const files = prepared.sanitized.files || {};
+        processedFilesMap.set(
+          i,
+          await processFilesForS3(files, req.user!.id, prepared.id, prisma),
+        );
+      }
+
       const result = await prisma.$transaction(async (tx) => {
         const trashCollectionId = getUserTrashCollectionId(req.user!.id);
         const collectionIdMap = new Map<string, string>();
@@ -390,7 +402,9 @@ export const registerExcalidashImportRoutes = (deps: RegisterImportExportDeps) =
           return collectionIdMap.get(collectionId) || null;
         };
 
-        for (const prepared of preparedDrawings) {
+        for (let i = 0; i < preparedDrawings.length; i++) {
+          const prepared = preparedDrawings[i];
+          const processedFiles = processedFilesMap.get(i) ?? {};
           const targetCollectionId = resolveCollectionId(prepared.collectionId);
           const existing = await tx.drawing.findUnique({ where: { id: prepared.id } });
           if (!existing) {
@@ -400,7 +414,7 @@ export const registerExcalidashImportRoutes = (deps: RegisterImportExportDeps) =
                 name: prepared.name,
                 elements: JSON.stringify(prepared.sanitized.elements),
                 appState: JSON.stringify(prepared.sanitized.appState),
-                files: JSON.stringify(prepared.sanitized.files || {}),
+                files: JSON.stringify(processedFiles),
                 preview: prepared.sanitized.preview ?? null,
                 version: prepared.version ?? 1,
                 userId: req.user!.id,
@@ -418,7 +432,7 @@ export const registerExcalidashImportRoutes = (deps: RegisterImportExportDeps) =
                 name: prepared.name,
                 elements: JSON.stringify(prepared.sanitized.elements),
                 appState: JSON.stringify(prepared.sanitized.appState),
-                files: JSON.stringify(prepared.sanitized.files || {}),
+                files: JSON.stringify(processedFiles),
                 preview: prepared.sanitized.preview ?? null,
                 version: prepared.version ?? existing.version,
                 collectionId: targetCollectionId,
@@ -435,7 +449,7 @@ export const registerExcalidashImportRoutes = (deps: RegisterImportExportDeps) =
               name: prepared.name,
               elements: JSON.stringify(prepared.sanitized.elements),
               appState: JSON.stringify(prepared.sanitized.appState),
-              files: JSON.stringify(prepared.sanitized.files || {}),
+              files: JSON.stringify(processedFiles),
               preview: prepared.sanitized.preview ?? null,
               version: prepared.version ?? 1,
               userId: req.user!.id,

--- a/backend/src/routes/importExport/excalidashImportRoutes.ts
+++ b/backend/src/routes/importExport/excalidashImportRoutes.ts
@@ -335,15 +335,44 @@ export const registerExcalidashImportRoutes = (deps: RegisterImportExportDeps) =
         throw error;
       }
 
-      // Process files for S3 upload before entering the transaction
-      const processedFilesMap = new Map<number, Record<string, any>>();
+      // Resolve the final drawing id used for each prepared drawing
+      // BEFORE uploading. If the manifest id collides with a drawing
+      // owned by someone else, we will write under a fresh UUID inside
+      // the transaction — and S3 keys must match that final id, otherwise
+      // the uploaded objects become permanent orphans.
+      const finalDrawingIdMap = new Map<number, string>();
       for (let i = 0; i < preparedDrawings.length; i++) {
         const prepared = preparedDrawings[i];
-        const files = prepared.sanitized.files || {};
-        processedFilesMap.set(
-          i,
-          await processFilesForS3(files, req.user!.id, prepared.id, prisma),
-        );
+        const existing = await prisma.drawing.findUnique({
+          where: { id: prepared.id },
+          select: { userId: true },
+        });
+        const finalId =
+          existing && existing.userId !== req.user!.id ? uuidv4() : prepared.id;
+        finalDrawingIdMap.set(i, finalId);
+      }
+
+      // Process files for S3 upload before entering the transaction.
+      // Bounded concurrency keeps thousands-of-drawings imports from
+      // saturating S3 sockets or stalling the request to a reverse-proxy
+      // timeout.
+      const S3_UPLOAD_CONCURRENCY = 8;
+      const processedFilesMap = new Map<number, Record<string, any>>();
+      for (let start = 0; start < preparedDrawings.length; start += S3_UPLOAD_CONCURRENCY) {
+        const batch = preparedDrawings
+          .slice(start, start + S3_UPLOAD_CONCURRENCY)
+          .map((prepared, offset) => {
+            const i = start + offset;
+            const files = prepared.sanitized.files || {};
+            const finalId = finalDrawingIdMap.get(i)!;
+            return processFilesForS3(files, req.user!.id, finalId, prisma).then(
+              (processed) => ({ i, processed })
+            );
+          });
+        const results = await Promise.all(batch);
+        for (const { i, processed } of results) {
+          processedFilesMap.set(i, processed);
+        }
       }
 
       const result = await prisma.$transaction(async (tx) => {
@@ -407,10 +436,15 @@ export const registerExcalidashImportRoutes = (deps: RegisterImportExportDeps) =
           const processedFiles = processedFilesMap.get(i) ?? {};
           const targetCollectionId = resolveCollectionId(prepared.collectionId);
           const existing = await tx.drawing.findUnique({ where: { id: prepared.id } });
+          // Reuse the id we committed to before the S3 upload. If the
+          // pre-upload check disagrees with the in-transaction state
+          // (race), we still write under finalId so the file path
+          // matches what was uploaded.
+          const finalId = finalDrawingIdMap.get(i) ?? prepared.id;
           if (!existing) {
             await tx.drawing.create({
               data: {
-                id: prepared.id,
+                id: finalId,
                 name: prepared.name,
                 elements: JSON.stringify(prepared.sanitized.elements),
                 appState: JSON.stringify(prepared.sanitized.appState),
@@ -442,10 +476,9 @@ export const registerExcalidashImportRoutes = (deps: RegisterImportExportDeps) =
             continue;
           }
 
-          const newId = uuidv4();
           await tx.drawing.create({
             data: {
-              id: newId,
+              id: finalId,
               name: prepared.name,
               elements: JSON.stringify(prepared.sanitized.elements),
               appState: JSON.stringify(prepared.sanitized.appState),

--- a/backend/src/routes/importExport/excalidashImportRoutes.ts
+++ b/backend/src/routes/importExport/excalidashImportRoutes.ts
@@ -476,9 +476,27 @@ export const registerExcalidashImportRoutes = (deps: RegisterImportExportDeps) =
             continue;
           }
 
+          // Race-safe id selection inside the transaction. The pre-upload
+          // check (which sets finalDrawingIdMap) may have decided
+          // finalId === prepared.id because no conflict was visible at
+          // that time, but a conflict may have appeared since. If the
+          // tx-time `existing` is owned by someone else AND finalId still
+          // equals prepared.id, regenerate a fresh id rather than letting
+          // tx.drawing.create hit a unique-constraint error and abort the
+          // whole import. The S3 objects we uploaded sit under the
+          // prepared.id path; they become orphans the storage tools can
+          // sweep up.
+          const createId = finalId === prepared.id ? uuidv4() : finalId;
+          if (createId !== finalId) {
+            console.warn(
+              `[import/excalidash] race conflict on drawing ${prepared.id}; ` +
+                `creating under ${createId}; S3 objects keyed under ` +
+                `${prepared.id} are now orphans`,
+            );
+          }
           await tx.drawing.create({
             data: {
-              id: finalId,
+              id: createId,
               name: prepared.name,
               elements: JSON.stringify(prepared.sanitized.elements),
               appState: JSON.stringify(prepared.sanitized.appState),

--- a/backend/src/routes/importExport/legacySqliteImportRoutes.ts
+++ b/backend/src/routes/importExport/legacySqliteImportRoutes.ts
@@ -12,6 +12,7 @@ import {
   resolveSafeUploadedFilePath,
   sanitizeDrawingData,
 } from "./shared";
+import { processFilesForS3 } from "../../fileProcessing";
 
 export const registerLegacySqliteImportRoutes = (deps: RegisterImportExportDeps) => {
   const {
@@ -257,6 +258,20 @@ export const registerLegacySqliteImportRoutes = (deps: RegisterImportExportDeps)
           });
         }
 
+        // Process files for S3 upload before entering the transaction
+        const processedFilesMap = new Map<number, Record<string, any>>();
+        for (let i = 0; i < preparedDrawings.length; i++) {
+          const d = preparedDrawings[i];
+          const files = d.sanitized.files || {};
+          const drawingIdForS3 = d.importedId || uuidv4();
+          // Store generated ID so the transaction can reuse it
+          if (!d.importedId) d.importedId = drawingIdForS3;
+          processedFilesMap.set(
+            i,
+            await processFilesForS3(files, req.user!.id, drawingIdForS3, prisma),
+          );
+        }
+
         const result = await prisma.$transaction(async (tx) => {
           const trashCollectionId = getUserTrashCollectionId(req.user!.id);
           const hasTrash = importedDrawings.some((d) => String(d.collectionId || "") === "trash");
@@ -330,7 +345,9 @@ export const registerLegacySqliteImportRoutes = (deps: RegisterImportExportDeps)
             return null;
           };
 
-          for (const d of preparedDrawings) {
+          for (let i = 0; i < preparedDrawings.length; i++) {
+            const d = preparedDrawings[i];
+            const processedFiles = processedFilesMap.get(i) ?? {};
             const resolvedCollectionId = resolveImportedCollectionId(d.collectionIdRaw, d.collectionNameRaw);
             const existing = d.importedId ? await tx.drawing.findUnique({ where: { id: d.importedId } }) : null;
 
@@ -342,7 +359,7 @@ export const registerLegacySqliteImportRoutes = (deps: RegisterImportExportDeps)
                   name: d.name,
                   elements: JSON.stringify(d.sanitized.elements),
                   appState: JSON.stringify(d.sanitized.appState),
-                  files: JSON.stringify(d.sanitized.files || {}),
+                  files: JSON.stringify(processedFiles),
                   preview: d.sanitized.preview ?? null,
                   version: Number.isFinite(Number(d.versionRaw)) ? Number(d.versionRaw) : 1,
                   userId: req.user!.id,
@@ -360,7 +377,7 @@ export const registerLegacySqliteImportRoutes = (deps: RegisterImportExportDeps)
                   name: d.name,
                   elements: JSON.stringify(d.sanitized.elements),
                   appState: JSON.stringify(d.sanitized.appState),
-                  files: JSON.stringify(d.sanitized.files || {}),
+                  files: JSON.stringify(processedFiles),
                   preview: d.sanitized.preview ?? null,
                   version: Number.isFinite(Number(d.versionRaw)) ? Number(d.versionRaw) : existing.version,
                   collectionId: resolvedCollectionId ?? null,
@@ -377,7 +394,7 @@ export const registerLegacySqliteImportRoutes = (deps: RegisterImportExportDeps)
                 name: d.name,
                 elements: JSON.stringify(d.sanitized.elements),
                 appState: JSON.stringify(d.sanitized.appState),
-                files: JSON.stringify(d.sanitized.files || {}),
+                files: JSON.stringify(processedFiles),
                 preview: d.sanitized.preview ?? null,
                 version: Number.isFinite(Number(d.versionRaw)) ? Number(d.versionRaw) : 1,
                 userId: req.user!.id,

--- a/backend/src/routes/importExport/legacySqliteImportRoutes.ts
+++ b/backend/src/routes/importExport/legacySqliteImportRoutes.ts
@@ -258,18 +258,52 @@ export const registerLegacySqliteImportRoutes = (deps: RegisterImportExportDeps)
           });
         }
 
-        // Process files for S3 upload before entering the transaction
-        const processedFilesMap = new Map<number, Record<string, any>>();
+        // Resolve final drawing id BEFORE uploading. Three cases:
+        //  1) no importedId: generate UUID, use it for both S3 and DB.
+        //  2) importedId conflicts with another user's drawing: generate
+        //     UUID; the in-transaction conflict path will reuse it.
+        //  3) otherwise: keep importedId.
+        // Without this, a conflict (case 2) would upload to S3 under
+        // importedId but write the row under a fresh uuidv4(), leaving
+        // permanent S3 orphans.
+        const finalDrawingIdMap = new Map<number, string>();
         for (let i = 0; i < preparedDrawings.length; i++) {
           const d = preparedDrawings[i];
-          const files = d.sanitized.files || {};
-          const drawingIdForS3 = d.importedId || uuidv4();
-          // Store generated ID so the transaction can reuse it
-          if (!d.importedId) d.importedId = drawingIdForS3;
-          processedFilesMap.set(
-            i,
-            await processFilesForS3(files, req.user!.id, drawingIdForS3, prisma),
-          );
+          let finalId: string;
+          if (!d.importedId) {
+            finalId = uuidv4();
+            d.importedId = finalId;
+          } else {
+            const existing = await prisma.drawing.findUnique({
+              where: { id: d.importedId },
+              select: { userId: true },
+            });
+            finalId =
+              existing && existing.userId !== req.user!.id
+                ? uuidv4()
+                : d.importedId;
+          }
+          finalDrawingIdMap.set(i, finalId);
+        }
+
+        // Bounded concurrency to avoid stalling on large imports.
+        const S3_UPLOAD_CONCURRENCY = 8;
+        const processedFilesMap = new Map<number, Record<string, any>>();
+        for (let start = 0; start < preparedDrawings.length; start += S3_UPLOAD_CONCURRENCY) {
+          const batch = preparedDrawings
+            .slice(start, start + S3_UPLOAD_CONCURRENCY)
+            .map((d, offset) => {
+              const i = start + offset;
+              const files = d.sanitized.files || {};
+              const finalId = finalDrawingIdMap.get(i)!;
+              return processFilesForS3(files, req.user!.id, finalId, prisma).then(
+                (processed) => ({ i, processed })
+              );
+            });
+          const results = await Promise.all(batch);
+          for (const { i, processed } of results) {
+            processedFilesMap.set(i, processed);
+          }
         }
 
         const result = await prisma.$transaction(async (tx) => {
@@ -350,12 +384,14 @@ export const registerLegacySqliteImportRoutes = (deps: RegisterImportExportDeps)
             const processedFiles = processedFilesMap.get(i) ?? {};
             const resolvedCollectionId = resolveImportedCollectionId(d.collectionIdRaw, d.collectionNameRaw);
             const existing = d.importedId ? await tx.drawing.findUnique({ where: { id: d.importedId } }) : null;
+            // Always use the id we committed to before the S3 upload, so
+            // the row's S3 keys point to objects that actually exist.
+            const finalId = finalDrawingIdMap.get(i) ?? d.importedId ?? uuidv4();
 
             if (!existing) {
-              const idToUse = d.importedId || uuidv4();
               await tx.drawing.create({
                 data: {
-                  id: idToUse,
+                  id: finalId,
                   name: d.name,
                   elements: JSON.stringify(d.sanitized.elements),
                   appState: JSON.stringify(d.sanitized.appState),
@@ -387,10 +423,9 @@ export const registerLegacySqliteImportRoutes = (deps: RegisterImportExportDeps)
               continue;
             }
 
-            const newId = uuidv4();
             await tx.drawing.create({
               data: {
-                id: newId,
+                id: finalId,
                 name: d.name,
                 elements: JSON.stringify(d.sanitized.elements),
                 appState: JSON.stringify(d.sanitized.appState),

--- a/backend/src/routes/importExport/legacySqliteImportRoutes.ts
+++ b/backend/src/routes/importExport/legacySqliteImportRoutes.ts
@@ -423,9 +423,25 @@ export const registerLegacySqliteImportRoutes = (deps: RegisterImportExportDeps)
               continue;
             }
 
+            // Race-safe id: the pre-upload finalId may have been kept as
+            // d.importedId because no conflict was visible at the time;
+            // a conflict that appeared since this point would otherwise
+            // explode the entire transaction with a unique constraint
+            // error. If finalId would collide with the now-existing row,
+            // generate a fresh id; the S3 objects under the original id
+            // become orphans the storage tools can sweep up later.
+            const createId =
+              finalId === d.importedId ? uuidv4() : finalId;
+            if (createId !== finalId) {
+              console.warn(
+                `[import/legacy] race conflict on drawing ${d.importedId}; ` +
+                  `creating under ${createId}; S3 objects keyed under ` +
+                  `${d.importedId} are now orphans`,
+              );
+            }
             await tx.drawing.create({
               data: {
-                id: finalId,
+                id: createId,
                 name: d.name,
                 elements: JSON.stringify(d.sanitized.elements),
                 appState: JSON.stringify(d.sanitized.appState),

--- a/backend/src/routes/storage.ts
+++ b/backend/src/routes/storage.ts
@@ -244,13 +244,14 @@ export const registerStorageRoutes = (
         }
       }
 
-      // 7. Update drawing
+      // 7. Update drawing — bump version so concurrent editors get a VERSION_CONFLICT
+      // and reload, instead of having their newer version silently overwritten.
       await prisma.drawing.update({
         where: { id },
         data: {
           elements: JSON.stringify(activeElements),
           files: JSON.stringify(cleanedFiles),
-          version: 1,
+          version: { increment: 1 },
         },
       });
       invalidateDrawingsCache();

--- a/backend/src/routes/storage.ts
+++ b/backend/src/routes/storage.ts
@@ -7,10 +7,12 @@
 import express from "express";
 import type { Server as SocketIoServer } from "socket.io";
 import { PrismaClient } from "../generated/client";
-import { isS3Enabled, deleteS3Object, listS3Objects } from "../s3";
-
-const FILE_KEY_PREFIX =
-  process.env.S3_KEY_PREFIX?.replace(/\/+$/, "") || "excalidash";
+import {
+  isS3Enabled,
+  deleteS3Object,
+  listS3Objects,
+  drawingS3Prefix,
+} from "../s3";
 
 export type StorageRouteDeps = {
   prisma: PrismaClient;
@@ -25,44 +27,6 @@ export type StorageRouteDeps = {
   parseJsonField: <T>(rawValue: string | null | undefined, fallback: T) => T;
   invalidateDrawingsCache: () => void;
   io: SocketIoServer;
-};
-
-/**
- * Returns the subset of fileIds still referenced by a drawing OTHER than
- * `excludeDrawingId` and owned by `userId`. Those files must NOT be
- * deleted from S3 / S3File when trimming this drawing.
- *
- * Uses a substring check on the JSON columns: fileIds are randomly
- * generated identifiers (UUID/SHA-1), so false positives are negligible
- * compared to the cost of parsing every drawing's full JSON.
- */
-const findFileIdsStillReferencedElsewhere = async (
-  prisma: PrismaClient,
-  userId: string,
-  excludeDrawingId: string,
-  fileIds: string[]
-): Promise<Set<string>> => {
-  const stillReferenced = new Set<string>();
-  if (fileIds.length === 0) return stillReferenced;
-
-  for (const fileId of fileIds) {
-    // Wrap with quotes so we don't match a longer id that contains this
-    // one as a substring (`abc123` shouldn't match `abc1234`).
-    const needle = `"${fileId}"`;
-    const other = await prisma.drawing.findFirst({
-      where: {
-        userId,
-        id: { not: excludeDrawingId },
-        OR: [
-          { files: { contains: needle } },
-          { elements: { contains: needle } },
-        ],
-      },
-      select: { id: true },
-    });
-    if (other) stillReferenced.add(fileId);
-  }
-  return stillReferenced;
 };
 
 /**
@@ -169,64 +133,44 @@ export const registerStorageRoutes = (
       const filesRemoved = originalFileCount - Object.keys(cleanedFiles).length;
 
       // 6. S3 cleanup
+      //
+      // S3File is keyed (drawingId, fileId) and S3 objects sit under a
+      // per-drawing path, so this drawing's storage is independent from
+      // every other drawing's — no cross-drawing reference check needed.
+      // Duplicates are made by copying objects into the new drawingId
+      // path (see drawings.ts /duplicate), so deleting the original
+      // does not strand a sibling.
       let s3ObjectsDeleted = 0;
       let s3DeleteErrors = 0;
 
       if (isS3Enabled()) {
-        const s3Prefix = `${FILE_KEY_PREFIX}/${userId}/${id}/`;
+        const s3Prefix = drawingS3Prefix(userId, id);
 
-        // Query S3File records for this drawing
         const s3FileRecords = await prisma.s3File.findMany({
-          where: { s3Key: { startsWith: s3Prefix } },
+          where: { drawingId: id },
         });
-
-        // List actual S3 objects
         const s3Objects = await listS3Objects(s3Prefix);
 
-        // Collect candidate orphan fileIds, then exclude any that another
-        // drawing of the same user still references (Excalidraw fileIds are
-        // content hashes, so the same image can appear in multiple drawings).
-        const candidateOrphans = new Map<string, Set<string>>(); // fileId -> s3Keys
-
-        const recordOrphan = (fileId: string, s3Key: string) => {
-          if (!candidateOrphans.has(fileId)) {
-            candidateOrphans.set(fileId, new Set());
-          }
-          candidateOrphans.get(fileId)!.add(s3Key);
-        };
+        // Union of S3File rows and physical S3 objects, minus the
+        // surviving fileIds — anything left is orphan storage.
+        const orphanKeys = new Set<string>();
+        const orphanFileIds = new Set<string>();
 
         for (const record of s3FileRecords) {
-          if (!survivingFileIds.has(record.id)) {
-            recordOrphan(record.id, record.s3Key);
+          if (!survivingFileIds.has(record.fileId)) {
+            orphanKeys.add(record.s3Key);
+            orphanFileIds.add(record.fileId);
           }
         }
 
         for (const obj of s3Objects) {
           const fileId = fileIdFromS3Key(obj.key);
           if (fileId && !survivingFileIds.has(fileId)) {
-            recordOrphan(fileId, obj.key);
+            orphanKeys.add(obj.key);
           }
         }
 
-        const stillReferenced = await findFileIdsStillReferencedElsewhere(
-          prisma,
-          userId,
-          id,
-          Array.from(candidateOrphans.keys())
-        );
-
-        const trulyOrphanedKeys = new Set<string>();
-        const trulyOrphanedRecordIds: string[] = [];
-        for (const [fileId, keys] of candidateOrphans.entries()) {
-          if (stillReferenced.has(fileId)) continue;
-          for (const k of keys) trulyOrphanedKeys.add(k);
-          if (s3FileRecords.some((r) => r.id === fileId)) {
-            trulyOrphanedRecordIds.push(fileId);
-          }
-        }
-
-        // Delete S3 objects.
-        for (const key of trulyOrphanedKeys) {
+        for (const key of orphanKeys) {
           try {
             await deleteS3Object(key);
             s3ObjectsDeleted++;
@@ -236,10 +180,9 @@ export const registerStorageRoutes = (
           }
         }
 
-        // Delete S3File rows for the truly-orphaned files.
-        if (trulyOrphanedRecordIds.length > 0) {
+        if (orphanFileIds.size > 0) {
           await prisma.s3File.deleteMany({
-            where: { id: { in: trulyOrphanedRecordIds } },
+            where: { drawingId: id, fileId: { in: Array.from(orphanFileIds) } },
           });
         }
       }
@@ -298,10 +241,10 @@ export const registerStorageRoutes = (
       // SQLite file keys
       const sqliteFileIds = new Set(Object.keys(files));
 
-      // S3File records and actual S3 objects
-      const s3Prefix = `${FILE_KEY_PREFIX}/${userId}/${id}/`;
+      // S3File records and actual S3 objects (drawing-scoped)
+      const s3Prefix = drawingS3Prefix(userId, id);
       let s3FileRecords: Array<{
-        id: string;
+        fileId: string;
         s3Key: string;
         mimeType: string;
       }> = [];
@@ -309,14 +252,14 @@ export const registerStorageRoutes = (
 
       if (isS3Enabled()) {
         s3FileRecords = await prisma.s3File.findMany({
-          where: { s3Key: { startsWith: s3Prefix } },
-          select: { id: true, s3Key: true, mimeType: true },
+          where: { drawingId: id },
+          select: { fileId: true, s3Key: true, mimeType: true },
         });
         s3Objects = await listS3Objects(s3Prefix);
       }
 
       const s3RecordMap = new Map(
-        s3FileRecords.map((r) => [r.id, r])
+        s3FileRecords.map((r) => [r.fileId, r])
       );
       const s3ObjectMap = new Map(
         s3Objects.map((o) => {
@@ -329,7 +272,7 @@ export const registerStorageRoutes = (
       const allFileIds = new Set<string>();
       for (const fid of allCanvasRefs) allFileIds.add(fid);
       for (const fid of sqliteFileIds) allFileIds.add(fid);
-      for (const r of s3FileRecords) allFileIds.add(r.id);
+      for (const r of s3FileRecords) allFileIds.add(r.fileId);
       for (const o of s3Objects) {
         const fid = fileIdFromS3Key(o.key);
         if (fid) allFileIds.add(fid);
@@ -411,33 +354,24 @@ export const registerStorageRoutes = (
       let deletedCount = 0;
       let errorCount = 0;
 
-      // Skip S3-side deletion for fileIds that any other drawing of the
-      // same user still references — those files must remain reachable.
-      const stillReferencedElsewhere = await findFileIdsStillReferencedElsewhere(
-        prisma,
-        userId,
-        id,
-        fileIds as string[]
-      );
-
+      // S3File rows are scoped (drawingId, fileId), and each drawing
+      // has its own S3 object under its own prefix path — deleting
+      // here cannot strand a sibling drawing.
       for (const fileId of fileIds as string[]) {
         try {
-          // Delete S3 object via S3File record only when no other drawing
-          // owned by this user still references the file.
-          if (isS3Enabled() && !stillReferencedElsewhere.has(fileId)) {
+          if (isS3Enabled()) {
             const s3Record = await prisma.s3File.findUnique({
-              where: { id: fileId },
+              where: { drawingId_fileId: { drawingId: id, fileId } },
             });
             if (s3Record) {
               await deleteS3Object(s3Record.s3Key);
-              await prisma.s3File.delete({ where: { id: fileId } });
+              await prisma.s3File.delete({
+                where: { drawingId_fileId: { drawingId: id, fileId } },
+              });
             }
           }
 
-          // Remove from THIS drawing's files JSON regardless — the
-          // sibling drawing keeps its own entry pointing at the same key.
           delete files[fileId];
-
           deletedCount++;
         } catch (err: any) {
           console.error(

--- a/backend/src/routes/storage.ts
+++ b/backend/src/routes/storage.ts
@@ -22,6 +22,45 @@ export type StorageRouteDeps = {
     ) => Promise<T>
   ) => express.RequestHandler;
   parseJsonField: <T>(rawValue: string | null | undefined, fallback: T) => T;
+  invalidateDrawingsCache: () => void;
+};
+
+/**
+ * Returns the subset of fileIds still referenced by a drawing OTHER than
+ * `excludeDrawingId` and owned by `userId`. Those files must NOT be
+ * deleted from S3 / S3File when trimming this drawing.
+ *
+ * Uses a substring check on the JSON columns: fileIds are randomly
+ * generated identifiers (UUID/SHA-1), so false positives are negligible
+ * compared to the cost of parsing every drawing's full JSON.
+ */
+const findFileIdsStillReferencedElsewhere = async (
+  prisma: PrismaClient,
+  userId: string,
+  excludeDrawingId: string,
+  fileIds: string[]
+): Promise<Set<string>> => {
+  const stillReferenced = new Set<string>();
+  if (fileIds.length === 0) return stillReferenced;
+
+  for (const fileId of fileIds) {
+    // Wrap with quotes so we don't match a longer id that contains this
+    // one as a substring (`abc123` shouldn't match `abc1234`).
+    const needle = `"${fileId}"`;
+    const other = await prisma.drawing.findFirst({
+      where: {
+        userId,
+        id: { not: excludeDrawingId },
+        OR: [
+          { files: { contains: needle } },
+          { elements: { contains: needle } },
+        ],
+      },
+      select: { id: true },
+    });
+    if (other) stillReferenced.add(fileId);
+  }
+  return stillReferenced;
 };
 
 /**
@@ -59,7 +98,13 @@ export const registerStorageRoutes = (
   app: express.Express,
   deps: StorageRouteDeps
 ): void => {
-  const { prisma, requireAuth, asyncHandler, parseJsonField } = deps;
+  const {
+    prisma,
+    requireAuth,
+    asyncHandler,
+    parseJsonField,
+    invalidateDrawingsCache,
+  } = deps;
 
   // ------------------------------------------------------------------
   // POST /drawings/:id/trim
@@ -125,25 +170,50 @@ export const registerStorageRoutes = (
         // List actual S3 objects
         const s3Objects = await listS3Objects(s3Prefix);
 
-        // Collect all keys to potentially delete (union of records and actual objects)
-        const orphanedKeys = new Set<string>();
+        // Collect candidate orphan fileIds, then exclude any that another
+        // drawing of the same user still references (Excalidraw fileIds are
+        // content hashes, so the same image can appear in multiple drawings).
+        const candidateOrphans = new Map<string, Set<string>>(); // fileId -> s3Keys
+
+        const recordOrphan = (fileId: string, s3Key: string) => {
+          if (!candidateOrphans.has(fileId)) {
+            candidateOrphans.set(fileId, new Set());
+          }
+          candidateOrphans.get(fileId)!.add(s3Key);
+        };
 
         for (const record of s3FileRecords) {
-          const fileId = record.id;
-          if (!survivingFileIds.has(fileId)) {
-            orphanedKeys.add(record.s3Key);
+          if (!survivingFileIds.has(record.id)) {
+            recordOrphan(record.id, record.s3Key);
           }
         }
 
         for (const obj of s3Objects) {
           const fileId = fileIdFromS3Key(obj.key);
           if (fileId && !survivingFileIds.has(fileId)) {
-            orphanedKeys.add(obj.key);
+            recordOrphan(fileId, obj.key);
           }
         }
 
-        // Delete orphaned S3 objects and records
-        for (const key of orphanedKeys) {
+        const stillReferenced = await findFileIdsStillReferencedElsewhere(
+          prisma,
+          userId,
+          id,
+          Array.from(candidateOrphans.keys())
+        );
+
+        const trulyOrphanedKeys = new Set<string>();
+        const trulyOrphanedRecordIds: string[] = [];
+        for (const [fileId, keys] of candidateOrphans.entries()) {
+          if (stillReferenced.has(fileId)) continue;
+          for (const k of keys) trulyOrphanedKeys.add(k);
+          if (s3FileRecords.some((r) => r.id === fileId)) {
+            trulyOrphanedRecordIds.push(fileId);
+          }
+        }
+
+        // Delete S3 objects.
+        for (const key of trulyOrphanedKeys) {
           try {
             await deleteS3Object(key);
             s3ObjectsDeleted++;
@@ -153,14 +223,10 @@ export const registerStorageRoutes = (
           }
         }
 
-        // Delete orphaned S3File records
-        const orphanedRecordIds = s3FileRecords
-          .filter((r) => !survivingFileIds.has(r.id))
-          .map((r) => r.id);
-
-        if (orphanedRecordIds.length > 0) {
+        // Delete S3File rows for the truly-orphaned files.
+        if (trulyOrphanedRecordIds.length > 0) {
           await prisma.s3File.deleteMany({
-            where: { id: { in: orphanedRecordIds } },
+            where: { id: { in: trulyOrphanedRecordIds } },
           });
         }
       }
@@ -174,6 +240,7 @@ export const registerStorageRoutes = (
           version: 1,
         },
       });
+      invalidateDrawingsCache();
 
       return res.json({
         trimmed: {
@@ -329,10 +396,20 @@ export const registerStorageRoutes = (
       let deletedCount = 0;
       let errorCount = 0;
 
+      // Skip S3-side deletion for fileIds that any other drawing of the
+      // same user still references — those files must remain reachable.
+      const stillReferencedElsewhere = await findFileIdsStillReferencedElsewhere(
+        prisma,
+        userId,
+        id,
+        fileIds as string[]
+      );
+
       for (const fileId of fileIds as string[]) {
         try {
-          // Delete S3 object via S3File record
-          if (isS3Enabled()) {
+          // Delete S3 object via S3File record only when no other drawing
+          // owned by this user still references the file.
+          if (isS3Enabled() && !stillReferencedElsewhere.has(fileId)) {
             const s3Record = await prisma.s3File.findUnique({
               where: { id: fileId },
             });
@@ -342,7 +419,8 @@ export const registerStorageRoutes = (
             }
           }
 
-          // Remove from drawing.files JSON
+          // Remove from THIS drawing's files JSON regardless — the
+          // sibling drawing keeps its own entry pointing at the same key.
           delete files[fileId];
 
           deletedCount++;
@@ -370,14 +448,17 @@ export const registerStorageRoutes = (
         return true;
       });
 
-      // Update drawing with cleaned files and elements
+      // Update drawing with cleaned files and elements. Bump version so
+      // concurrent editors reload instead of silently overwriting.
       await prisma.drawing.update({
         where: { id },
         data: {
           files: JSON.stringify(files),
           elements: JSON.stringify(cleanedElements),
+          version: { increment: 1 },
         },
       });
+      invalidateDrawingsCache();
 
       return res.json({ deleted: deletedCount, errors: errorCount });
     })

--- a/backend/src/routes/storage.ts
+++ b/backend/src/routes/storage.ts
@@ -1,0 +1,385 @@
+/**
+ * Storage management routes:
+ *   POST   /drawings/:id/trim          – trim deleted elements and orphaned files
+ *   GET    /drawings/:id/files/diff    – three-way file comparison
+ *   DELETE /drawings/:id/files/orphans – delete selected orphaned files
+ */
+import express from "express";
+import { PrismaClient } from "../generated/client";
+import { isS3Enabled, deleteS3Object, listS3Objects } from "../s3";
+
+const FILE_KEY_PREFIX =
+  process.env.S3_KEY_PREFIX?.replace(/\/+$/, "") || "excalidash";
+
+export type StorageRouteDeps = {
+  prisma: PrismaClient;
+  requireAuth: express.RequestHandler;
+  asyncHandler: <T = void>(
+    fn: (
+      req: express.Request,
+      res: express.Response,
+      next: express.NextFunction
+    ) => Promise<T>
+  ) => express.RequestHandler;
+  parseJsonField: <T>(rawValue: string | null | undefined, fallback: T) => T;
+};
+
+/**
+ * Collect fileIds referenced by image elements.
+ * When includeDeleted is false, elements with isDeleted: true are skipped.
+ */
+const collectReferencedFileIds = (
+  elements: any[],
+  includeDeleted: boolean
+): Set<string> => {
+  const ids = new Set<string>();
+  for (const el of elements) {
+    if (!includeDeleted && el.isDeleted) continue;
+    if (el.type === "image" && typeof el.fileId === "string" && el.fileId) {
+      ids.add(el.fileId);
+    }
+  }
+  return ids;
+};
+
+/**
+ * Extract the fileId from an S3 key. The key format is:
+ *   {prefix}/{userId}/{drawingId}/{fileId}.{ext}
+ * Returns the fileId (without extension), or null if the key doesn't match.
+ */
+const fileIdFromS3Key = (key: string): string | null => {
+  const lastSegment = key.split("/").pop();
+  if (!lastSegment) return null;
+  const dotIndex = lastSegment.lastIndexOf(".");
+  if (dotIndex <= 0) return lastSegment; // no extension
+  return lastSegment.substring(0, dotIndex);
+};
+
+export const registerStorageRoutes = (
+  app: express.Express,
+  deps: StorageRouteDeps
+): void => {
+  const { prisma, requireAuth, asyncHandler, parseJsonField } = deps;
+
+  // ------------------------------------------------------------------
+  // POST /drawings/:id/trim
+  // ------------------------------------------------------------------
+  app.post(
+    "/drawings/:id/trim",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: "Unauthorized" });
+
+      const { id } = req.params;
+      const { confirmName } = req.body ?? {};
+
+      // 1. Find drawing owned by user
+      const drawing = await prisma.drawing.findFirst({
+        where: { id, userId },
+      });
+      if (!drawing) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
+
+      // Confirm name must match
+      if (typeof confirmName !== "string" || confirmName !== drawing.name) {
+        return res
+          .status(403)
+          .json({ error: "confirmName does not match drawing name" });
+      }
+
+      // 2. Parse elements and files
+      const elements: any[] = parseJsonField(drawing.elements, []);
+      const files: Record<string, any> = parseJsonField(drawing.files, {});
+
+      // 3. Filter elements: keep only non-deleted
+      const activeElements = elements.filter((el) => !el.isDeleted);
+      const elementsRemoved = elements.length - activeElements.length;
+
+      // 4. Collect surviving fileIds
+      const survivingFileIds = collectReferencedFileIds(activeElements, false);
+
+      // 5. Filter files
+      const originalFileCount = Object.keys(files).length;
+      const cleanedFiles: Record<string, any> = {};
+      for (const [fileId, value] of Object.entries(files)) {
+        if (survivingFileIds.has(fileId)) {
+          cleanedFiles[fileId] = value;
+        }
+      }
+      const filesRemoved = originalFileCount - Object.keys(cleanedFiles).length;
+
+      // 6. S3 cleanup
+      let s3ObjectsDeleted = 0;
+      let s3DeleteErrors = 0;
+
+      if (isS3Enabled()) {
+        const s3Prefix = `${FILE_KEY_PREFIX}/${userId}/${id}/`;
+
+        // Query S3File records for this drawing
+        const s3FileRecords = await prisma.s3File.findMany({
+          where: { s3Key: { startsWith: s3Prefix } },
+        });
+
+        // List actual S3 objects
+        const s3Objects = await listS3Objects(s3Prefix);
+
+        // Collect all keys to potentially delete (union of records and actual objects)
+        const orphanedKeys = new Set<string>();
+
+        for (const record of s3FileRecords) {
+          const fileId = record.id;
+          if (!survivingFileIds.has(fileId)) {
+            orphanedKeys.add(record.s3Key);
+          }
+        }
+
+        for (const obj of s3Objects) {
+          const fileId = fileIdFromS3Key(obj.key);
+          if (fileId && !survivingFileIds.has(fileId)) {
+            orphanedKeys.add(obj.key);
+          }
+        }
+
+        // Delete orphaned S3 objects and records
+        for (const key of orphanedKeys) {
+          try {
+            await deleteS3Object(key);
+            s3ObjectsDeleted++;
+          } catch (err) {
+            console.error(`[storage/trim] Failed to delete S3 object: ${key}`, err);
+            s3DeleteErrors++;
+          }
+        }
+
+        // Delete orphaned S3File records
+        const orphanedRecordIds = s3FileRecords
+          .filter((r) => !survivingFileIds.has(r.id))
+          .map((r) => r.id);
+
+        if (orphanedRecordIds.length > 0) {
+          await prisma.s3File.deleteMany({
+            where: { id: { in: orphanedRecordIds } },
+          });
+        }
+      }
+
+      // 7. Update drawing
+      await prisma.drawing.update({
+        where: { id },
+        data: {
+          elements: JSON.stringify(activeElements),
+          files: JSON.stringify(cleanedFiles),
+          version: 1,
+        },
+      });
+
+      return res.json({
+        trimmed: {
+          elementsRemoved,
+          filesRemoved,
+          s3ObjectsDeleted,
+          s3DeleteErrors,
+        },
+      });
+    })
+  );
+
+  // ------------------------------------------------------------------
+  // GET /drawings/:id/files/diff
+  // ------------------------------------------------------------------
+  app.get(
+    "/drawings/:id/files/diff",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: "Unauthorized" });
+
+      const { id } = req.params;
+
+      const drawing = await prisma.drawing.findFirst({
+        where: { id, userId },
+      });
+      if (!drawing) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
+
+      const elements: any[] = parseJsonField(drawing.elements, []);
+      const files: Record<string, any> = parseJsonField(drawing.files, {});
+
+      // Canvas refs (all elements including deleted)
+      const allCanvasRefs = collectReferencedFileIds(elements, true);
+      // Active canvas refs (non-deleted only)
+      const activeCanvasRefs = collectReferencedFileIds(elements, false);
+
+      // SQLite file keys
+      const sqliteFileIds = new Set(Object.keys(files));
+
+      // S3File records and actual S3 objects
+      const s3Prefix = `${FILE_KEY_PREFIX}/${userId}/${id}/`;
+      let s3FileRecords: Array<{
+        id: string;
+        s3Key: string;
+        mimeType: string;
+      }> = [];
+      let s3Objects: Array<{ key: string; size: number }> = [];
+
+      if (isS3Enabled()) {
+        s3FileRecords = await prisma.s3File.findMany({
+          where: { s3Key: { startsWith: s3Prefix } },
+          select: { id: true, s3Key: true, mimeType: true },
+        });
+        s3Objects = await listS3Objects(s3Prefix);
+      }
+
+      const s3RecordMap = new Map(
+        s3FileRecords.map((r) => [r.id, r])
+      );
+      const s3ObjectMap = new Map(
+        s3Objects.map((o) => {
+          const fid = fileIdFromS3Key(o.key);
+          return [fid, o] as const;
+        })
+      );
+
+      // Build union of all fileIds
+      const allFileIds = new Set<string>();
+      for (const fid of allCanvasRefs) allFileIds.add(fid);
+      for (const fid of sqliteFileIds) allFileIds.add(fid);
+      for (const r of s3FileRecords) allFileIds.add(r.id);
+      for (const o of s3Objects) {
+        const fid = fileIdFromS3Key(o.key);
+        if (fid) allFileIds.add(fid);
+      }
+
+      const filesList = Array.from(allFileIds).map((fileId) => {
+        const s3Record = s3RecordMap.get(fileId);
+        const s3Obj = s3ObjectMap.get(fileId);
+
+        return {
+          fileId,
+          inCanvas: allCanvasRefs.has(fileId),
+          inCanvasActive: activeCanvasRefs.has(fileId),
+          inSqlite: sqliteFileIds.has(fileId),
+          inS3: !!s3Obj,
+          inS3Record: !!s3Record,
+          s3Key: s3Record?.s3Key ?? s3Obj?.key ?? null,
+          mimeType: s3Record?.mimeType ?? null,
+          s3SizeBytes: s3Obj?.size ?? null,
+        };
+      });
+
+      return res.json({
+        summary: {
+          totalCanvasRefs: allCanvasRefs.size,
+          totalSqliteFiles: sqliteFileIds.size,
+          totalS3Files: s3Objects.length,
+        },
+        files: filesList,
+      });
+    })
+  );
+
+  // ------------------------------------------------------------------
+  // DELETE /drawings/:id/files/orphans
+  // ------------------------------------------------------------------
+  app.delete(
+    "/drawings/:id/files/orphans",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: "Unauthorized" });
+
+      const { id } = req.params;
+      const { confirmName, fileIds } = req.body ?? {};
+
+      if (!Array.isArray(fileIds) || fileIds.length === 0) {
+        return res.status(400).json({ error: "fileIds must be a non-empty array" });
+      }
+
+      const drawing = await prisma.drawing.findFirst({
+        where: { id, userId },
+      });
+      if (!drawing) {
+        return res.status(404).json({ error: "Drawing not found" });
+      }
+
+      if (typeof confirmName !== "string" || confirmName !== drawing.name) {
+        return res
+          .status(403)
+          .json({ error: "confirmName does not match drawing name" });
+      }
+
+      const elements: any[] = parseJsonField(drawing.elements, []);
+      const files: Record<string, any> = parseJsonField(drawing.files, {});
+
+      // Safety: reject if any fileId is still referenced by a non-deleted element
+      const activeRefs = collectReferencedFileIds(elements, false);
+      const blockedIds = (fileIds as string[]).filter((fid) =>
+        activeRefs.has(fid)
+      );
+      if (blockedIds.length > 0) {
+        return res.status(400).json({
+          error: "Cannot delete files referenced by active elements",
+          blockedFileIds: blockedIds,
+        });
+      }
+
+      let deletedCount = 0;
+      let errorCount = 0;
+
+      for (const fileId of fileIds as string[]) {
+        try {
+          // Delete S3 object via S3File record
+          if (isS3Enabled()) {
+            const s3Record = await prisma.s3File.findUnique({
+              where: { id: fileId },
+            });
+            if (s3Record) {
+              await deleteS3Object(s3Record.s3Key);
+              await prisma.s3File.delete({ where: { id: fileId } });
+            }
+          }
+
+          // Remove from drawing.files JSON
+          delete files[fileId];
+
+          deletedCount++;
+        } catch (err: any) {
+          console.error(
+            `[storage/orphans] Failed to delete fileId=${fileId}`,
+            err
+          );
+          errorCount++;
+        }
+      }
+
+      // Also remove deleted elements that reference the orphaned files,
+      // so the files disappear from the diff completely.
+      const deletedFileIdSet = new Set(fileIds as string[]);
+      const cleanedElements = elements.filter((el: any) => {
+        if (
+          el.isDeleted &&
+          el.type === "image" &&
+          typeof el.fileId === "string" &&
+          deletedFileIdSet.has(el.fileId)
+        ) {
+          return false; // remove this deleted element
+        }
+        return true;
+      });
+
+      // Update drawing with cleaned files and elements
+      await prisma.drawing.update({
+        where: { id },
+        data: {
+          files: JSON.stringify(files),
+          elements: JSON.stringify(cleanedElements),
+        },
+      });
+
+      return res.json({ deleted: deletedCount, errors: errorCount });
+    })
+  );
+};

--- a/backend/src/routes/storage.ts
+++ b/backend/src/routes/storage.ts
@@ -5,6 +5,7 @@
  *   DELETE /drawings/:id/files/orphans – delete selected orphaned files
  */
 import express from "express";
+import type { Server as SocketIoServer } from "socket.io";
 import { PrismaClient } from "../generated/client";
 import { isS3Enabled, deleteS3Object, listS3Objects } from "../s3";
 
@@ -23,6 +24,7 @@ export type StorageRouteDeps = {
   ) => express.RequestHandler;
   parseJsonField: <T>(rawValue: string | null | undefined, fallback: T) => T;
   invalidateDrawingsCache: () => void;
+  io: SocketIoServer;
 };
 
 /**
@@ -104,7 +106,18 @@ export const registerStorageRoutes = (
     asyncHandler,
     parseJsonField,
     invalidateDrawingsCache,
+    io,
   } = deps;
+
+  /**
+   * Tell anyone joined to the drawing's collaboration room that the
+   * server-side state has changed underneath them. The frontend reacts
+   * by reloading the drawing — otherwise a collaborator's next save
+   * would re-introduce the trimmed-away elements.
+   */
+  const notifyServerStateChange = (drawingId: string) => {
+    io.to(`drawing_${drawingId}`).emit("drawing-server-update", { drawingId });
+  };
 
   // ------------------------------------------------------------------
   // POST /drawings/:id/trim
@@ -241,6 +254,7 @@ export const registerStorageRoutes = (
         },
       });
       invalidateDrawingsCache();
+      notifyServerStateChange(id);
 
       return res.json({
         trimmed: {
@@ -459,6 +473,7 @@ export const registerStorageRoutes = (
         },
       });
       invalidateDrawingsCache();
+      notifyServerStateChange(id);
 
       return res.json({ deleted: deletedCount, errors: errorCount });
     })

--- a/backend/src/routes/storage.ts
+++ b/backend/src/routes/storage.ts
@@ -317,11 +317,27 @@ export const registerStorageRoutes = (
       if (!userId) return res.status(401).json({ error: "Unauthorized" });
 
       const { id } = req.params;
-      const { confirmName, fileIds } = req.body ?? {};
+      const { confirmName, fileIds: rawFileIds } = req.body ?? {};
 
-      if (!Array.isArray(fileIds) || fileIds.length === 0) {
+      if (!Array.isArray(rawFileIds) || rawFileIds.length === 0) {
         return res.status(400).json({ error: "fileIds must be a non-empty array" });
       }
+
+      // Validate every entry: same regex as the rest of the codebase
+      // (security.ts sanitiser, /files/:fileId route, processFilesForS3).
+      // Without this, a non-string or path-traversal-shaped id would
+      // explode inside the Prisma / S3 calls below.
+      const VALID_FILE_ID = /^[\w-]{1,200}$/;
+      const invalidIds = rawFileIds.filter(
+        (fid) => typeof fid !== "string" || !VALID_FILE_ID.test(fid),
+      );
+      if (invalidIds.length > 0) {
+        return res.status(400).json({
+          error: "fileIds contains invalid entries",
+          invalidFileIds: invalidIds,
+        });
+      }
+      const fileIds = rawFileIds as string[];
 
       const drawing = await prisma.drawing.findFirst({
         where: { id, userId },
@@ -341,9 +357,7 @@ export const registerStorageRoutes = (
 
       // Safety: reject if any fileId is still referenced by a non-deleted element
       const activeRefs = collectReferencedFileIds(elements, false);
-      const blockedIds = (fileIds as string[]).filter((fid) =>
-        activeRefs.has(fid)
-      );
+      const blockedIds = fileIds.filter((fid) => activeRefs.has(fid));
       if (blockedIds.length > 0) {
         return res.status(400).json({
           error: "Cannot delete files referenced by active elements",
@@ -351,36 +365,53 @@ export const registerStorageRoutes = (
         });
       }
 
-      let deletedCount = 0;
-      let errorCount = 0;
+      // Batched S3 + DB cleanup. S3File rows are scoped
+      // (drawingId, fileId), and each drawing has its own S3 object
+      // under its own prefix path — deletion here cannot strand a
+      // sibling drawing. Doing N+1 sequential lookups + deletes per
+      // file would tie up the request unnecessarily for large
+      // selections.
+      let s3ObjectsDeleted = 0;
+      let s3DeleteErrors = 0;
 
-      // S3File rows are scoped (drawingId, fileId), and each drawing
-      // has its own S3 object under its own prefix path — deleting
-      // here cannot strand a sibling drawing.
-      for (const fileId of fileIds as string[]) {
-        try {
-          if (isS3Enabled()) {
-            const s3Record = await prisma.s3File.findUnique({
-              where: { drawingId_fileId: { drawingId: id, fileId } },
-            });
-            if (s3Record) {
-              await deleteS3Object(s3Record.s3Key);
-              await prisma.s3File.delete({
-                where: { drawingId_fileId: { drawingId: id, fileId } },
-              });
+      if (isS3Enabled()) {
+        const s3Records = await prisma.s3File.findMany({
+          where: { drawingId: id, fileId: { in: fileIds } },
+        });
+
+        const S3_DELETE_CONCURRENCY = 8;
+        for (let i = 0; i < s3Records.length; i += S3_DELETE_CONCURRENCY) {
+          const batch = s3Records.slice(i, i + S3_DELETE_CONCURRENCY);
+          const results = await Promise.allSettled(
+            batch.map((rec) => deleteS3Object(rec.s3Key)),
+          );
+          for (let j = 0; j < results.length; j++) {
+            const result = results[j];
+            if (result.status === "fulfilled") {
+              s3ObjectsDeleted++;
+            } else {
+              console.error(
+                `[storage/orphans] Failed to delete S3 object: ${batch[j].s3Key}`,
+                result.reason,
+              );
+              s3DeleteErrors++;
             }
           }
-
-          delete files[fileId];
-          deletedCount++;
-        } catch (err: any) {
-          console.error(
-            `[storage/orphans] Failed to delete fileId=${fileId}`,
-            err
-          );
-          errorCount++;
         }
+
+        await prisma.s3File.deleteMany({
+          where: { drawingId: id, fileId: { in: fileIds } },
+        });
       }
+
+      // Update the drawing's files JSON regardless of S3 outcomes —
+      // the JSON entry is what the editor reads, and once trimmed it
+      // can't be restored from the bucket alone.
+      for (const fileId of fileIds) {
+        delete files[fileId];
+      }
+      const deletedCount = fileIds.length;
+      const errorCount = s3DeleteErrors;
 
       // Also remove deleted elements that reference the orphaned files,
       // so the files disappear from the diff completely.

--- a/backend/src/s3.ts
+++ b/backend/src/s3.ts
@@ -8,6 +8,7 @@ import {
   GetObjectCommand,
   DeleteObjectCommand,
   ListObjectsV2Command,
+  CopyObjectCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
@@ -231,6 +232,32 @@ export const listS3Objects = async (
   } while (continuationToken);
 
   return results;
+};
+
+/**
+ * Copy an object inside the same bucket (server-side copy — no
+ * download/re-upload). Used by the duplicate-drawing path so each
+ * drawing owns its own object under its own (drawingId) prefix.
+ */
+export const copyS3Object = async (
+  sourceKey: string,
+  destKey: string,
+  mimeType?: string,
+): Promise<void> => {
+  if (!s3Client || !s3Config) {
+    throw new Error("S3 is not configured");
+  }
+
+  const command = new CopyObjectCommand({
+    Bucket: s3Config.bucket,
+    Key: destKey,
+    CopySource: `${s3Config.bucket}/${sourceKey}`,
+    ContentType: mimeType,
+    CacheControl: "public, max-age=31536000, immutable",
+    MetadataDirective: mimeType ? "REPLACE" : "COPY",
+  });
+
+  await s3Client.send(command);
 };
 
 /**

--- a/backend/src/s3.ts
+++ b/backend/src/s3.ts
@@ -1,0 +1,224 @@
+/**
+ * S3 client setup and helper utilities for presigned URL generation.
+ * Supports AWS S3 and S3-compatible services (Cloudflare R2, MinIO, Alibaba OSS, etc.)
+ */
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+  DeleteObjectCommand,
+  ListObjectsV2Command,
+} from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+
+export interface S3Config {
+  bucket: string;
+  region: string;
+  /** Optional custom endpoint for S3-compatible services (e.g. MinIO, Cloudflare R2) */
+  endpoint?: string;
+  /** Optional public base URL for public-read buckets or CDN (e.g. https://cdn.example.com) */
+  publicUrl?: string;
+  /** Force path-style addressing (required for MinIO, must be false for Alibaba Cloud OSS) */
+  forcePathStyle?: boolean;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+}
+
+let s3Client: S3Client | null = null;
+let s3Config: S3Config | null = null;
+
+/**
+ * Initialize the S3 client. Called once on backend startup when S3 env vars are present.
+ */
+export const initS3 = (cfg: S3Config): void => {
+  s3Config = cfg;
+
+  const clientConfig: ConstructorParameters<typeof S3Client>[0] = {
+    region: cfg.region,
+  };
+
+  if (cfg.endpoint) {
+    clientConfig.endpoint = cfg.endpoint;
+    // Path-style is required for MinIO but must be false for services like
+    // Alibaba Cloud OSS that use virtual-hosted-style URLs.
+    clientConfig.forcePathStyle = cfg.forcePathStyle ?? false;
+  }
+
+  if (cfg.accessKeyId && cfg.secretAccessKey) {
+    clientConfig.credentials = {
+      accessKeyId: cfg.accessKeyId,
+      secretAccessKey: cfg.secretAccessKey,
+    };
+  }
+
+  s3Client = new S3Client(clientConfig);
+};
+
+/** Returns true when S3 has been initialised (i.e. S3_BUCKET is configured). */
+export const isS3Enabled = (): boolean =>
+  s3Client !== null && s3Config !== null;
+
+/** Returns the active S3 configuration, or null if S3 is disabled. */
+export const getS3Config = (): S3Config | null => s3Config;
+
+/**
+ * Generate a presigned PUT URL that allows a browser to upload a single object directly to S3.
+ * @param key      S3 object key
+ * @param mimeType Content-Type of the upload
+ * @param expiresInSeconds URL validity window (default: 5 minutes)
+ */
+export const generatePresignedUploadUrl = async (
+  key: string,
+  mimeType: string,
+  expiresInSeconds = 300
+): Promise<string> => {
+  if (!s3Client || !s3Config) {
+    throw new Error("S3 is not configured");
+  }
+
+  const command = new PutObjectCommand({
+    Bucket: s3Config.bucket,
+    Key: key,
+    ContentType: mimeType,
+    // Image keys contain a content hash, so they are immutable — cache
+    // aggressively to reduce repeated downloads from S3/CDN.
+    CacheControl: "public, max-age=31536000, immutable",
+  });
+
+  return getSignedUrl(s3Client, command, { expiresIn: expiresInSeconds });
+};
+
+/**
+ * Generate a presigned GET URL for reading a private S3 object.
+ * @param key             S3 object key
+ * @param expiresInSeconds URL validity window (default: 1 hour)
+ */
+export const generatePresignedDownloadUrl = async (
+  key: string,
+  expiresInSeconds = 3600
+): Promise<string> => {
+  if (!s3Client || !s3Config) {
+    throw new Error("S3 is not configured");
+  }
+
+  const command = new GetObjectCommand({
+    Bucket: s3Config.bucket,
+    Key: key,
+    ResponseCacheControl: "public, max-age=31536000, immutable",
+  });
+
+  return getSignedUrl(s3Client, command, { expiresIn: expiresInSeconds });
+};
+
+/**
+ * Build the public access URL for an object in a public-read bucket or behind a CDN.
+ * Falls back to the standard virtual-hosted-style S3 URL when S3_PUBLIC_URL is not set.
+ *
+ * NOTE: When using a custom S3-compatible endpoint (MinIO, R2, etc.) without
+ * setting S3_PUBLIC_URL, this function logs a warning and returns a best-effort
+ * AWS-style URL that will likely not resolve correctly.  Always set S3_PUBLIC_URL
+ * when using non-AWS endpoints.
+ */
+export const getPublicUrl = (key: string): string => {
+  if (!s3Config) {
+    throw new Error("S3 is not configured");
+  }
+
+  if (s3Config.publicUrl) {
+    const base = s3Config.publicUrl.endsWith("/")
+      ? s3Config.publicUrl.slice(0, -1)
+      : s3Config.publicUrl;
+    return `${base}/${key}`;
+  }
+
+  if (s3Config.endpoint) {
+    // Custom endpoint without S3_PUBLIC_URL is ambiguous — the URL format
+    // varies between MinIO, Cloudflare R2, and other services.
+    console.warn(
+      "[S3] S3_PUBLIC_URL is not set but a custom S3_ENDPOINT is configured. " +
+        "Public image URLs may not resolve correctly. Set S3_PUBLIC_URL to the " +
+        "public base URL of your bucket or CDN."
+    );
+  }
+
+  // Standard AWS virtual-hosted-style URL.
+  return `https://${s3Config.bucket}.s3.${s3Config.region}.amazonaws.com/${key}`;
+};
+
+/**
+ * Upload a Buffer directly to S3.
+ * Used by the backend to store image data without going through presigned URLs.
+ */
+export const uploadBuffer = async (
+  key: string,
+  body: Buffer,
+  mimeType: string
+): Promise<void> => {
+  if (!s3Client || !s3Config) {
+    throw new Error("S3 is not configured");
+  }
+
+  const command = new PutObjectCommand({
+    Bucket: s3Config.bucket,
+    Key: key,
+    Body: body,
+    ContentType: mimeType,
+    CacheControl: "public, max-age=31536000, immutable",
+  });
+
+  await s3Client.send(command);
+};
+
+/**
+ * List all objects under a given prefix. Handles pagination automatically.
+ */
+export const listS3Objects = async (
+  prefix: string
+): Promise<Array<{ key: string; size: number }>> => {
+  if (!s3Client || !s3Config) {
+    throw new Error("S3 is not configured");
+  }
+
+  const results: Array<{ key: string; size: number }> = [];
+  let continuationToken: string | undefined;
+
+  do {
+    const command = new ListObjectsV2Command({
+      Bucket: s3Config.bucket,
+      Prefix: prefix,
+      ContinuationToken: continuationToken,
+    });
+
+    const response = await s3Client.send(command);
+
+    if (response.Contents) {
+      for (const obj of response.Contents) {
+        if (obj.Key) {
+          results.push({ key: obj.Key, size: obj.Size ?? 0 });
+        }
+      }
+    }
+
+    continuationToken = response.IsTruncated
+      ? response.NextContinuationToken
+      : undefined;
+  } while (continuationToken);
+
+  return results;
+};
+
+/**
+ * Delete an object from S3. Best-effort — errors are thrown to the caller.
+ */
+export const deleteS3Object = async (key: string): Promise<void> => {
+  if (!s3Client || !s3Config) {
+    throw new Error("S3 is not configured");
+  }
+
+  const command = new DeleteObjectCommand({
+    Bucket: s3Config.bucket,
+    Key: key,
+  });
+
+  await s3Client.send(command);
+};

--- a/backend/src/s3.ts
+++ b/backend/src/s3.ts
@@ -28,6 +28,32 @@ let s3Client: S3Client | null = null;
 let s3Config: S3Config | null = null;
 
 /**
+ * Shared S3 object-key prefix. Reading the env var in one place avoids
+ * upload and cleanup code paths drifting onto different prefixes.
+ */
+export const FILE_KEY_PREFIX =
+  process.env.S3_KEY_PREFIX?.replace(/\/+$/, "") || "excalidash";
+
+/**
+ * Build the canonical S3 object key for a given drawing's image file.
+ * Layout: `{prefix}/{userId}/{drawingId}/{fileId}.{ext}`
+ *
+ * Including drawingId means duplicating a drawing always produces a
+ * separate object (and S3File row), so deleting the original cannot
+ * break the duplicate.
+ */
+export const buildS3Key = (
+  userId: string,
+  drawingId: string,
+  fileId: string,
+  ext: string,
+): string => `${FILE_KEY_PREFIX}/${userId}/${drawingId}/${fileId}.${ext}`;
+
+/** Prefix used when listing objects belonging to a single drawing. */
+export const drawingS3Prefix = (userId: string, drawingId: string): string =>
+  `${FILE_KEY_PREFIX}/${userId}/${drawingId}/`;
+
+/**
  * Initialize the S3 client. Called once on backend startup when S3 env vars are present.
  */
 export const initS3 = (cfg: S3Config): void => {

--- a/backend/src/security.ts
+++ b/backend/src/security.ts
@@ -525,6 +525,19 @@ export const sanitizeDrawingData = (data: {
                   } else {
                     file[key] = value;
                   }
+                } else if (/^https:\/\//i.test(value)) {
+                  // S3 / CDN public URL — validate format, no HTML injection risk.
+                  const hasSuspiciousContent = suspiciousPatterns.some(
+                    (pattern) => pattern.test(value)
+                  );
+                  if (hasSuspiciousContent || value.length > 2048) {
+                    file[key] = "";
+                  } else {
+                    file[key] = value;
+                  }
+                } else if (/^\/api\/files\/[\w-]{1,200}$/.test(value)) {
+                  // Private-bucket redirect path — allow as-is.
+                  file[key] = value;
                 } else {
                   file[key] = sanitizeText(value, 1000);
                 }

--- a/backend/src/security.ts
+++ b/backend/src/security.ts
@@ -546,8 +546,9 @@ export const sanitizeDrawingData = (data: {
                   } else {
                     file[key] = value;
                   }
-                } else if (/^\/api\/files\/[\w-]{1,200}$/.test(value)) {
-                  // Private-bucket redirect path — allow as-is.
+                } else if (/^\/api\/files\/[\w-]{1,200}\/[\w-]{1,200}$/.test(value)) {
+                  // Private-bucket redirect path /api/files/:drawingId/:fileId
+                  // — allow as-is.
                   file[key] = value;
                 } else {
                   file[key] = sanitizeText(value, 1000);

--- a/backend/src/security.ts
+++ b/backend/src/security.ts
@@ -492,6 +492,17 @@ export const sanitizeDrawingData = (data: {
 
       const MAX_DATAURL_SIZE = activeConfig.maxDataUrlSize;
 
+      // Drop entries whose key would not be safe to embed in an S3 object
+      // path. Backend file-storage code uses the fileId as a path segment,
+      // so a malicious key like "../../foo" must never reach the uploader
+      // or the database row. Same regex as backend/src/routes/files.ts.
+      const VALID_FILE_ID = /^[\w-]{1,200}$/;
+      for (const fileId in sanitizedFiles) {
+        if (!VALID_FILE_ID.test(fileId)) {
+          delete sanitizedFiles[fileId];
+        }
+      }
+
       for (const fileId in sanitizedFiles) {
         const file = sanitizedFiles[fileId];
         if (typeof file === "object" && file !== null) {

--- a/backend/src/security.ts
+++ b/backend/src/security.ts
@@ -496,8 +496,11 @@ export const sanitizeDrawingData = (data: {
       // path. Backend file-storage code uses the fileId as a path segment,
       // so a malicious key like "../../foo" must never reach the uploader
       // or the database row. Same regex as backend/src/routes/files.ts.
+      // Snapshot the key list before mutating: deleting properties while
+      // iterating with `for...in` can skip entries depending on engine
+      // ordering, leaving an unsafe key in place.
       const VALID_FILE_ID = /^[\w-]{1,200}$/;
-      for (const fileId in sanitizedFiles) {
+      for (const fileId of Object.keys(sanitizedFiles)) {
         if (!VALID_FILE_ID.test(fileId)) {
           delete sanitizedFiles[fileId];
         }
@@ -536,8 +539,11 @@ export const sanitizeDrawingData = (data: {
                   } else {
                     file[key] = value;
                   }
-                } else if (/^https:\/\//i.test(value)) {
-                  // S3 / CDN public URL — validate format, no HTML injection risk.
+                } else if (/^https?:\/\//i.test(value)) {
+                  // S3 / CDN public URL — validate format, no HTML
+                  // injection risk. Both http:// and https:// are
+                  // accepted because S3_PUBLIC_URL may legitimately be
+                  // a plain-HTTP MinIO / dev endpoint.
                   const hasSuspiciousContent = suspiciousPatterns.some(
                     (pattern) => pattern.test(value)
                   );

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -15,5 +15,12 @@
     "allowJs": true,
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "prisma.config.ts"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "prisma.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.integration.ts",
+    "src/__tests__/**"
+  ]
 }

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -686,22 +686,42 @@ export const updateLibrary = async (items: LibraryItem[]): Promise<LibraryItem[]
 // S3 file upload helpers
 // ---------------------------------------------------------------------------
 
-/** Cache the result of the /files/config probe so we only call it once. */
+/** Cached resolved result, settled successfully at least once. */
 let s3EnabledCache: boolean | null = null;
+/**
+ * In-flight promise so concurrent callers (e.g. many `DrawingCard`s
+ * mounting at once) coalesce onto a single `/files/config` request
+ * instead of stampeding the backend, and so a transient failure on
+ * one caller doesn't poison the cache for everyone.
+ */
+let s3EnabledInFlight: Promise<boolean> | null = null;
 
 /**
  * Returns true when the backend has S3 configured.
- * The result is cached for the lifetime of the page.
+ * The successful result is cached for the lifetime of the page; on a
+ * transient request failure we let the next caller retry rather than
+ * permanently latching to false.
  */
 export const isS3Enabled = async (): Promise<boolean> => {
   if (s3EnabledCache !== null) return s3EnabledCache;
-  try {
-    const response = await api.get<{ s3Enabled: boolean }>("/files/config");
-    s3EnabledCache = response.data.s3Enabled === true;
-  } catch {
-    s3EnabledCache = false;
-  }
-  return s3EnabledCache;
+  if (s3EnabledInFlight) return s3EnabledInFlight;
+
+  s3EnabledInFlight = (async () => {
+    try {
+      const response = await api.get<{ s3Enabled: boolean }>("/files/config");
+      s3EnabledCache = response.data.s3Enabled === true;
+      return s3EnabledCache;
+    } catch {
+      // Don't cache failures — a transient 401 during auth bootstrap or
+      // a network blip would otherwise permanently disable S3 for the
+      // rest of the page lifetime.
+      return false;
+    } finally {
+      s3EnabledInFlight = null;
+    }
+  })();
+
+  return s3EnabledInFlight;
 };
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -704,4 +704,56 @@ export const isS3Enabled = async (): Promise<boolean> => {
   return s3EnabledCache;
 };
 
+// ---------------------------------------------------------------------------
+// Storage management
+// ---------------------------------------------------------------------------
 
+export type TrimResult = {
+  trimmed: {
+    elementsRemoved: number;
+    filesRemoved: number;
+    s3ObjectsDeleted: number;
+    s3DeleteErrors: number;
+  };
+};
+
+export type FileDiffEntry = {
+  fileId: string;
+  inCanvas: boolean;
+  inCanvasActive: boolean;
+  inSqlite: boolean;
+  inS3: boolean;
+  inS3Record: boolean;
+  s3Key: string | null;
+  mimeType: string | null;
+  s3SizeBytes: number | null;
+};
+
+export type FilesDiffResult = {
+  summary: {
+    totalCanvasRefs: number;
+    totalSqliteFiles: number;
+    totalS3Files: number;
+  };
+  files: FileDiffEntry[];
+};
+
+export type DeleteOrphansResult = {
+  deleted: number;
+  errors: number;
+};
+
+export const trimDrawing = async (id: string, confirmName: string): Promise<TrimResult> => {
+  const response = await api.post<TrimResult>(`/drawings/${id}/trim`, { confirmName });
+  return response.data;
+};
+
+export const getFilesDiff = async (id: string): Promise<FilesDiffResult> => {
+  const response = await api.get<FilesDiffResult>(`/drawings/${id}/files/diff`);
+  return response.data;
+};
+
+export const deleteOrphanFiles = async (id: string, confirmName: string, fileIds: string[]): Promise<DeleteOrphansResult> => {
+  const response = await api.delete<DeleteOrphansResult>(`/drawings/${id}/files/orphans`, { data: { confirmName, fileIds } });
+  return response.data;
+};

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -681,3 +681,27 @@ export const updateLibrary = async (items: LibraryItem[]): Promise<LibraryItem[]
   const response = await api.put<{ items: LibraryItem[] }>("/library", { items });
   return response.data.items;
 };
+
+// ---------------------------------------------------------------------------
+// S3 file upload helpers
+// ---------------------------------------------------------------------------
+
+/** Cache the result of the /files/config probe so we only call it once. */
+let s3EnabledCache: boolean | null = null;
+
+/**
+ * Returns true when the backend has S3 configured.
+ * The result is cached for the lifetime of the page.
+ */
+export const isS3Enabled = async (): Promise<boolean> => {
+  if (s3EnabledCache !== null) return s3EnabledCache;
+  try {
+    const response = await api.get<{ s3Enabled: boolean }>("/files/config");
+    s3EnabledCache = response.data.s3Enabled === true;
+  } catch {
+    s3EnabledCache = false;
+  }
+  return s3EnabledCache;
+};
+
+

--- a/frontend/src/components/DrawingCard.tsx
+++ b/frontend/src/components/DrawingCard.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { PenTool, Trash2, FolderInput, ArrowRight, Check, Clock, Copy, Download, Loader2 } from 'lucide-react';
+import { PenTool, Trash2, FolderInput, ArrowRight, Check, Clock, Copy, Download, Loader2, HardDrive } from 'lucide-react';
 import type { DrawingSummary, Collection, Drawing } from '../types';
 import { formatDistanceToNow } from 'date-fns';
 import clsx from 'clsx';
@@ -9,6 +9,7 @@ import { exportDrawingToFile } from '../utils/exportUtils';
 import { previewHasEmbeddedImages } from '../utils/previewSvg';
 
 import * as api from '../api';
+import { StorageManageModal } from './StorageManageModal';
 
 type HydratedDrawingData = {
   elements: any[];
@@ -86,12 +87,18 @@ export const DrawingCard: React.FC<DrawingCardProps> = ({
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const [isExporting, setIsExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
+  const [showStorageModal, setShowStorageModal] = useState(false);
+  const [s3Enabled, setS3Enabled] = useState(false);
   const [fullData, setFullData] = useState<HydratedDrawingData | null>(null);
   const hasEmbeddedImages = previewHasEmbeddedImages(previewSvg);
 
   const fullDataRef = React.useRef(fullData);
   fullDataRef.current = fullData;
   const fullDataPromiseRef = React.useRef<Promise<HydratedDrawingData> | null>(null);
+
+  useEffect(() => {
+    api.isS3Enabled().then(setS3Enabled).catch(() => {});
+  }, []);
 
   useEffect(() => {
     setFullData(null);
@@ -491,6 +498,18 @@ export const DrawingCard: React.FC<DrawingCardProps> = ({
                 </div>
               )}
 
+              {!isShared && s3Enabled && (
+                <button
+                  onClick={() => {
+                    setShowStorageModal(true);
+                    setContextMenu(null);
+                  }}
+                  className="w-full px-3 py-2 text-sm text-left text-slate-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800 hover:text-neutral-900 dark:hover:text-white flex items-center gap-2"
+                >
+                  <HardDrive size={14} /> Storage Management
+                </button>
+              )}
+
               {!isShared ? (
                 <>
                   <div className="border-t border-slate-50 dark:border-slate-700 my-1"></div>
@@ -509,6 +528,13 @@ export const DrawingCard: React.FC<DrawingCardProps> = ({
           </div>
         </ContextMenuPortal>
       )}
+
+      <StorageManageModal
+        isOpen={showStorageModal}
+        drawingId={drawing.id}
+        drawingName={drawing.name}
+        onClose={() => setShowStorageModal(false)}
+      />
     </>
   );
 };

--- a/frontend/src/components/StorageManageModal.tsx
+++ b/frontend/src/components/StorageManageModal.tsx
@@ -1,0 +1,392 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  X,
+  RefreshCw,
+  Scissors,
+  Trash2,
+  Loader2,
+  CheckCircle,
+  AlertTriangle,
+  HardDrive,
+} from 'lucide-react';
+import clsx from 'clsx';
+import {
+  getFilesDiff,
+  trimDrawing,
+  deleteOrphanFiles,
+  type FilesDiffResult,
+  type FileDiffEntry,
+} from '../api';
+
+interface StorageManageModalProps {
+  isOpen: boolean;
+  drawingId: string;
+  drawingName: string;
+  onClose: () => void;
+}
+
+function formatSize(bytes: number | null): string {
+  if (bytes === null || bytes === undefined) return '\u2014';
+  if (bytes >= 1_000_000) return `${(bytes / 1_000_000).toFixed(1)} MB`;
+  if (bytes >= 1_000) return `${(bytes / 1_000).toFixed(1)} KB`;
+  return `${bytes} B`;
+}
+
+function StatusIcon({ active, present }: { active?: boolean; present: boolean }) {
+  if (active) {
+    return <span className="text-emerald-600 dark:text-emerald-400 font-bold" title="Active">{'\u2713'}</span>;
+  }
+  if (present) {
+    return <span className="text-amber-500 dark:text-amber-400 font-bold" title="History-only">{'\u25D0'}</span>;
+  }
+  return <span className="text-neutral-400 dark:text-neutral-500 font-bold" title="Missing">{'\u2717'}</span>;
+}
+
+export const StorageManageModal: React.FC<StorageManageModalProps> = ({
+  isOpen,
+  drawingId,
+  drawingName,
+  onClose,
+}) => {
+  const [diffData, setDiffData] = useState<FilesDiffResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [confirmAction, setConfirmAction] = useState<'trim' | 'delete-orphans' | null>(null);
+  const [confirmInput, setConfirmInput] = useState('');
+  const [actionLoading, setActionLoading] = useState(false);
+  const [lastResult, setLastResult] = useState<string | null>(null);
+
+  const loadDiff = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getFilesDiff(drawingId);
+      setDiffData(data);
+      // Pre-select files where inCanvasActive === false
+      const preSelected = new Set<string>();
+      for (const f of data.files) {
+        if (!f.inCanvasActive) {
+          preSelected.add(f.fileId);
+        }
+      }
+      setSelectedIds(preSelected);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to load file diff';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [drawingId]);
+
+  useEffect(() => {
+    if (isOpen) {
+      loadDiff();
+      setLastResult(null);
+      setConfirmAction(null);
+      setConfirmInput('');
+    }
+  }, [isOpen, loadDiff]);
+
+  const handleToggle = (fileId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(fileId)) {
+        next.delete(fileId);
+      } else {
+        next.add(fileId);
+      }
+      return next;
+    });
+  };
+
+  const handleTrim = async () => {
+    setActionLoading(true);
+    setError(null);
+    try {
+      const result = await trimDrawing(drawingId, confirmInput);
+      const t = result.trimmed;
+      setLastResult(
+        `Trim complete: ${t.elementsRemoved} elements removed, ${t.filesRemoved} files removed, ${t.s3ObjectsDeleted} S3 objects deleted.`
+      );
+      setConfirmAction(null);
+      setConfirmInput('');
+      await loadDiff();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Trim failed';
+      setError(message);
+      setConfirmAction(null);
+      setConfirmInput('');
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleDeleteOrphans = async () => {
+    setActionLoading(true);
+    setError(null);
+    try {
+      const ids = Array.from(selectedIds);
+      const result = await deleteOrphanFiles(drawingId, confirmInput, ids);
+      setLastResult(
+        `Deleted ${result.deleted} orphan file(s).${result.errors > 0 ? ` ${result.errors} error(s).` : ''}`
+      );
+      setConfirmAction(null);
+      setConfirmInput('');
+      await loadDiff();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Delete failed';
+      setError(message);
+      setConfirmAction(null);
+      setConfirmInput('');
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const confirmMatch = confirmInput === drawingName;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-neutral-900/20 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      <div className="relative w-full max-w-3xl max-h-[90vh] flex flex-col bg-white dark:bg-neutral-900 rounded-2xl border-2 border-black dark:border-neutral-700 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] dark:shadow-[2px_2px_0px_0px_rgba(255,255,255,0.08)] animate-in fade-in zoom-in-95 duration-200">
+        {/* Header */}
+        <div className="flex items-center gap-3 p-5 pb-4 border-b-2 border-black dark:border-neutral-700">
+          <div className="w-10 h-10 rounded-full bg-indigo-100 dark:bg-indigo-900/30 flex items-center justify-center text-indigo-600 dark:text-indigo-300 border-2 border-indigo-200 dark:border-indigo-900/30">
+            <HardDrive size={20} />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h2 className="text-lg font-bold text-neutral-900 dark:text-neutral-100 tracking-tight">
+              Storage Management
+            </h2>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400 truncate">
+              {drawingName}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-neutral-400 hover:text-neutral-900 dark:hover:text-white transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Scrollable content */}
+        <div className="flex-1 overflow-y-auto p-5 space-y-5">
+          {/* Banners */}
+          {lastResult && (
+            <div className="flex items-start gap-3 p-3 rounded-xl bg-emerald-50 dark:bg-emerald-900/20 border-2 border-emerald-200 dark:border-emerald-900/40 text-emerald-800 dark:text-emerald-200 text-sm font-medium">
+              <CheckCircle size={18} className="mt-0.5 shrink-0" />
+              {lastResult}
+            </div>
+          )}
+          {error && (
+            <div className="flex items-start gap-3 p-3 rounded-xl bg-rose-50 dark:bg-rose-900/20 border-2 border-rose-200 dark:border-rose-900/40 text-rose-800 dark:text-rose-200 text-sm font-medium">
+              <AlertTriangle size={18} className="mt-0.5 shrink-0" />
+              {error}
+            </div>
+          )}
+
+          {/* Trim History */}
+          <div>
+            <button
+              onClick={() => {
+                setConfirmAction('trim');
+                setConfirmInput('');
+              }}
+              className="px-4 py-2.5 font-bold rounded-xl border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-0.5 active:translate-y-0 active:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] transition-all duration-200 bg-rose-600 text-white flex items-center gap-2"
+            >
+              <Scissors size={16} />
+              Trim History
+            </button>
+            <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400">
+              Remove deleted elements and orphaned file references from this drawing.
+            </p>
+          </div>
+
+          <hr className="border-neutral-200 dark:border-neutral-700" />
+
+          {/* File Comparison */}
+          <div>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-base font-bold text-neutral-900 dark:text-neutral-100">
+                File Comparison
+              </h3>
+              <button
+                onClick={loadDiff}
+                disabled={loading}
+                className="px-3 py-1.5 text-sm font-bold rounded-xl border-2 border-black dark:border-neutral-700 shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] dark:shadow-[1px_1px_0px_0px_rgba(255,255,255,0.08)] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-0.5 active:translate-y-0 active:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] transition-all duration-200 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 flex items-center gap-1.5 disabled:opacity-50"
+              >
+                <RefreshCw size={14} className={clsx(loading && 'animate-spin')} />
+                Refresh
+              </button>
+            </div>
+
+            {loading && !diffData ? (
+              <div className="flex items-center justify-center py-12 text-neutral-400">
+                <Loader2 size={24} className="animate-spin" />
+              </div>
+            ) : diffData ? (
+              <>
+                {/* Summary */}
+                <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-3">
+                  Canvas refs: <span className="font-semibold text-neutral-700 dark:text-neutral-300">{diffData.summary.totalCanvasRefs}</span>
+                  {' \u00B7 '}SQLite: <span className="font-semibold text-neutral-700 dark:text-neutral-300">{diffData.summary.totalSqliteFiles}</span>
+                  {' \u00B7 '}S3: <span className="font-semibold text-neutral-700 dark:text-neutral-300">{diffData.summary.totalS3Files}</span>
+                </p>
+
+                {/* Table */}
+                <div className="border-2 border-black dark:border-neutral-700 rounded-xl overflow-hidden">
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="bg-neutral-100 dark:bg-neutral-800 border-b-2 border-black dark:border-neutral-700">
+                          <th className="w-10 px-3 py-2 text-center">
+                            <span className="sr-only">Select</span>
+                          </th>
+                          <th className="px-3 py-2 text-left font-bold text-neutral-700 dark:text-neutral-300">File ID</th>
+                          <th className="px-3 py-2 text-center font-bold text-neutral-700 dark:text-neutral-300">Canvas</th>
+                          <th className="px-3 py-2 text-center font-bold text-neutral-700 dark:text-neutral-300">SQLite</th>
+                          <th className="px-3 py-2 text-center font-bold text-neutral-700 dark:text-neutral-300">S3</th>
+                          <th className="px-3 py-2 text-right font-bold text-neutral-700 dark:text-neutral-300">Size</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {diffData.files.length === 0 ? (
+                          <tr>
+                            <td colSpan={6} className="px-3 py-6 text-center text-neutral-400">
+                              No files found.
+                            </td>
+                          </tr>
+                        ) : (
+                          diffData.files.map((file: FileDiffEntry) => (
+                            <tr
+                              key={file.fileId}
+                              className="border-t border-neutral-200 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-800/50"
+                            >
+                              <td className="px-3 py-2 text-center">
+                                <input
+                                  type="checkbox"
+                                  checked={selectedIds.has(file.fileId)}
+                                  disabled={file.inCanvasActive}
+                                  onChange={() => handleToggle(file.fileId)}
+                                  className="accent-rose-600 w-4 h-4 disabled:opacity-30"
+                                />
+                              </td>
+                              <td className="px-3 py-2 text-neutral-900 dark:text-neutral-100 font-mono text-xs truncate max-w-[200px]" title={file.fileId}>
+                                {file.fileId}
+                              </td>
+                              <td className="px-3 py-2 text-center">
+                                <StatusIcon active={file.inCanvasActive} present={file.inCanvas} />
+                              </td>
+                              <td className="px-3 py-2 text-center">
+                                <StatusIcon present={file.inSqlite} />
+                              </td>
+                              <td className="px-3 py-2 text-center">
+                                <StatusIcon present={file.inS3} />
+                              </td>
+                              <td className="px-3 py-2 text-right text-neutral-600 dark:text-neutral-400 tabular-nums">
+                                {formatSize(file.s3SizeBytes)}
+                              </td>
+                            </tr>
+                          ))
+                        )}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+
+                {/* Legend */}
+                <div className="flex gap-4 mt-2 text-xs text-neutral-500 dark:text-neutral-400">
+                  <span><span className="text-emerald-600 dark:text-emerald-400 font-bold">{'\u2713'}</span> active</span>
+                  <span><span className="text-amber-500 dark:text-amber-400 font-bold">{'\u25D0'}</span> history-only</span>
+                  <span><span className="text-neutral-400 dark:text-neutral-500 font-bold">{'\u2717'}</span> missing</span>
+                </div>
+
+                {/* Delete orphans button */}
+                <div className="mt-4">
+                  <button
+                    onClick={() => {
+                      setConfirmAction('delete-orphans');
+                      setConfirmInput('');
+                    }}
+                    disabled={selectedIds.size === 0}
+                    className="px-4 py-2.5 font-bold rounded-xl border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-0.5 active:translate-y-0 active:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] transition-all duration-200 bg-rose-600 text-white flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] disabled:hover:translate-y-0"
+                  >
+                    <Trash2 size={16} />
+                    Delete Selected Orphans ({selectedIds.size})
+                  </button>
+                </div>
+              </>
+            ) : null}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="p-4 border-t-2 border-black dark:border-neutral-700 flex items-center gap-2 text-xs text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/10 rounded-b-2xl">
+          <AlertTriangle size={14} className="shrink-0" />
+          These operations are irreversible.
+        </div>
+
+        {/* Confirmation overlay */}
+        {confirmAction && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-white/90 dark:bg-neutral-900/90 backdrop-blur-sm">
+            <div className="w-full max-w-sm p-6 space-y-4">
+              <div className="flex flex-col items-center text-center gap-3">
+                <div className="w-12 h-12 rounded-full bg-rose-100 dark:bg-rose-900/30 flex items-center justify-center text-rose-600 dark:text-rose-300 border-2 border-rose-200 dark:border-rose-900/30">
+                  <AlertTriangle size={24} strokeWidth={2.5} />
+                </div>
+                <h3 className="text-lg font-bold text-neutral-900 dark:text-neutral-100">
+                  {confirmAction === 'trim' ? 'Trim History' : 'Delete Orphan Files'}
+                </h3>
+                <p className="text-sm text-neutral-500 dark:text-neutral-400">
+                  Type the drawing name to confirm:
+                  <br />
+                  <span className="font-bold text-neutral-700 dark:text-neutral-200">{drawingName}</span>
+                </p>
+              </div>
+
+              <input
+                type="text"
+                value={confirmInput}
+                onChange={(e) => setConfirmInput(e.target.value)}
+                placeholder={drawingName}
+                autoFocus
+                className="w-full px-3 py-2 rounded-xl border-2 border-black dark:border-neutral-700 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+
+              <div className="flex gap-3">
+                <button
+                  onClick={() => {
+                    setConfirmAction(null);
+                    setConfirmInput('');
+                  }}
+                  disabled={actionLoading}
+                  className="flex-1 px-4 py-2.5 bg-emerald-50 dark:bg-neutral-800 text-emerald-700 dark:text-emerald-200 font-bold rounded-xl border-2 border-emerald-200 dark:border-neutral-700 hover:bg-emerald-100 dark:hover:bg-neutral-700 hover:border-emerald-300 dark:hover:border-neutral-600 hover:-translate-y-0.5 transition-all duration-200"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={confirmAction === 'trim' ? handleTrim : handleDeleteOrphans}
+                  disabled={!confirmMatch || actionLoading}
+                  className="flex-1 px-4 py-2.5 font-bold rounded-xl border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-0.5 active:translate-y-0 active:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] transition-all duration-200 bg-rose-600 text-white disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] disabled:hover:translate-y-0 flex items-center justify-center gap-2"
+                >
+                  {actionLoading && <Loader2 size={16} className="animate-spin" />}
+                  Confirm
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+};

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -144,6 +144,7 @@ const loadDroppedImageData = async (file: File): Promise<DroppedImageData> => {
   };
 };
 
+
 // Content-based signature for detecting "live" changes even when Excalidraw doesn't
 // bump version/versionNonce/updated until commit (e.g. during shape creation drags).
 const getElementContentSig = (element: any): string => {
@@ -264,6 +265,8 @@ export const Editor: React.FC = () => {
   const pendingRemoteElementOrderRef = useRef<string[] | null>(null);
   const remoteFlushScheduledRef = useRef(false);
   const remoteFlushRafIdRef = useRef<number | null>(null);
+  /** File IDs present at initial drawing load — skip S3 re-upload for these. */
+  const initialFileIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     setAutoHideEnabled(getStoredAutoHideEnabled());
@@ -892,6 +895,8 @@ export const Editor: React.FC = () => {
     scrollToContent: true,
   }), []);
 
+
+
   const saveDataRef = useRef<((drawingId: string, elements: readonly any[], appState: any, files?: Record<string, any>) => Promise<void>) | null>(null);
   const savePreviewRef = useRef<((drawingId: string, elements: readonly any[], appState: any, files: any) => Promise<void>) | null>(null);
   const saveLibraryRef = useRef<((items: any[]) => Promise<void>) | null>(null);
@@ -928,7 +933,9 @@ export const Editor: React.FC = () => {
         });
         return;
       }
-      let persistableFiles = files ?? latestFilesRef.current ?? {};
+      let persistableFiles: Record<string, any> = files ?? latestFilesRef.current ?? {};
+      // Compress images before sending to the backend; the backend's
+      // processFilesForS3 will then upload the compressed bytes to S3.
       const compressedFilesResult = await compressExcalidrawFiles(persistableFiles);
       if (compressedFilesResult.changed) {
         persistableFiles = compressedFilesResult.files;
@@ -949,6 +956,7 @@ export const Editor: React.FC = () => {
           });
         }
       }
+
       const filesChangedSincePersist =
         Object.keys(getFilesDelta(lastPersistedFilesRef.current || {}, persistableFiles || {}))
           .length > 0;
@@ -1206,7 +1214,11 @@ export const Editor: React.FC = () => {
         latestFilesRef.current = nextFiles;
       }
       if (shouldSyncFiles) {
-        lastSyncedFilesRef.current = nextFiles;
+        // Only mark as synced the files we actually broadcast.
+        lastSyncedFilesRef.current = {
+          ...lastSyncedFilesRef.current,
+          ...filesDelta,
+        };
       }
 
       if (changes.length > 0 || shouldSyncFiles || shouldSyncOrder) {
@@ -1311,6 +1323,7 @@ export const Editor: React.FC = () => {
         latestFilesRef.current = files;
         lastSyncedFilesRef.current = files;
         lastPersistedFilesRef.current = files;
+        initialFileIdsRef.current = new Set(Object.keys(files));
         currentDrawingVersionRef.current = typeof data.version === "number" ? data.version : null;
         lastPersistedElementsRef.current = elements;
 
@@ -1552,6 +1565,7 @@ export const Editor: React.FC = () => {
           appState
         );
 
+        // Load image data (base64 + dimensions) for all dropped files.
         const loadedImages = await Promise.all(droppedImages.map(loadDroppedImageData));
         if (loadedImages.length === 0) return;
 

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -265,8 +265,6 @@ export const Editor: React.FC = () => {
   const pendingRemoteElementOrderRef = useRef<string[] | null>(null);
   const remoteFlushScheduledRef = useRef(false);
   const remoteFlushRafIdRef = useRef<number | null>(null);
-  /** File IDs present at initial drawing load — skip S3 re-upload for these. */
-  const initialFileIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     setAutoHideEnabled(getStoredAutoHideEnabled());
@@ -1323,7 +1321,6 @@ export const Editor: React.FC = () => {
         latestFilesRef.current = files;
         lastSyncedFilesRef.current = files;
         lastPersistedFilesRef.current = files;
-        initialFileIdsRef.current = new Set(Object.keys(files));
         currentDrawingVersionRef.current = typeof data.version === "number" ? data.version : null;
         lastPersistedElementsRef.current = elements;
 

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -670,6 +670,13 @@ export const Editor: React.FC = () => {
       remoteFlushRafIdRef.current = requestAnimationFrame(flushRemoteUpdates);
     };
 
+    // Server-side mutations (storage trim, orphan delete) bypass the
+    // collaborative element-update channel — refetch so the open editor
+    // doesn't paper over the server change with its stale state.
+    socket.on("drawing-server-update", () => {
+      window.location.reload();
+    });
+
     socket.on(
       "element-update",
       ({
@@ -729,6 +736,7 @@ export const Editor: React.FC = () => {
       socket.off('error');
       socket.off('cursor-move');
       socket.off('element-update');
+      socket.off('drawing-server-update');
       socket.disconnect();
       if (remoteFlushRafIdRef.current !== null) {
         cancelAnimationFrame(remoteFlushRafIdRef.current);


### PR DESCRIPTION
Part of #145. **Depends on #163, please review/merge that first.**

## Why
The drift between canvas refs, `Drawing.files` JSON keys, and the actual S3 bucket is inevitable: soft-deleted elements that still reference files, S3 objects with no DB row from partially-failed saves, etc. Operators need tooling to see and clean up that drift per drawing.

## What
**Backend routes** (require ownership + name confirmation):
- `POST /drawings/:id/trim` — drop `isDeleted` elements, prune unreferenced file entries, delete the corresponding S3 objects + `S3File` rows. Requires `confirmName` matching the drawing name (GitHub-style guard). Bumps `version` so concurrent editors get `VERSION_CONFLICT` and reload (regression-tested: previously hard-coded `version: 1`, which silently overwrote concurrent newer versions).
- `GET /drawings/:id/files/diff` — three-way diff over canvas refs, SQLite files keys, and S3 objects under the per-drawing prefix.
- `DELETE /drawings/:id/files/orphans` — selectively delete fileIds the caller knows are unused. Refuses fileIds active in non-deleted elements; also strips deleted-element references to deleted fileIds so the diff stops reporting them.

**Frontend**:
- `StorageManageModal` renders the three-way diff with checkboxes.
- "Trim history" and "delete selected orphans" buttons require typing the drawing name (destructive-action guard).
- Hooked into `DrawingCard` right-click menu.

## Notable safety fixes (review feedback, separate commits)
- `fix(storage): invalidate cache, share-aware orphan deletion, version bump` — cache invalidated after every mutation; orphan-delete refuses to delete shared S3 objects (the earlier PR already isolates per drawing, kept as belt-and-braces); orphans route also bumps version.
- `fix(storage): notify open editors of server-side mutations` — emits `drawing-server-update` on the socket room after every mutation; `Editor.tsx` listens and reloads. Without this, a collaborator's next save would echo the trimmed-away elements back, undoing the cleanup.
- `fix(storage): bump version on trim instead of resetting to 1` — regression-locked by the new tests.
- `fix(storage): drawing-scoped S3 queries` — composite-PK aware queries for trim/diff/orphans (matches the earlier PR's per-drawing isolation model).
- `test(storage): replace tautological tests with real route integration` — the original tests re-implemented the route logic inline and asserted on their own work; replaced with supertest driving the real Express handler (8 cases: confirmName guards, version monotonicity, active-ref protection, empty payload, non-owner 404, etc.).

## Risk
All write operations are destructive but **gated behind a name-confirmation prompt** (matching the drawing's actual name). The diff query is read-only. Tests cover the version-bump behaviour so the trim regression that prompted the rewrite cannot recur.

## Verification
- `npm run build`, `npm test` (all pass; 8 storage integration tests cover this PR)
- Manual: trim/orphan cycle on a deployment with OSS-backed images confirms S3 objects are cleaned and the diff reports converge.
