### PR TITLE
Add API key authentication for automation clients

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,99 @@
+name: Publish GHCR Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_suffix:
+        description: Tag to publish; defaults to current ref slug
+        required: false
+        type: string
+  push:
+    branches:
+      - api-key-auth-for-obsidian-plugin
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and Publish Images
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare tags
+        id: vars
+        shell: bash
+        env:
+          INPUT_TAG_SUFFIX: ${{ github.event.inputs.tag_suffix || '' }}
+        run: |
+          owner_lc="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          ref_slug="$(printf '%s' "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g; s/^-+|-+$//g')"
+          tag_suffix="$INPUT_TAG_SUFFIX"
+          if [ -z "$tag_suffix" ]; then
+            tag_suffix="$ref_slug"
+          fi
+          tag_suffix="$(printf '%s' "$tag_suffix" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g; s/^-+|-+$//g')"
+          echo "owner_lc=$owner_lc" >> "$GITHUB_OUTPUT"
+          echo "tag_suffix=$tag_suffix" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Backend metadata
+        id: backend-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ steps.vars.outputs.owner_lc }}/excalidash-backend
+          tags: |
+            type=raw,value=${{ steps.vars.outputs.tag_suffix }}
+            type=raw,value=${{ steps.vars.outputs.short_sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+
+      - name: Build and push backend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.backend-meta.outputs.tags }}
+          labels: ${{ steps.backend-meta.outputs.labels }}
+
+      - name: Frontend metadata
+        id: frontend-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ steps.vars.outputs.owner_lc }}/excalidash-frontend
+          tags: |
+            type=raw,value=${{ steps.vars.outputs.tag_suffix }}
+            type=raw,value=${{ steps.vars.outputs.short_sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+
+      - name: Build and push frontend
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./frontend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.frontend-meta.outputs.tags }}
+          labels: ${{ steps.frontend-meta.outputs.labels }}
+          build-args: |
+            VITE_APP_VERSION=${{ steps.vars.outputs.tag_suffix }}
+            VITE_APP_BUILD_LABEL=fork

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Notes:
 Personal API keys for automation clients:
 
 - Create and manage keys from the authenticated account API: `GET /auth/api-keys`, `POST /auth/api-keys`, and `DELETE /auth/api-keys/:id`.
-- `POST /auth/api-keys` accepts `{ "name": "Obsidian" }` and returns the plaintext token once. Store it immediately; ExcaliDash stores only a hash and metadata.
+- `POST /auth/api-keys` accepts `{ "name": "Obsidian" }` and optional `scopes`, for example `{ "name": "Obsidian", "scopes": ["drawings:read", "drawings:write"] }`. If omitted, all API-key scopes are granted. Store the returned plaintext token immediately; ExcaliDash stores only a hash and metadata.
 - Automation clients such as the Obsidian plugin should call normal drawing and collection APIs with `Authorization: Bearer <key>`, for example `Authorization: Bearer exd_...`.
 - API keys are scoped automation credentials for `/drawings` and `/collections` only. They cannot manage account settings, create/revoke API keys, call admin endpoints, or use import/export APIs.
 - API-key Bearer requests without browser `Origin`/`Referer` headers do not require CSRF tokens. Cookie-authenticated browser requests keep the existing CSRF behavior.

--- a/README.md
+++ b/README.md
@@ -328,6 +328,13 @@ Notes:
 | OIDC admin mapping          | If `OIDC_ADMIN_GROUPS` is set, admin role is reconciled on each authenticated request for OIDC users: users in those groups are promoted to `ADMIN`, users not in those groups are demoted to `USER`. |
 | Legacy sessions             | Users with old sessions (issued before group claims were embedded) should sign out/in once so OIDC group claims are refreshed. |
 
+Personal API keys for automation clients:
+
+- Create and manage keys from the authenticated account API: `GET /auth/api-keys`, `POST /auth/api-keys`, and `DELETE /auth/api-keys/:id`.
+- `POST /auth/api-keys` accepts `{ "name": "Obsidian" }` and returns the plaintext token once. Store it immediately; ExcaliDash stores only a hash and metadata.
+- Automation clients such as the Obsidian plugin should call normal drawing and collection APIs with `Authorization: Bearer <key>`, for example `Authorization: Bearer exd_...`.
+- API-key Bearer requests without browser `Origin`/`Referer` headers do not require CSRF tokens. Cookie-authenticated browser requests keep the existing CSRF behavior.
+
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ Personal API keys for automation clients:
 - Create and manage keys from the authenticated account API: `GET /auth/api-keys`, `POST /auth/api-keys`, and `DELETE /auth/api-keys/:id`.
 - `POST /auth/api-keys` accepts `{ "name": "Obsidian" }` and returns the plaintext token once. Store it immediately; ExcaliDash stores only a hash and metadata.
 - Automation clients such as the Obsidian plugin should call normal drawing and collection APIs with `Authorization: Bearer <key>`, for example `Authorization: Bearer exd_...`.
+- API keys are scoped automation credentials for `/drawings` and `/collections` only. They cannot manage account settings, create/revoke API keys, call admin endpoints, or use import/export APIs.
 - API-key Bearer requests without browser `Origin`/`Referer` headers do not require CSRF tokens. Cookie-authenticated browser requests keep the existing CSRF behavior.
 
 </details>

--- a/backend/prisma/migrations/20260513120000_add_api_keys/migration.sql
+++ b/backend/prisma/migrations/20260513120000_add_api_keys/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "ApiKey" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "keyId" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "prefix" TEXT NOT NULL,
+    "scopes" TEXT NOT NULL DEFAULT 'drawings:read,drawings:write,collections:read,collections:write',
+    "lastUsedAt" DATETIME,
+    "revokedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ApiKey_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ApiKey_keyId_key" ON "ApiKey"("keyId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ApiKey_tokenHash_key" ON "ApiKey"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "ApiKey_userId_createdAt_idx" ON "ApiKey"("userId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ApiKey_keyId_revokedAt_idx" ON "ApiKey"("keyId", "revokedAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -24,6 +24,7 @@ model User {
   drawingPermissions  DrawingPermission[]
   passwordResetTokens PasswordResetToken[]
   refreshTokens       RefreshToken[]
+  apiKeys             ApiKey[]
   auditLogs           AuditLog[]
   createdAt           DateTime            @default(now())
   updatedAt           DateTime            @updatedAt
@@ -155,6 +156,24 @@ model RefreshToken {
   expiresAt DateTime
   revoked   Boolean  @default(false)
   createdAt DateTime @default(now())
+}
+
+model ApiKey {
+  id          String    @id @default(uuid())
+  userId      String
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  name        String
+  keyId       String    @unique
+  tokenHash   String    @unique
+  prefix      String
+  scopes      String    @default("drawings:read,drawings:write,collections:read,collections:write")
+  lastUsedAt  DateTime?
+  revokedAt   DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@index([userId, createdAt])
+  @@index([keyId, revokedAt])
 }
 
 model AuditLog {

--- a/backend/src/__tests__/api-key-auth.integration.ts
+++ b/backend/src/__tests__/api-key-auth.integration.ts
@@ -123,6 +123,15 @@ describe("API key authentication", () => {
     expect(response.status).toBe(403);
   });
 
+  it("rejects API key access to drawing permission subroutes", async () => {
+    const response = await request(app)
+      .post("/drawings/drawing-1/permissions")
+      .set("Authorization", `Bearer ${apiKeyToken}`)
+      .send({ granteeUserId: "user-2", permission: "view" });
+
+    expect(response.status).toBe(403);
+  });
+
   it("stores only hashed API keys and metadata", async () => {
     const stored = await prisma.apiKey.findUnique({ where: { id: apiKeyId } });
 

--- a/backend/src/__tests__/api-key-auth.integration.ts
+++ b/backend/src/__tests__/api-key-auth.integration.ts
@@ -5,6 +5,32 @@ import { PrismaClient } from "../generated/client";
 import { generateApiKey, serializeApiKeyScopes } from "../auth/apiKeys";
 import { getTestPrisma, setupTestDb } from "./testUtils";
 
+type ApiKeyFixture = {
+  id: string;
+  token: string;
+};
+
+async function createApiKeyFixture(
+  prisma: PrismaClient,
+  userId: string,
+  name: string,
+): Promise<ApiKeyFixture> {
+  const generated = generateApiKey();
+  const apiKey = await prisma.apiKey.create({
+    data: {
+      userId,
+      name,
+      keyId: generated.keyId,
+      tokenHash: generated.tokenHash,
+      prefix: generated.prefix,
+      scopes: serializeApiKeyScopes(),
+    },
+    select: { id: true },
+  });
+
+  return { id: apiKey.id, token: generated.token };
+}
+
 describe("API key authentication", () => {
   let prisma: PrismaClient;
   let app: any;
@@ -37,20 +63,9 @@ describe("API key authentication", () => {
     });
     userId = user.id;
 
-    const generated = generateApiKey();
-    apiKeyToken = generated.token;
-    const apiKey = await prisma.apiKey.create({
-      data: {
-        userId,
-        name: "Obsidian automation",
-        keyId: generated.keyId,
-        tokenHash: generated.tokenHash,
-        prefix: generated.prefix,
-        scopes: serializeApiKeyScopes(),
-      },
-      select: { id: true },
-    });
-    apiKeyId = apiKey.id;
+    const apiKeyFixture = await createApiKeyFixture(prisma, userId, "Obsidian automation");
+    apiKeyToken = apiKeyFixture.token;
+    apiKeyId = apiKeyFixture.id;
 
     const adminUser = await prisma.user.create({
       data: {
@@ -62,18 +77,8 @@ describe("API key authentication", () => {
       },
       select: { id: true },
     });
-    const adminGenerated = generateApiKey();
-    adminApiKeyToken = adminGenerated.token;
-    await prisma.apiKey.create({
-      data: {
-        userId: adminUser.id,
-        name: "Admin automation",
-        keyId: adminGenerated.keyId,
-        tokenHash: adminGenerated.tokenHash,
-        prefix: adminGenerated.prefix,
-        scopes: serializeApiKeyScopes(),
-      },
-    });
+    const adminApiKeyFixture = await createApiKeyFixture(prisma, adminUser.id, "Admin automation");
+    adminApiKeyToken = adminApiKeyFixture.token;
   });
 
   afterAll(async () => {

--- a/backend/src/__tests__/api-key-auth.integration.ts
+++ b/backend/src/__tests__/api-key-auth.integration.ts
@@ -1,0 +1,104 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import request from "supertest";
+import bcrypt from "bcrypt";
+import { PrismaClient } from "../generated/client";
+import { generateApiKey, serializeApiKeyScopes } from "../auth/apiKeys";
+import { getTestPrisma, setupTestDb } from "./testUtils";
+
+describe("API key authentication", () => {
+  let prisma: PrismaClient;
+  let app: any;
+  let userId: string;
+  let apiKeyId: string;
+  let apiKeyToken: string;
+
+  beforeAll(async () => {
+    setupTestDb();
+    prisma = getTestPrisma();
+    ({ app } = await import("../index"));
+
+    await prisma.systemConfig.upsert({
+      where: { id: "default" },
+      update: { authEnabled: true, registrationEnabled: false },
+      create: { id: "default", authEnabled: true, registrationEnabled: false },
+    });
+
+    const passwordHash = await bcrypt.hash("password123", 10);
+    const user = await prisma.user.create({
+      data: {
+        email: "api-key-user@test.local",
+        passwordHash,
+        name: "API Key User",
+        role: "USER",
+        isActive: true,
+      },
+      select: { id: true },
+    });
+    userId = user.id;
+
+    const generated = generateApiKey();
+    apiKeyToken = generated.token;
+    const apiKey = await prisma.apiKey.create({
+      data: {
+        userId,
+        name: "Obsidian automation",
+        keyId: generated.keyId,
+        tokenHash: generated.tokenHash,
+        prefix: generated.prefix,
+        scopes: serializeApiKeyScopes(),
+      },
+      select: { id: true },
+    });
+    apiKeyId = apiKey.id;
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("accepts API key bearer auth for write API requests without CSRF", async () => {
+    const response = await request(app)
+      .post("/collections")
+      .set("Authorization", `Bearer ${apiKeyToken}`)
+      .send({ name: "Automation" });
+
+    expect(response.status).toBe(200);
+    expect(response.body?.name).toBe("Automation");
+    expect(response.body?.userId).toBe(userId);
+
+    const stored = await prisma.apiKey.findUnique({ where: { id: apiKeyId } });
+    expect(stored?.lastUsedAt).toBeInstanceOf(Date);
+  });
+
+  it("stores only hashed API keys and metadata", async () => {
+    const stored = await prisma.apiKey.findUnique({ where: { id: apiKeyId } });
+
+    expect(stored?.tokenHash).toBeTruthy();
+    expect(stored?.tokenHash).not.toBe(apiKeyToken);
+    expect(stored?.keyId).not.toBe(apiKeyToken);
+    expect(stored?.prefix).toBe(apiKeyToken.slice(0, 16));
+  });
+
+  it("rejects invalid API keys", async () => {
+    const response = await request(app)
+      .post("/collections")
+      .set("Authorization", "Bearer exd_invalid_invalid")
+      .send({ name: "Invalid" });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects revoked API keys", async () => {
+    await prisma.apiKey.update({
+      where: { id: apiKeyId },
+      data: { revokedAt: new Date() },
+    });
+
+    const response = await request(app)
+      .post("/collections")
+      .set("Authorization", `Bearer ${apiKeyToken}`)
+      .send({ name: "Revoked" });
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/backend/src/__tests__/api-key-auth.integration.ts
+++ b/backend/src/__tests__/api-key-auth.integration.ts
@@ -11,6 +11,7 @@ describe("API key authentication", () => {
   let userId: string;
   let apiKeyId: string;
   let apiKeyToken: string;
+  let adminApiKeyToken: string;
 
   beforeAll(async () => {
     setupTestDb();
@@ -50,6 +51,29 @@ describe("API key authentication", () => {
       select: { id: true },
     });
     apiKeyId = apiKey.id;
+
+    const adminUser = await prisma.user.create({
+      data: {
+        email: "api-key-admin@test.local",
+        passwordHash,
+        name: "API Key Admin",
+        role: "ADMIN",
+        isActive: true,
+      },
+      select: { id: true },
+    });
+    const adminGenerated = generateApiKey();
+    adminApiKeyToken = adminGenerated.token;
+    await prisma.apiKey.create({
+      data: {
+        userId: adminUser.id,
+        name: "Admin automation",
+        keyId: adminGenerated.keyId,
+        tokenHash: adminGenerated.tokenHash,
+        prefix: adminGenerated.prefix,
+        scopes: serializeApiKeyScopes(),
+      },
+    });
   });
 
   afterAll(async () => {
@@ -68,6 +92,35 @@ describe("API key authentication", () => {
 
     const stored = await prisma.apiKey.findUnique({ where: { id: apiKeyId } });
     expect(stored?.lastUsedAt).toBeInstanceOf(Date);
+  });
+
+  it("accepts API key bearer auth for allowed read routes", async () => {
+    const collectionsResponse = await request(app)
+      .get("/collections")
+      .set("Authorization", `Bearer ${apiKeyToken}`);
+    const drawingsResponse = await request(app)
+      .get("/drawings")
+      .set("Authorization", `Bearer ${apiKeyToken}`);
+
+    expect(collectionsResponse.status).toBe(200);
+    expect(drawingsResponse.status).toBe(200);
+  });
+
+  it("rejects API key management with API key auth", async () => {
+    const response = await request(app)
+      .get("/auth/api-keys")
+      .set("Authorization", `Bearer ${apiKeyToken}`);
+
+    expect(response.status).toBe(403);
+  });
+
+  it("rejects admin actions with admin-owned API key auth", async () => {
+    const response = await request(app)
+      .get("/auth/users")
+      .set("Authorization", `Bearer ${adminApiKeyToken}`)
+      .send();
+
+    expect(response.status).toBe(403);
   });
 
   it("stores only hashed API keys and metadata", async () => {

--- a/backend/src/__tests__/drawing-history.test.ts
+++ b/backend/src/__tests__/drawing-history.test.ts
@@ -74,8 +74,8 @@ function buildApp() {
     asyncHandler: (fn: any) => (req: any, res: any, next: any) => Promise.resolve(fn(req, res, next)).catch(next),
     parseJsonField: (val: string, fallback: any) => { try { return JSON.parse(val); } catch { return fallback; } },
     validateImportedDrawing: vi.fn().mockReturnValue(true),
-    drawingCreateSchema: { safeParse: vi.fn().mockReturnValue({ success: true, data: {} }) },
-    drawingUpdateSchema: { safeParse: vi.fn() },
+    drawingCreateSchema: { safeParse: vi.fn().mockReturnValue({ success: true, data: {} }) } as any,
+    drawingUpdateSchema: { safeParse: vi.fn() } as any,
     respondWithValidationErrors: vi.fn(),
     ensureTrashCollection: vi.fn(),
     invalidateDrawingsCache: vi.fn(),
@@ -85,7 +85,7 @@ function buildApp() {
     MAX_PAGE_SIZE: 100,
     config: { nodeEnv: "test", enableAuditLogging: false },
     logAuditEvent: vi.fn(),
-  });
+  } as any);
 
   return { app, prisma };
 }

--- a/backend/src/__tests__/testUtils.ts
+++ b/backend/src/__tests__/testUtils.ts
@@ -90,6 +90,7 @@ export const setupTestDb = () => {
  * Clean up the test database between tests
  */
 export const cleanupTestDb = async (prisma: PrismaClient) => {
+  await prisma.apiKey.deleteMany({});
   await prisma.drawing.deleteMany({});
   await prisma.collection.deleteMany({});
 };

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -34,6 +34,7 @@ import {
   setAccessTokenCookie,
   setAuthCookies,
 } from "./auth/cookies";
+import { isNonBrowserApiKeyBearerRequest } from "./auth/apiKeys";
 
 interface JwtPayload {
   userId: string;
@@ -348,6 +349,10 @@ export const createAuthRouter = (deps: CreateAuthRouterDeps): express.Router => 
   };
 
   const requireCsrf = (req: Request, res: Response): boolean => {
+    if (isNonBrowserApiKeyBearerRequest(req)) {
+      return true;
+    }
+
     const origin = req.headers["origin"];
     const referer = req.headers["referer"];
     const originValue = Array.isArray(origin) ? origin[0] : origin;

--- a/backend/src/auth/accountRoutes.test.ts
+++ b/backend/src/auth/accountRoutes.test.ts
@@ -23,6 +23,8 @@ const buildApp = (options?: { impersonatorId?: string }) => {
     },
     apiKey: {
       findFirst: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
       update: vi.fn(),
     },
   } as any;
@@ -140,5 +142,83 @@ describe("accountRoutes local-password safeguards", () => {
     expect(response.body?.message).toContain("impersonating");
     expect(prisma.apiKey.findFirst).not.toHaveBeenCalled();
     expect(prisma.apiKey.update).not.toHaveBeenCalled();
+  });
+
+  it("creates API keys with sanitized custom scopes", async () => {
+    const { app, prisma } = buildApp();
+    prisma.apiKey.create.mockImplementation(async ({ data }: any) => ({
+      id: "key-1",
+      name: data.name,
+      prefix: data.prefix,
+      scopes: data.scopes,
+      lastUsedAt: null,
+      revokedAt: null,
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+      updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+    }));
+
+    const response = await request(app).post("/api-keys").send({
+      name: "Scoped Key",
+      scopes: [" drawings:read ", "drawings:read", "collections:write"],
+    });
+
+    expect(response.status).toBe(201);
+    expect(prisma.apiKey.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        name: "Scoped Key",
+        scopes: "drawings:read,collections:write",
+      }),
+    }));
+    expect(response.body.apiKey.scopes).toEqual(["drawings:read", "collections:write"]);
+    expect(response.body.token).toMatch(/^exd_/);
+  });
+
+  it("keeps default API key scopes when scopes are omitted", async () => {
+    const { app, prisma } = buildApp();
+    prisma.apiKey.create.mockImplementation(async ({ data }: any) => ({
+      id: "key-1",
+      name: data.name,
+      prefix: data.prefix,
+      scopes: data.scopes,
+      lastUsedAt: null,
+      revokedAt: null,
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+      updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+    }));
+
+    const response = await request(app).post("/api-keys").send({ name: "Default Key" });
+
+    expect(response.status).toBe(201);
+    expect(prisma.apiKey.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        scopes: "drawings:read,drawings:write,collections:read,collections:write",
+      }),
+    }));
+  });
+
+  it("rejects API key creation with no scopes", async () => {
+    const { app, prisma } = buildApp();
+
+    const response = await request(app).post("/api-keys").send({
+      name: "No Scopes",
+      scopes: [],
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body?.message).toContain("at least one");
+    expect(prisma.apiKey.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects API key creation with invalid scopes", async () => {
+    const { app, prisma } = buildApp();
+
+    const response = await request(app).post("/api-keys").send({
+      name: "Bad Scope",
+      scopes: ["drawings:read", "admin:write"],
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body?.message).toContain("valid API key scope");
+    expect(prisma.apiKey.create).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/auth/accountRoutes.test.ts
+++ b/backend/src/auth/accountRoutes.test.ts
@@ -3,7 +3,7 @@ import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { registerAccountRoutes } from "./accountRoutes";
 
-const buildApp = () => {
+const buildApp = (options?: { impersonatorId?: string }) => {
   const router = express.Router();
   router.use(express.json());
 
@@ -21,6 +21,10 @@ const buildApp = () => {
     refreshToken: {
       updateMany: vi.fn(),
     },
+    apiKey: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
   } as any;
 
   registerAccountRoutes({
@@ -32,6 +36,7 @@ const buildApp = () => {
         email: "user@example.com",
         name: "User",
         role: "USER",
+        impersonatorId: options?.impersonatorId,
       };
       next();
     }) as any,
@@ -124,5 +129,16 @@ describe("accountRoutes local-password safeguards", () => {
       data: { used: true },
     });
     expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects API key revocation while impersonating", async () => {
+    const { app, prisma } = buildApp({ impersonatorId: "admin-1" });
+
+    const response = await request(app).delete("/api-keys/key-1");
+
+    expect(response.status).toBe(403);
+    expect(response.body?.message).toContain("impersonating");
+    expect(prisma.apiKey.findFirst).not.toHaveBeenCalled();
+    expect(prisma.apiKey.update).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/auth/accountRoutes.ts
+++ b/backend/src/auth/accountRoutes.ts
@@ -4,6 +4,7 @@ import crypto from "crypto";
 import { PrismaClient } from "../generated/client";
 import { logAuditEvent } from "../utils/audit";
 import {
+  apiKeyCreateSchema,
   changePasswordSchema,
   mustResetPasswordSchema,
   passwordResetConfirmSchema,
@@ -13,6 +14,12 @@ import {
 } from "./schemas";
 import { canUseLocalPasswordFlows } from "./localPassword";
 import { hashTokenForStorage } from "./tokenSecurity";
+import {
+  DEFAULT_API_KEY_SCOPES,
+  generateApiKey,
+  parseApiKeyScopes,
+  serializeApiKeyScopes,
+} from "./apiKeys";
 
 type RegisterAccountRoutesDeps = {
   router: express.Router;
@@ -62,6 +69,26 @@ export const registerAccountRoutes = (deps: RegisterAccountRoutesDeps) => {
     setAuthCookies,
     requireCsrf,
   } = deps;
+
+  const serializeApiKeyMetadata = (apiKey: {
+    id: string;
+    name: string;
+    prefix: string;
+    scopes: string;
+    lastUsedAt: Date | null;
+    revokedAt: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }) => ({
+    id: apiKey.id,
+    name: apiKey.name,
+    prefix: apiKey.prefix,
+    scopes: parseApiKeyScopes(apiKey.scopes),
+    lastUsedAt: apiKey.lastUsedAt,
+    revokedAt: apiKey.revokedAt,
+    createdAt: apiKey.createdAt,
+    updatedAt: apiKey.updatedAt,
+  });
 
   router.post("/password-reset-request", loginAttemptRateLimiter, async (req: Request, res: Response) => {
     if (!(await ensureAuthEnabled(res))) return;
@@ -278,6 +305,147 @@ export const registerAccountRoutes = (deps: RegisterAccountRoutesDeps) => {
       return res.status(500).json({
         error: "Internal server error",
         message: "Failed to update profile",
+      });
+    }
+  });
+
+  router.get("/api-keys", requireAuth, async (req: Request, res: Response) => {
+    try {
+      if (!(await ensureAuthEnabled(res))) return;
+      if (!req.user) {
+        return res.status(401).json({ error: "Unauthorized", message: "User not authenticated" });
+      }
+
+      const apiKeys = await prisma.apiKey.findMany({
+        where: { userId: req.user.id },
+        orderBy: { createdAt: "desc" },
+        select: {
+          id: true,
+          name: true,
+          prefix: true,
+          scopes: true,
+          lastUsedAt: true,
+          revokedAt: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
+
+      return res.json({ apiKeys: apiKeys.map(serializeApiKeyMetadata) });
+    } catch (error) {
+      console.error("List API keys error:", error);
+      return res.status(500).json({
+        error: "Internal server error",
+        message: "Failed to list API keys",
+      });
+    }
+  });
+
+  router.post("/api-keys", requireAuth, accountActionRateLimiter, async (req: Request, res: Response) => {
+    try {
+      if (!(await ensureAuthEnabled(res))) return;
+      if (!requireCsrf(req, res)) return;
+      if (!req.user) {
+        return res.status(401).json({ error: "Unauthorized", message: "User not authenticated" });
+      }
+      if (req.user.impersonatorId) {
+        return res.status(403).json({
+          error: "Forbidden",
+          message: "API key creation is not allowed while impersonating",
+        });
+      }
+
+      const parsed = apiKeyCreateSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({
+          error: "Validation error",
+          message: "API key name must be between 1 and 100 characters",
+        });
+      }
+
+      const generated = generateApiKey();
+      const apiKey = await prisma.apiKey.create({
+        data: {
+          userId: req.user.id,
+          name: sanitizeText(parsed.data.name, 100),
+          keyId: generated.keyId,
+          tokenHash: generated.tokenHash,
+          prefix: generated.prefix,
+          scopes: serializeApiKeyScopes(DEFAULT_API_KEY_SCOPES),
+        },
+        select: {
+          id: true,
+          name: true,
+          prefix: true,
+          scopes: true,
+          lastUsedAt: true,
+          revokedAt: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
+
+      if (config.enableAuditLogging) {
+        await logAuditEvent({
+          userId: req.user.id,
+          action: "api_key_created",
+          resource: `api_key:${apiKey.id}`,
+          ipAddress: req.ip || req.connection.remoteAddress || undefined,
+          userAgent: req.headers["user-agent"] || undefined,
+        });
+      }
+
+      return res.status(201).json({
+        apiKey: serializeApiKeyMetadata(apiKey),
+        token: generated.token,
+      });
+    } catch (error) {
+      console.error("Create API key error:", error);
+      return res.status(500).json({
+        error: "Internal server error",
+        message: "Failed to create API key",
+      });
+    }
+  });
+
+  router.delete("/api-keys/:id", requireAuth, accountActionRateLimiter, async (req: Request, res: Response) => {
+    try {
+      if (!(await ensureAuthEnabled(res))) return;
+      if (!requireCsrf(req, res)) return;
+      if (!req.user) {
+        return res.status(401).json({ error: "Unauthorized", message: "User not authenticated" });
+      }
+
+      const apiKey = await prisma.apiKey.findFirst({
+        where: { id: req.params.id, userId: req.user.id },
+        select: { id: true, revokedAt: true },
+      });
+      if (!apiKey) {
+        return res.status(404).json({ error: "Not found", message: "API key not found" });
+      }
+      if (!apiKey.revokedAt) {
+        await prisma.apiKey.update({
+          where: { id: apiKey.id },
+          data: { revokedAt: new Date() },
+        });
+      }
+
+      if (config.enableAuditLogging) {
+        await logAuditEvent({
+          userId: req.user.id,
+          action: "api_key_revoked",
+          resource: `api_key:${apiKey.id}`,
+          ipAddress: req.ip || req.connection.remoteAddress || undefined,
+          userAgent: req.headers["user-agent"] || undefined,
+        });
+      }
+
+      return res.json({ success: true });
+    } catch (error) {
+      console.error("Revoke API key error:", error);
+      return res.status(500).json({
+        error: "Internal server error",
+        message: "Failed to revoke API key",
       });
     }
   });

--- a/backend/src/auth/accountRoutes.ts
+++ b/backend/src/auth/accountRoutes.ts
@@ -90,6 +90,16 @@ export const registerAccountRoutes = (deps: RegisterAccountRoutesDeps) => {
     updatedAt: apiKey.updatedAt,
   });
 
+  const normalizeApiKeyScopes = (scopes: string[] | undefined): string[] | null => {
+    if (!scopes) return [...DEFAULT_API_KEY_SCOPES];
+    const allowedScopes = new Set<string>(DEFAULT_API_KEY_SCOPES);
+    const normalized = Array.from(new Set(scopes.map((scope) => scope.trim()).filter(Boolean)));
+    if (normalized.length === 0 || normalized.some((scope) => !allowedScopes.has(scope))) {
+      return null;
+    }
+    return normalized;
+  };
+
   router.post("/password-reset-request", loginAttemptRateLimiter, async (req: Request, res: Response) => {
     if (!(await ensureAuthEnabled(res))) return;
     if (!config.enablePasswordReset) {
@@ -363,6 +373,14 @@ export const registerAccountRoutes = (deps: RegisterAccountRoutesDeps) => {
         });
       }
 
+      const scopes = normalizeApiKeyScopes(parsed.data.scopes);
+      if (!scopes) {
+        return res.status(400).json({
+          error: "Validation error",
+          message: "Select at least one valid API key scope",
+        });
+      }
+
       const generated = generateApiKey();
       const apiKey = await prisma.apiKey.create({
         data: {
@@ -371,7 +389,7 @@ export const registerAccountRoutes = (deps: RegisterAccountRoutesDeps) => {
           keyId: generated.keyId,
           tokenHash: generated.tokenHash,
           prefix: generated.prefix,
-          scopes: serializeApiKeyScopes(DEFAULT_API_KEY_SCOPES),
+          scopes: serializeApiKeyScopes(scopes),
         },
         select: {
           id: true,

--- a/backend/src/auth/accountRoutes.ts
+++ b/backend/src/auth/accountRoutes.ts
@@ -415,6 +415,12 @@ export const registerAccountRoutes = (deps: RegisterAccountRoutesDeps) => {
       if (!req.user) {
         return res.status(401).json({ error: "Unauthorized", message: "User not authenticated" });
       }
+      if (req.user.impersonatorId) {
+        return res.status(403).json({
+          error: "Forbidden",
+          message: "API key revocation is not allowed while impersonating",
+        });
+      }
 
       const apiKey = await prisma.apiKey.findFirst({
         where: { id: req.params.id, userId: req.user.id },

--- a/backend/src/auth/apiKeys.test.ts
+++ b/backend/src/auth/apiKeys.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { API_KEY_PREFIX, extractApiKeyId } from "./apiKeys";
+
+describe("API key helpers", () => {
+  it("extracts generated-format key IDs that contain underscores", () => {
+    const keyId = "abcd_efgh_123456";
+    const token = `${API_KEY_PREFIX}${keyId}_secret_value`;
+
+    expect(extractApiKeyId(token)).toBe(keyId);
+  });
+});

--- a/backend/src/auth/apiKeys.ts
+++ b/backend/src/auth/apiKeys.ts
@@ -1,0 +1,73 @@
+import crypto from "crypto";
+
+export const API_KEY_PREFIX = "exd_";
+export const DEFAULT_API_KEY_SCOPES = [
+  "drawings:read",
+  "drawings:write",
+  "collections:read",
+  "collections:write",
+] as const;
+
+export const generateApiKey = (): {
+  token: string;
+  keyId: string;
+  prefix: string;
+  tokenHash: string;
+} => {
+  const keyId = crypto.randomBytes(12).toString("base64url");
+  const secret = crypto.randomBytes(32).toString("base64url");
+  const token = `${API_KEY_PREFIX}${keyId}_${secret}`;
+
+  return {
+    token,
+    keyId,
+    prefix: token.slice(0, 16),
+    tokenHash: hashApiKey(token),
+  };
+};
+
+export const hashApiKey = (token: string): string =>
+  crypto.createHash("sha256").update(token, "utf8").digest("hex");
+
+export const isApiKeyToken = (token: string): boolean => token.startsWith(API_KEY_PREFIX);
+
+export const extractApiKeyId = (token: string): string | null => {
+  if (!isApiKeyToken(token)) return null;
+  const withoutPrefix = token.slice(API_KEY_PREFIX.length);
+  const separatorIndex = withoutPrefix.indexOf("_");
+  if (separatorIndex <= 0) return null;
+  const keyId = withoutPrefix.slice(0, separatorIndex);
+  return /^[A-Za-z0-9_-]{8,64}$/.test(keyId) ? keyId : null;
+};
+
+export const apiKeyHashMatches = (token: string, storedHash: string): boolean => {
+  const computed = Buffer.from(hashApiKey(token), "hex");
+  const stored = Buffer.from(storedHash, "hex");
+  if (computed.length !== stored.length) return false;
+  return crypto.timingSafeEqual(computed, stored);
+};
+
+export const serializeApiKeyScopes = (scopes: readonly string[] = DEFAULT_API_KEY_SCOPES): string =>
+  scopes.join(",");
+
+export const parseApiKeyScopes = (raw: string | null | undefined): string[] =>
+  (raw || "")
+    .split(",")
+    .map((scope) => scope.trim())
+    .filter((scope) => scope.length > 0);
+
+export const hasBearerApiKey = (authorizationHeader: unknown): boolean => {
+  const header = Array.isArray(authorizationHeader)
+    ? authorizationHeader[0]
+    : authorizationHeader;
+  if (typeof header !== "string") return false;
+  const [scheme, token] = header.split(" ");
+  return scheme === "Bearer" && typeof token === "string" && isApiKeyToken(token);
+};
+
+export const isNonBrowserApiKeyBearerRequest = (req: {
+  headers: Record<string, unknown>;
+}): boolean => {
+  if (!hasBearerApiKey(req.headers.authorization)) return false;
+  return !req.headers.origin && !req.headers.referer;
+};

--- a/backend/src/auth/apiKeys.ts
+++ b/backend/src/auth/apiKeys.ts
@@ -34,7 +34,7 @@ export const isApiKeyToken = (token: string): boolean => token.startsWith(API_KE
 export const extractApiKeyId = (token: string): string | null => {
   if (!isApiKeyToken(token)) return null;
   const withoutPrefix = token.slice(API_KEY_PREFIX.length);
-  const separatorIndex = withoutPrefix.indexOf("_");
+  const separatorIndex = withoutPrefix[16] === "_" ? 16 : withoutPrefix.indexOf("_");
   if (separatorIndex <= 0) return null;
   const keyId = withoutPrefix.slice(0, separatorIndex);
   return /^[A-Za-z0-9_-]{8,64}$/.test(keyId) ? keyId : null;

--- a/backend/src/auth/schemas.ts
+++ b/backend/src/auth/schemas.ts
@@ -127,4 +127,5 @@ export const mustResetPasswordSchema = z.object({
 
 export const apiKeyCreateSchema = z.object({
   name: z.string().trim().min(1).max(100),
+  scopes: z.array(z.string()).optional(),
 });

--- a/backend/src/auth/schemas.ts
+++ b/backend/src/auth/schemas.ts
@@ -124,3 +124,7 @@ export const changePasswordSchema = z.object({
 export const mustResetPasswordSchema = z.object({
   newPassword: passwordSchema,
 });
+
+export const apiKeyCreateSchema = z.object({
+  name: z.string().trim().min(1).max(100),
+});

--- a/backend/src/middleware/auth.test.ts
+++ b/backend/src/middleware/auth.test.ts
@@ -319,6 +319,84 @@ describe("auth middleware", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it("rejects API keys for drawing permission subroutes", async () => {
+    const { prisma, authModeService } = createDeps();
+    authModeService.getAuthEnabled.mockResolvedValue(true);
+    const generated = generateApiKey();
+    prisma.apiKey.findUnique.mockResolvedValue({
+      id: "api-key-1",
+      tokenHash: generated.tokenHash,
+      scopes: serializeApiKeyScopes(),
+      revokedAt: null,
+      user: {
+        id: "user-1",
+        username: "user1",
+        email: "user-1@test.local",
+        name: "User One",
+        role: "USER",
+        mustResetPassword: false,
+        isActive: true,
+      },
+    });
+    prisma.apiKey.update.mockResolvedValue({});
+    const { requireAuth } = createAuthMiddleware({ prisma, authModeService });
+
+    const req = createRequest({
+      method: "POST",
+      originalUrl: "/drawings/drawing-1/permissions",
+      headers: {
+        authorization: `Bearer ${generated.token}`,
+      },
+    });
+    const res = createResponse();
+    const next = vi.fn() as NextFunction;
+
+    await requireAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("does not send 403 from optionalAuth when API key is not route-authorized", async () => {
+    const { prisma, authModeService } = createDeps();
+    authModeService.getAuthEnabled.mockResolvedValue(true);
+    const generated = generateApiKey();
+    prisma.apiKey.findUnique.mockResolvedValue({
+      id: "api-key-1",
+      tokenHash: generated.tokenHash,
+      scopes: serializeApiKeyScopes(),
+      revokedAt: null,
+      user: {
+        id: "user-1",
+        username: "user1",
+        email: "user-1@test.local",
+        name: "User One",
+        role: "USER",
+        mustResetPassword: false,
+        isActive: true,
+      },
+    });
+    prisma.apiKey.update.mockResolvedValue({});
+    const { optionalAuth } = createAuthMiddleware({ prisma, authModeService });
+
+    const req = createRequest({
+      method: "GET",
+      originalUrl: "/drawings/drawing-1/history",
+      headers: {
+        authorization: `Bearer ${generated.token}`,
+      },
+    });
+    const res = createResponse();
+    const next = vi.fn() as NextFunction;
+
+    await optionalAuth(req, res, next);
+
+    expect(req.user).toBeUndefined();
+    expect(req.authError).toEqual({ code: "INVALID_ACCESS_TOKEN" });
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects API keys missing the required resource scope", async () => {
     const { prisma, authModeService } = createDeps();
     authModeService.getAuthEnabled.mockResolvedValue(true);

--- a/backend/src/middleware/auth.test.ts
+++ b/backend/src/middleware/auth.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { config } from "../config";
 import { createAuthMiddleware } from "./auth";
 import { BOOTSTRAP_USER_ID } from "../auth/authMode";
+import { generateApiKey } from "../auth/apiKeys";
 
 const createRequest = (overrides?: Partial<Request>): Request =>
   ({
@@ -28,6 +29,10 @@ const createDeps = () => {
     },
     authIdentity: {
       findUnique: vi.fn(),
+    },
+    apiKey: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
     },
   } as any;
 
@@ -189,6 +194,81 @@ describe("auth middleware", () => {
       email: "user-1@test.local",
       impersonatorId: "admin-1",
     });
+  });
+
+  it("attaches active user for valid API key", async () => {
+    const { prisma, authModeService } = createDeps();
+    authModeService.getAuthEnabled.mockResolvedValue(true);
+    const generated = generateApiKey();
+    prisma.apiKey.findUnique.mockResolvedValue({
+      id: "api-key-1",
+      tokenHash: generated.tokenHash,
+      revokedAt: null,
+      user: {
+        id: "user-1",
+        username: "user1",
+        email: "user-1@test.local",
+        name: "User One",
+        role: "USER",
+        mustResetPassword: false,
+        isActive: true,
+      },
+    });
+    prisma.apiKey.update.mockResolvedValue({});
+    const { requireAuth } = createAuthMiddleware({ prisma, authModeService });
+
+    const req = createRequest({
+      headers: {
+        authorization: `Bearer ${generated.token}`,
+      },
+    });
+    const res = createResponse();
+    const next = vi.fn() as NextFunction;
+
+    await requireAuth(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.user).toMatchObject({
+      id: "user-1",
+      email: "user-1@test.local",
+      authCredentialType: "apiKey",
+    });
+    expect(req.principal).toEqual({ kind: "user", userId: "user-1" });
+    expect(prisma.apiKey.update).toHaveBeenCalledWith({
+      where: { id: "api-key-1" },
+      data: { lastUsedAt: expect.any(Date) },
+    });
+  });
+
+  it("rejects revoked API keys", async () => {
+    const { prisma, authModeService } = createDeps();
+    authModeService.getAuthEnabled.mockResolvedValue(true);
+    const generated = generateApiKey();
+    prisma.apiKey.findUnique.mockResolvedValue({
+      id: "api-key-1",
+      tokenHash: generated.tokenHash,
+      revokedAt: new Date(),
+      user: {
+        isActive: true,
+      },
+    });
+    const { requireAuth } = createAuthMiddleware({ prisma, authModeService });
+
+    const req = createRequest({
+      headers: {
+        authorization: `Bearer ${generated.token}`,
+      },
+    });
+    const res = createResponse();
+    const next = vi.fn() as NextFunction;
+
+    await requireAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Invalid or revoked API key" }),
+    );
+    expect(next).not.toHaveBeenCalled();
   });
 
   it("blocks non-auth routes when password reset is required", async () => {

--- a/backend/src/middleware/auth.test.ts
+++ b/backend/src/middleware/auth.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { config } from "../config";
 import { createAuthMiddleware } from "./auth";
 import { BOOTSTRAP_USER_ID } from "../auth/authMode";
-import { generateApiKey } from "../auth/apiKeys";
+import { generateApiKey, serializeApiKeyScopes } from "../auth/apiKeys";
 
 const createRequest = (overrides?: Partial<Request>): Request =>
   ({
@@ -203,6 +203,7 @@ describe("auth middleware", () => {
     prisma.apiKey.findUnique.mockResolvedValue({
       id: "api-key-1",
       tokenHash: generated.tokenHash,
+      scopes: serializeApiKeyScopes(),
       revokedAt: null,
       user: {
         id: "user-1",
@@ -238,6 +239,122 @@ describe("auth middleware", () => {
       where: { id: "api-key-1" },
       data: { lastUsedAt: expect.any(Date) },
     });
+  });
+
+  it("allows valid API key auth when lastUsedAt update fails", async () => {
+    const { prisma, authModeService } = createDeps();
+    authModeService.getAuthEnabled.mockResolvedValue(true);
+    const generated = generateApiKey();
+    prisma.apiKey.findUnique.mockResolvedValue({
+      id: "api-key-1",
+      tokenHash: generated.tokenHash,
+      scopes: serializeApiKeyScopes(),
+      revokedAt: null,
+      user: {
+        id: "user-1",
+        username: "user1",
+        email: "user-1@test.local",
+        name: "User One",
+        role: "USER",
+        mustResetPassword: false,
+        isActive: true,
+      },
+    });
+    prisma.apiKey.update.mockRejectedValue(new Error("write failed"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { requireAuth } = createAuthMiddleware({ prisma, authModeService });
+
+    const req = createRequest({
+      method: "GET",
+      originalUrl: "/drawings",
+      headers: {
+        authorization: `Bearer ${generated.token}`,
+      },
+    });
+    const res = createResponse();
+    const next = vi.fn() as NextFunction;
+
+    await requireAuth(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("rejects API keys for routes outside drawings and collections", async () => {
+    const { prisma, authModeService } = createDeps();
+    authModeService.getAuthEnabled.mockResolvedValue(true);
+    const generated = generateApiKey();
+    prisma.apiKey.findUnique.mockResolvedValue({
+      id: "api-key-1",
+      tokenHash: generated.tokenHash,
+      scopes: serializeApiKeyScopes(),
+      revokedAt: null,
+      user: {
+        id: "admin-1",
+        username: "admin",
+        email: "admin@test.local",
+        name: "Admin",
+        role: "ADMIN",
+        mustResetPassword: false,
+        isActive: true,
+      },
+    });
+    prisma.apiKey.update.mockResolvedValue({});
+    const { requireAuth } = createAuthMiddleware({ prisma, authModeService });
+
+    const req = createRequest({
+      method: "GET",
+      originalUrl: "/auth/api-keys",
+      headers: {
+        authorization: `Bearer ${generated.token}`,
+      },
+    });
+    const res = createResponse();
+    const next = vi.fn() as NextFunction;
+
+    await requireAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("rejects API keys missing the required resource scope", async () => {
+    const { prisma, authModeService } = createDeps();
+    authModeService.getAuthEnabled.mockResolvedValue(true);
+    const generated = generateApiKey();
+    prisma.apiKey.findUnique.mockResolvedValue({
+      id: "api-key-1",
+      tokenHash: generated.tokenHash,
+      scopes: serializeApiKeyScopes(["drawings:read"]),
+      revokedAt: null,
+      user: {
+        id: "user-1",
+        username: "user1",
+        email: "user-1@test.local",
+        name: "User One",
+        role: "USER",
+        mustResetPassword: false,
+        isActive: true,
+      },
+    });
+    prisma.apiKey.update.mockResolvedValue({});
+    const { requireAuth } = createAuthMiddleware({ prisma, authModeService });
+
+    const req = createRequest({
+      method: "POST",
+      originalUrl: "/drawings",
+      headers: {
+        authorization: `Bearer ${generated.token}`,
+      },
+    });
+    const res = createResponse();
+    const next = vi.fn() as NextFunction;
+
+    await requireAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
   });
 
   it("rejects revoked API keys", async () => {

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -9,6 +9,11 @@ import {
   REFRESH_TOKEN_COOKIE_NAME,
   readCookie,
 } from "../auth/cookies";
+import {
+  apiKeyHashMatches,
+  extractApiKeyId,
+  isApiKeyToken,
+} from "../auth/apiKeys";
 
 declare global {
   namespace Express {
@@ -21,6 +26,7 @@ declare global {
         role: string;
         mustResetPassword?: boolean;
         impersonatorId?: string;
+        authCredentialType?: "jwt" | "apiKey" | "bootstrap";
       };
       principal?: {
         kind: "user";
@@ -70,16 +76,17 @@ const isJwtPayload = (decoded: unknown): decoded is JwtPayload => {
   );
 };
 
-const extractToken = (req: Request): string | null => {
+const extractToken = (req: Request): { token: string; source: "bearer" | "cookie" } | null => {
   const authHeader = req.headers.authorization;
   if (authHeader && typeof authHeader === "string") {
     const parts = authHeader.split(" ");
     if (parts.length === 2 && parts[0] === "Bearer") {
-      return parts[1] || null;
+      return parts[1] ? { token: parts[1], source: "bearer" } : null;
     }
   }
 
-  return readCookie(req, ACCESS_TOKEN_COOKIE_NAME);
+  const cookieToken = readCookie(req, ACCESS_TOKEN_COOKIE_NAME);
+  return cookieToken ? { token: cookieToken, source: "cookie" } : null;
 };
 
 const hasRefreshTokenCookie = (req: Request): boolean =>
@@ -135,6 +142,40 @@ export const createAuthMiddleware = ({
           .filter((group) => group.length > 0),
       ),
     );
+
+  const findActiveUser = (userId: string) =>
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        username: true,
+        email: true,
+        name: true,
+        role: true,
+        mustResetPassword: true,
+        isActive: true,
+      },
+    });
+
+  const authenticateApiKey = async (token: string) => {
+    const keyId = extractApiKeyId(token);
+    if (!keyId) return null;
+
+    const apiKey = await prisma.apiKey.findUnique({
+      where: { keyId },
+      include: { user: true },
+    });
+    if (!apiKey || apiKey.revokedAt) return null;
+    if (!apiKeyHashMatches(token, apiKey.tokenHash)) return null;
+    if (!apiKey.user.isActive) return null;
+
+    await prisma.apiKey.update({
+      where: { id: apiKey.id },
+      data: { lastUsedAt: new Date() },
+    });
+
+    return apiKey.user;
+  };
 
   const shouldReconcileOidcRole = async (
     payload: JwtPayload,
@@ -216,7 +257,9 @@ export const createAuthMiddleware = ({
           name: user.name,
           role: user.role,
           mustResetPassword: user.mustResetPassword,
+          authCredentialType: "bootstrap",
         };
+        req.principal = { kind: "user", userId: user.id };
         return next();
       }
     } catch (error) {
@@ -228,9 +271,9 @@ export const createAuthMiddleware = ({
       return;
     }
 
-    const token = extractToken(req);
+    const extracted = extractToken(req);
 
-    if (!token) {
+    if (!extracted) {
       res.status(401).json({
         error: "Unauthorized",
         message: "Authentication token required",
@@ -238,7 +281,48 @@ export const createAuthMiddleware = ({
       return;
     }
 
-    const payload = verifyToken(token);
+    if (extracted.source === "bearer" && isApiKeyToken(extracted.token)) {
+      try {
+        const user = await authenticateApiKey(extracted.token);
+        if (!user) {
+          res.status(401).json({
+            error: "Unauthorized",
+            message: "Invalid or revoked API key",
+          });
+          return;
+        }
+
+        if (user.mustResetPassword && !isAllowedWhileMustResetPassword(req)) {
+          res.status(403).json({
+            error: "Forbidden",
+            code: "MUST_RESET_PASSWORD",
+            message: "You must reset your password before using the app",
+          });
+          return;
+        }
+
+        req.user = {
+          id: user.id,
+          username: user.username,
+          email: user.email,
+          name: user.name,
+          role: user.role,
+          mustResetPassword: user.mustResetPassword,
+          authCredentialType: "apiKey",
+        };
+        req.principal = { kind: "user", userId: user.id };
+        next();
+      } catch (error) {
+        console.error("Error verifying API key:", error);
+        res.status(500).json({
+          error: "Internal server error",
+          message: "Failed to verify API key",
+        });
+      }
+      return;
+    }
+
+    const payload = verifyToken(extracted.token);
 
     if (!payload) {
       res.status(401).json({
@@ -249,18 +333,7 @@ export const createAuthMiddleware = ({
     }
 
     try {
-      const user = await prisma.user.findUnique({
-        where: { id: payload.userId },
-        select: {
-          id: true,
-          username: true,
-          email: true,
-          name: true,
-          role: true,
-          mustResetPassword: true,
-          isActive: true,
-        },
-      });
+      const user = await findActiveUser(payload.userId);
 
       if (!user || !user.isActive) {
         res.status(401).json({
@@ -290,9 +363,11 @@ export const createAuthMiddleware = ({
         email: resolvedUser.email,
         name: resolvedUser.name,
         role: resolvedUser.role,
-        mustResetPassword: resolvedUser.mustResetPassword,
-        impersonatorId: payload.impersonatorId,
-      };
+          mustResetPassword: resolvedUser.mustResetPassword,
+          impersonatorId: payload.impersonatorId,
+          authCredentialType: "jwt",
+        };
+        req.principal = { kind: "user", userId: resolvedUser.id };
 
       next();
     } catch (error) {
@@ -322,7 +397,9 @@ export const createAuthMiddleware = ({
           name: user.name,
           role: user.role,
           mustResetPassword: user.mustResetPassword,
+          authCredentialType: "bootstrap",
         };
+        req.principal = { kind: "user", userId: user.id };
         return next();
       }
     } catch (error) {
@@ -330,9 +407,9 @@ export const createAuthMiddleware = ({
       return next();
     }
 
-    const token = extractToken(req);
+    const extracted = extractToken(req);
 
-    if (!token) {
+    if (!extracted) {
       if (hasRefreshTokenCookie(req)) {
         req.authError = { code: "ACCESS_TOKEN_MISSING" };
         return next();
@@ -340,7 +417,31 @@ export const createAuthMiddleware = ({
       return next();
     }
 
-    const payload = verifyToken(token);
+    if (extracted.source === "bearer" && isApiKeyToken(extracted.token)) {
+      try {
+        const user = await authenticateApiKey(extracted.token);
+        if (user) {
+          req.user = {
+            id: user.id,
+            username: user.username,
+            email: user.email,
+            name: user.name,
+            role: user.role,
+            mustResetPassword: user.mustResetPassword,
+            authCredentialType: "apiKey",
+          };
+          req.principal = { kind: "user", userId: user.id };
+        } else {
+          req.authError = { code: "INVALID_ACCESS_TOKEN" };
+        }
+      } catch (error) {
+        console.error("Error in optional API key auth:", error);
+        req.authError = { code: "INVALID_ACCESS_TOKEN" };
+      }
+      return next();
+    }
+
+    const payload = verifyToken(extracted.token);
 
     if (!payload) {
       req.authError = { code: "INVALID_ACCESS_TOKEN" };
@@ -348,18 +449,7 @@ export const createAuthMiddleware = ({
     }
 
     try {
-      const user = await prisma.user.findUnique({
-        where: { id: payload.userId },
-        select: {
-          id: true,
-          username: true,
-          email: true,
-          name: true,
-          role: true,
-          mustResetPassword: true,
-          isActive: true,
-        },
-      });
+      const user = await findActiveUser(payload.userId);
 
       if (user && user.isActive) {
         req.user = {
@@ -370,7 +460,9 @@ export const createAuthMiddleware = ({
           role: user.role,
           mustResetPassword: user.mustResetPassword,
           impersonatorId: payload.impersonatorId,
+          authCredentialType: "jwt",
         };
+        req.principal = { kind: "user", userId: user.id };
       }
     } catch (error) {
       console.error("Error in optional auth:", error);

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -124,13 +124,40 @@ const isAllowedWhileMustResetPassword = (req: Request): boolean => {
   return false;
 };
 
-const getRequiredApiKeyScope = (req: Request): string | null => {
+const getApiKeyRouteResource = (req: Request): "drawings" | "collections" | null => {
   const path = normalizeRequestPath(req);
-  const resource = path === "/drawings" || path.startsWith("/drawings/")
-    ? "drawings"
-    : path === "/collections" || path.startsWith("/collections/")
-      ? "collections"
-      : null;
+  const segments = path.split("/").filter(Boolean);
+  const method = req.method;
+
+  if (segments[0] === "drawings") {
+    if (segments.length === 1 && ["GET", "HEAD", "POST"].includes(method)) {
+      return "drawings";
+    }
+    if (
+      segments.length === 2 &&
+      segments[1] !== "shared" &&
+      ["GET", "HEAD", "PUT", "DELETE"].includes(method)
+    ) {
+      return "drawings";
+    }
+    return null;
+  }
+
+  if (segments[0] === "collections") {
+    if (segments.length === 1 && ["GET", "HEAD", "POST"].includes(method)) {
+      return "collections";
+    }
+    if (segments.length === 2 && ["PUT", "DELETE"].includes(method)) {
+      return "collections";
+    }
+    return null;
+  }
+
+  return null;
+};
+
+const getRequiredApiKeyScope = (req: Request): string | null => {
+  const resource = getApiKeyRouteResource(req);
   if (!resource) return null;
 
   const access = req.method === "GET" || req.method === "HEAD" ? "read" : "write";
@@ -461,8 +488,10 @@ export const createAuthMiddleware = ({
       try {
         const result = await authenticateApiKey(extracted.token);
         if (result) {
-          if (!authorizeApiKeyRequest(req, res, result.scopes)) {
-            return;
+          const requiredScope = getRequiredApiKeyScope(req);
+          if (!requiredScope || !result.scopes.includes(requiredScope)) {
+            req.authError = { code: "INVALID_ACCESS_TOKEN" };
+            return next();
           }
           const { user } = result;
           req.user = {

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -13,6 +13,7 @@ import {
   apiKeyHashMatches,
   extractApiKeyId,
   isApiKeyToken,
+  parseApiKeyScopes,
 } from "../auth/apiKeys";
 
 declare global {
@@ -123,6 +124,36 @@ const isAllowedWhileMustResetPassword = (req: Request): boolean => {
   return false;
 };
 
+const getRequiredApiKeyScope = (req: Request): string | null => {
+  const path = normalizeRequestPath(req);
+  const resource = path === "/drawings" || path.startsWith("/drawings/")
+    ? "drawings"
+    : path === "/collections" || path.startsWith("/collections/")
+      ? "collections"
+      : null;
+  if (!resource) return null;
+
+  const access = req.method === "GET" || req.method === "HEAD" ? "read" : "write";
+  return `${resource}:${access}`;
+};
+
+const authorizeApiKeyRequest = (
+  req: Request,
+  res: Response,
+  scopes: string[],
+): boolean => {
+  const requiredScope = getRequiredApiKeyScope(req);
+  if (requiredScope && scopes.includes(requiredScope)) {
+    return true;
+  }
+
+  res.status(403).json({
+    error: "Forbidden",
+    message: "API key is not authorized for this route",
+  });
+  return false;
+};
+
 export type AuthMiddlewareDeps = {
   prisma: PrismaClient;
   authModeService: AuthModeService;
@@ -169,12 +200,16 @@ export const createAuthMiddleware = ({
     if (!apiKeyHashMatches(token, apiKey.tokenHash)) return null;
     if (!apiKey.user.isActive) return null;
 
-    await prisma.apiKey.update({
-      where: { id: apiKey.id },
-      data: { lastUsedAt: new Date() },
-    });
+    try {
+      await prisma.apiKey.update({
+        where: { id: apiKey.id },
+        data: { lastUsedAt: new Date() },
+      });
+    } catch (error) {
+      console.warn("Failed to update API key lastUsedAt:", error);
+    }
 
-    return apiKey.user;
+    return { user: apiKey.user, scopes: parseApiKeyScopes(apiKey.scopes) };
   };
 
   const shouldReconcileOidcRole = async (
@@ -283,12 +318,17 @@ export const createAuthMiddleware = ({
 
     if (extracted.source === "bearer" && isApiKeyToken(extracted.token)) {
       try {
-        const user = await authenticateApiKey(extracted.token);
-        if (!user) {
+        const result = await authenticateApiKey(extracted.token);
+        if (!result) {
           res.status(401).json({
             error: "Unauthorized",
             message: "Invalid or revoked API key",
           });
+          return;
+        }
+        const { user, scopes } = result;
+
+        if (!authorizeApiKeyRequest(req, res, scopes)) {
           return;
         }
 
@@ -419,8 +459,12 @@ export const createAuthMiddleware = ({
 
     if (extracted.source === "bearer" && isApiKeyToken(extracted.token)) {
       try {
-        const user = await authenticateApiKey(extracted.token);
-        if (user) {
+        const result = await authenticateApiKey(extracted.token);
+        if (result) {
+          if (!authorizeApiKeyRequest(req, res, result.scopes)) {
+            return;
+          }
+          const { user } = result;
           req.user = {
             id: user.id,
             username: user.username,

--- a/backend/src/server/csrf.ts
+++ b/backend/src/server/csrf.ts
@@ -11,6 +11,7 @@ import {
   getCsrfClientCookieValue,
   getCsrfValidationClientIds,
 } from "../security/csrfClient";
+import { isNonBrowserApiKeyBearerRequest } from "../auth/apiKeys";
 
 const CSRF_CLIENT_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30; // 30 days
 const CSRF_RATE_LIMIT_WINDOW = 60 * 1000; // 1 minute
@@ -150,6 +151,9 @@ export const registerCsrfProtection = ({
   ) => {
     const safeMethods = ["GET", "HEAD", "OPTIONS"];
     if (safeMethods.includes(req.method)) {
+      return next();
+    }
+    if (isNonBrowserApiKeyBearerRequest(req)) {
       return next();
     }
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -119,6 +119,13 @@ export interface CreateApiKeyResponse {
   token: string;
 }
 
+export const API_KEY_SCOPES = [
+  "drawings:read",
+  "drawings:write",
+  "collections:read",
+  "collections:write",
+] as const;
+
 export const authStatus = async (): Promise<AuthStatusResponse> => {
   const response = await axios.get<AuthStatusResponse>(
     `${API_URL}/auth/status`,
@@ -183,8 +190,8 @@ export const listApiKeys = async (): Promise<ApiKeyMetadata[]> => {
   return response.data.apiKeys;
 };
 
-export const createApiKey = async (name: string): Promise<CreateApiKeyResponse> => {
-  const response = await api.post<CreateApiKeyResponse>("/auth/api-keys", { name });
+export const createApiKey = async (name: string, scopes?: string[]): Promise<CreateApiKeyResponse> => {
+  const response = await api.post<CreateApiKeyResponse>("/auth/api-keys", { name, scopes });
   return response.data;
 };
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -103,6 +103,22 @@ export interface AuthUser {
   mustResetPassword?: boolean;
 }
 
+export interface ApiKeyMetadata {
+  id: string;
+  name: string;
+  prefix: string;
+  scopes: string[];
+  lastUsedAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateApiKeyResponse {
+  apiKey: ApiKeyMetadata;
+  token: string;
+}
+
 export const authStatus = async (): Promise<AuthStatusResponse> => {
   const response = await axios.get<AuthStatusResponse>(
     `${API_URL}/auth/status`,
@@ -160,6 +176,20 @@ export const authRegister = async (
     payload
   );
   return response.data;
+};
+
+export const listApiKeys = async (): Promise<ApiKeyMetadata[]> => {
+  const response = await api.get<{ apiKeys: ApiKeyMetadata[] }>("/auth/api-keys");
+  return response.data.apiKeys;
+};
+
+export const createApiKey = async (name: string): Promise<CreateApiKeyResponse> => {
+  const response = await api.post<CreateApiKeyResponse>("/auth/api-keys", { name });
+  return response.data;
+};
+
+export const revokeApiKey = async (id: string): Promise<void> => {
+  await api.delete(`/auth/api-keys/${id}`);
 };
 
 export const authOnboardingChoice = async (

--- a/frontend/src/pages/Profile.apiKeys.test.tsx
+++ b/frontend/src/pages/Profile.apiKeys.test.tsx
@@ -23,6 +23,7 @@ vi.mock("../components/Layout", () => ({
 }));
 
 vi.mock("../api", () => ({
+  API_KEY_SCOPES: ["drawings:read", "drawings:write", "collections:read", "collections:write"],
   api: {
     put: vi.fn(),
     post: vi.fn(),
@@ -54,15 +55,16 @@ describe("Profile API keys", () => {
     mockAuthUser.mockReturnValue({ id: "user-1", email: "user@example.com", name: "User One" });
     vi.mocked(api.getCollections).mockResolvedValue([]);
     vi.mocked(api.listApiKeys).mockResolvedValue([existingApiKey]);
-    vi.mocked(api.createApiKey).mockResolvedValue({
+    vi.mocked(api.createApiKey).mockImplementation(async (name, scopes) => ({
       apiKey: {
         ...existingApiKey,
         id: "key-2",
-        name: "CI Token",
+        name,
         prefix: "exd_key_new456",
+        scopes: scopes ?? ["drawings:read", "drawings:write", "collections:read", "collections:write"],
       },
       token: "exd_key_new456.secret-token-value",
-    });
+    }));
     vi.mocked(api.revokeApiKey).mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
@@ -89,7 +91,12 @@ describe("Profile API keys", () => {
 
     expect(await screen.findByDisplayValue("exd_key_new456.secret-token-value")).toBeInTheDocument();
     expect(screen.getByText(/copy this token now/i)).toBeInTheDocument();
-    expect(api.createApiKey).toHaveBeenCalledWith("CI Token");
+    expect(api.createApiKey).toHaveBeenCalledWith("CI Token", [
+      "drawings:read",
+      "drawings:write",
+      "collections:read",
+      "collections:write",
+    ]);
 
     fireEvent.click(screen.getByRole("button", { name: /copy generated api token/i }));
     await waitFor(() => {
@@ -153,5 +160,49 @@ describe("Profile API keys", () => {
 
     resolveApiKeys([existingApiKey]);
     expect(await screen.findByText("Existing Key")).toBeInTheDocument();
+  });
+
+  it("submits and displays custom API key scopes", async () => {
+    render(
+      <MemoryRouter>
+        <Profile />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Existing Key");
+
+    fireEvent.change(screen.getByLabelText(/api key name/i), {
+      target: { value: "Read Token" },
+    });
+    fireEvent.click(screen.getByLabelText(/write drawings/i));
+    fireEvent.click(screen.getByLabelText(/read collections/i));
+    fireEvent.click(screen.getByLabelText(/write collections/i));
+    fireEvent.click(screen.getByRole("button", { name: /create api key/i }));
+
+    expect(await screen.findByDisplayValue("exd_key_new456.secret-token-value")).toBeInTheDocument();
+    expect(api.createApiKey).toHaveBeenCalledWith("Read Token", ["drawings:read"]);
+    expect(screen.getAllByText("drawings:read").length).toBeGreaterThan(0);
+  });
+
+  it("disables API key creation and shows validation when no scopes are selected", async () => {
+    render(
+      <MemoryRouter>
+        <Profile />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Existing Key");
+
+    fireEvent.change(screen.getByLabelText(/api key name/i), {
+      target: { value: "No Scope Token" },
+    });
+    fireEvent.click(screen.getByLabelText(/read drawings/i));
+    fireEvent.click(screen.getByLabelText(/write drawings/i));
+    fireEvent.click(screen.getByLabelText(/read collections/i));
+    fireEvent.click(screen.getByLabelText(/write collections/i));
+
+    expect(screen.getByText(/select at least one api key scope/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /create api key/i })).toBeDisabled();
+    expect(api.createApiKey).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/Profile.apiKeys.test.tsx
+++ b/frontend/src/pages/Profile.apiKeys.test.tsx
@@ -68,7 +68,6 @@ describe("Profile API keys", () => {
       configurable: true,
       value: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
-    vi.spyOn(window, "confirm").mockReturnValue(true);
   });
 
   it("lists, creates, copies, and revokes API keys", async () => {
@@ -101,6 +100,7 @@ describe("Profile API keys", () => {
     expect(screen.queryByDisplayValue("exd_key_new456.secret-token-value")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /revoke api key ci token/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^revoke$/i }));
 
     await waitFor(() => {
       expect(api.revokeApiKey).toHaveBeenCalledWith("key-2");

--- a/frontend/src/pages/Profile.apiKeys.test.tsx
+++ b/frontend/src/pages/Profile.apiKeys.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Profile } from "./Profile";
+import * as api from "../api";
+
+const { mockLogout } = vi.hoisted(() => ({
+  mockLogout: vi.fn(),
+}));
+
+vi.mock("../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "user-1", email: "user@example.com", name: "User One" },
+    logout: mockLogout,
+    authEnabled: true,
+  }),
+}));
+
+vi.mock("../components/Layout", () => ({
+  Layout: ({ children }: { children: React.ReactNode }) => <main>{children}</main>,
+}));
+
+vi.mock("../api", () => ({
+  api: {
+    put: vi.fn(),
+    post: vi.fn(),
+  },
+  isAxiosError: vi.fn(() => false),
+  getCollections: vi.fn(),
+  createCollection: vi.fn(),
+  updateCollection: vi.fn(),
+  deleteCollection: vi.fn(),
+  listApiKeys: vi.fn(),
+  createApiKey: vi.fn(),
+  revokeApiKey: vi.fn(),
+}));
+
+const existingApiKey = {
+  id: "key-1",
+  name: "Existing Key",
+  prefix: "exd_key_abc123",
+  scopes: ["drawings:read", "drawings:write"],
+  createdAt: "2026-05-01T12:00:00.000Z",
+  updatedAt: "2026-05-01T12:00:00.000Z",
+  lastUsedAt: null,
+  revokedAt: null,
+};
+
+describe("Profile API keys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.getCollections).mockResolvedValue([]);
+    vi.mocked(api.listApiKeys).mockResolvedValue([existingApiKey]);
+    vi.mocked(api.createApiKey).mockResolvedValue({
+      apiKey: {
+        ...existingApiKey,
+        id: "key-2",
+        name: "CI Token",
+        prefix: "exd_key_new456",
+      },
+      token: "exd_key_new456.secret-token-value",
+    });
+    vi.mocked(api.revokeApiKey).mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+  });
+
+  it("lists, creates, copies, and revokes API keys", async () => {
+    render(
+      <MemoryRouter>
+        <Profile />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Existing Key")).toBeInTheDocument();
+    expect(screen.getByText("exd_key_abc123")).toBeInTheDocument();
+    expect(screen.getByText("drawings:read, drawings:write")).toBeInTheDocument();
+    expect(screen.getAllByText("Never").length).toBeGreaterThan(0);
+
+    fireEvent.change(screen.getByLabelText(/api key name/i), {
+      target: { value: "CI Token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create api key/i }));
+
+    expect(await screen.findByDisplayValue("exd_key_new456.secret-token-value")).toBeInTheDocument();
+    expect(screen.getByText(/copy this token now/i)).toBeInTheDocument();
+    expect(api.createApiKey).toHaveBeenCalledWith("CI Token");
+
+    fireEvent.click(screen.getByRole("button", { name: /copy generated api token/i }));
+    await waitFor(() => {
+      expect(navigator.clipboard?.writeText).toHaveBeenCalledWith("exd_key_new456.secret-token-value");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /revoke api key ci token/i }));
+
+    await waitFor(() => {
+      expect(api.revokeApiKey).toHaveBeenCalledWith("key-2");
+    });
+    expect(await screen.findByText("API key revoked")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Profile.apiKeys.test.tsx
+++ b/frontend/src/pages/Profile.apiKeys.test.tsx
@@ -5,13 +5,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Profile } from "./Profile";
 import * as api from "../api";
 
-const { mockLogout } = vi.hoisted(() => ({
+const { mockLogout, mockAuthUser } = vi.hoisted(() => ({
   mockLogout: vi.fn(),
+  mockAuthUser: vi.fn(),
 }));
 
 vi.mock("../context/AuthContext", () => ({
   useAuth: () => ({
-    user: { id: "user-1", email: "user@example.com", name: "User One" },
+    user: mockAuthUser(),
     logout: mockLogout,
     authEnabled: true,
   }),
@@ -50,6 +51,7 @@ const existingApiKey = {
 describe("Profile API keys", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockAuthUser.mockReturnValue({ id: "user-1", email: "user@example.com", name: "User One" });
     vi.mocked(api.getCollections).mockResolvedValue([]);
     vi.mocked(api.listApiKeys).mockResolvedValue([existingApiKey]);
     vi.mocked(api.createApiKey).mockResolvedValue({
@@ -95,11 +97,61 @@ describe("Profile API keys", () => {
       expect(navigator.clipboard?.writeText).toHaveBeenCalledWith("exd_key_new456.secret-token-value");
     });
 
+    fireEvent.click(screen.getByRole("button", { name: /done/i }));
+    expect(screen.queryByDisplayValue("exd_key_new456.secret-token-value")).not.toBeInTheDocument();
+
     fireEvent.click(screen.getByRole("button", { name: /revoke api key ci token/i }));
 
     await waitFor(() => {
       expect(api.revokeApiKey).toHaveBeenCalledWith("key-2");
     });
     expect(await screen.findByText("API key revoked")).toBeInTheDocument();
+  });
+
+  it("does not load or show API key management while password reset is required", async () => {
+    mockAuthUser.mockReturnValue({
+      id: "user-1",
+      email: "user@example.com",
+      name: "User One",
+      mustResetPassword: true,
+    });
+
+    render(
+      <MemoryRouter>
+        <Profile />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/api key management is unavailable until you reset your password/i)).toBeInTheDocument();
+    expect(api.listApiKeys).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText(/api key name/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /create api key/i })).not.toBeInTheDocument();
+  });
+
+  it("disables API key creation while keys are loading", async () => {
+    let resolveApiKeys: (keys: Array<typeof existingApiKey>) => void = () => undefined;
+    vi.mocked(api.listApiKeys).mockReturnValue(
+      new Promise((resolve) => {
+        resolveApiKeys = resolve;
+      }),
+    );
+
+    render(
+      <MemoryRouter>
+        <Profile />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText(/api key name/i), {
+      target: { value: "CI Token" },
+    });
+
+    const createButton = screen.getByRole("button", { name: /create api key/i });
+    expect(createButton).toBeDisabled();
+    fireEvent.click(createButton);
+    expect(api.createApiKey).not.toHaveBeenCalled();
+
+    resolveApiKeys([existingApiKey]);
+    expect(await screen.findByText("Existing Key")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Profile.apiKeys.test.tsx
+++ b/frontend/src/pages/Profile.apiKeys.test.tsx
@@ -205,4 +205,41 @@ describe("Profile API keys", () => {
     expect(screen.getByRole("button", { name: /create api key/i })).toBeDisabled();
     expect(api.createApiKey).not.toHaveBeenCalled();
   });
+
+  it("keeps a one-time token visible if creating another API key fails", async () => {
+    vi.mocked(api.createApiKey)
+      .mockResolvedValueOnce({
+        apiKey: {
+          ...existingApiKey,
+          id: "key-2",
+          name: "First Token",
+          prefix: "exd_key_first",
+        },
+        token: "exd_key_first.secret-token-value",
+      })
+      .mockRejectedValueOnce(new Error("Network error"));
+
+    render(
+      <MemoryRouter>
+        <Profile />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Existing Key");
+
+    fireEvent.change(screen.getByLabelText(/api key name/i), {
+      target: { value: "First Token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create api key/i }));
+
+    expect(await screen.findByDisplayValue("exd_key_first.secret-token-value")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/api key name/i), {
+      target: { value: "Second Token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create api key/i }));
+
+    expect(await screen.findByText(/failed to create api key/i)).toBeInTheDocument();
+    expect(screen.getByDisplayValue("exd_key_first.secret-token-value")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -27,6 +27,13 @@ const formatApiKeyDate = (value: string | null) => {
     return new Date(value).toLocaleString();
 };
 
+const API_KEY_SCOPE_LABELS: Record<string, string> = {
+    'drawings:read': 'Read drawings',
+    'drawings:write': 'Write drawings',
+    'collections:read': 'Read collections',
+    'collections:write': 'Write collections',
+};
+
 export const Profile: React.FC = () => {
     const { user: authUser, logout, authEnabled } = useAuth();
     const navigate = useNavigate();
@@ -51,6 +58,7 @@ export const Profile: React.FC = () => {
     const [apiKeys, setApiKeys] = useState<api.ApiKeyMetadata[]>([]);
     const [apiKeysLoading, setApiKeysLoading] = useState(false);
     const [apiKeyName, setApiKeyName] = useState('');
+    const [selectedApiKeyScopes, setSelectedApiKeyScopes] = useState<string[]>([...api.API_KEY_SCOPES]);
     const [apiKeyActionLoading, setApiKeyActionLoading] = useState(false);
     const [apiKeyError, setApiKeyError] = useState('');
     const [generatedToken, setGeneratedToken] = useState('');
@@ -273,6 +281,10 @@ export const Profile: React.FC = () => {
             setApiKeyError('API key name is required');
             return;
         }
+        if (selectedApiKeyScopes.length === 0) {
+            setApiKeyError('Select at least one API key scope');
+            return;
+        }
 
         setApiKeyActionLoading(true);
         setApiKeyError('');
@@ -282,9 +294,10 @@ export const Profile: React.FC = () => {
         setCopiedToken(false);
 
         try {
-            const response = await api.createApiKey(trimmedName);
+            const response = await api.createApiKey(trimmedName, selectedApiKeyScopes);
             setApiKeys(prev => [response.apiKey, ...prev]);
             setApiKeyName('');
+            setSelectedApiKeyScopes([...api.API_KEY_SCOPES]);
             setGeneratedToken(response.token);
             setGeneratedTokenName(response.apiKey.name);
             setSuccess('API key created. Copy the token now; it will not be shown again.');
@@ -324,6 +337,14 @@ export const Profile: React.FC = () => {
         setGeneratedToken('');
         setGeneratedTokenName('');
         setCopiedToken(false);
+    };
+
+    const handleApiKeyScopeChange = (scope: string, checked: boolean) => {
+        const next = checked
+            ? [...selectedApiKeyScopes, scope]
+            : selectedApiKeyScopes.filter(value => value !== scope);
+        setSelectedApiKeyScopes(api.API_KEY_SCOPES.filter(value => next.includes(value)));
+        setApiKeyError(next.length === 0 ? 'Select at least one API key scope' : '');
     };
 
     const handleRevokeApiKey = async (id: string) => {
@@ -556,7 +577,8 @@ export const Profile: React.FC = () => {
                         </div>
                     )}
 
-                    <div className="flex flex-col sm:flex-row gap-3 mb-6">
+                    <div className="space-y-4 mb-6">
+                        <div className="flex flex-col sm:flex-row gap-3">
                         <div className="flex-1">
                             <label htmlFor="apiKeyName" className="block text-sm font-bold text-slate-700 dark:text-neutral-300 mb-2">
                                 API Key Name
@@ -573,11 +595,31 @@ export const Profile: React.FC = () => {
                         </div>
                         <button
                             onClick={() => void handleCreateApiKey()}
-                            disabled={apiKeysLoading || apiKeyActionLoading || !apiKeyName.trim()}
+                            disabled={apiKeysLoading || apiKeyActionLoading || !apiKeyName.trim() || selectedApiKeyScopes.length === 0}
                             className="sm:self-end px-6 py-3 bg-emerald-600 dark:bg-emerald-500 text-white font-bold rounded-xl border-2 border-black dark:border-neutral-700 shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] dark:shadow-[2px_2px_0px_0px_rgba(255,255,255,0.2)] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] dark:hover:shadow-[4px_4px_0px_0px_rgba(255,255,255,0.2)] hover:-translate-y-0.5 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0 disabled:hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] dark:disabled:hover:shadow-[2px_2px_0px_0px_rgba(255,255,255,0.2)]"
                         >
                             {apiKeyActionLoading ? 'Creating...' : 'Create API Key'}
                         </button>
+                        </div>
+                        <fieldset>
+                            <legend className="block text-sm font-bold text-slate-700 dark:text-neutral-300 mb-2">
+                                Scopes
+                            </legend>
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                                {api.API_KEY_SCOPES.map(scope => (
+                                    <label key={scope} className="flex items-center gap-2 px-3 py-2 bg-slate-50 dark:bg-neutral-800 border-2 border-slate-200 dark:border-neutral-700 rounded-xl text-sm font-medium text-slate-700 dark:text-neutral-300">
+                                        <input
+                                            type="checkbox"
+                                            checked={selectedApiKeyScopes.includes(scope)}
+                                            onChange={(event) => handleApiKeyScopeChange(scope, event.target.checked)}
+                                            className="h-4 w-4 accent-emerald-600"
+                                        />
+                                        <span>{API_KEY_SCOPE_LABELS[scope]}</span>
+                                        <span className="font-mono text-xs text-slate-500 dark:text-neutral-500">{scope}</span>
+                                    </label>
+                                ))}
+                            </div>
+                        </fieldset>
                     </div>
 
                     {apiKeysLoading ? (

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -8,6 +8,7 @@ import { User, Lock, Save, X, KeyRound, Copy, Trash2 } from 'lucide-react';
 import { USER_KEY } from '../utils/impersonation';
 import { getPasswordPolicy, validatePassword } from '../utils/passwordPolicy';
 import { PasswordRequirements } from '../components/PasswordRequirements';
+import { ConfirmModal } from '../components/ConfirmModal';
 
 const getApiErrorMessage = (err: unknown, fallback: string) => {
     if (api.isAxiosError(err)) {
@@ -55,6 +56,7 @@ export const Profile: React.FC = () => {
     const [generatedToken, setGeneratedToken] = useState('');
     const [generatedTokenName, setGeneratedTokenName] = useState('');
     const [copiedToken, setCopiedToken] = useState(false);
+    const [apiKeyToRevoke, setApiKeyToRevoke] = useState<api.ApiKeyMetadata | null>(null);
 
     useEffect(() => {
         if (authEnabled === false) {
@@ -324,10 +326,7 @@ export const Profile: React.FC = () => {
         setCopiedToken(false);
     };
 
-    const handleRevokeApiKey = async (id: string, name: string) => {
-        const confirmed = window.confirm(`Revoke API key "${name}"? Existing integrations using this key will stop working.`);
-        if (!confirmed) return;
-
+    const handleRevokeApiKey = async (id: string) => {
         setApiKeyActionLoading(true);
         setApiKeyError('');
         setSuccess('');
@@ -341,6 +340,7 @@ export const Profile: React.FC = () => {
             setApiKeyError(getApiErrorMessage(err, 'Failed to revoke API key'));
         } finally {
             setApiKeyActionLoading(false);
+            setApiKeyToRevoke(null);
         }
     };
 
@@ -622,7 +622,7 @@ export const Profile: React.FC = () => {
                                                 </dl>
                                             </div>
                                             <button
-                                                onClick={() => void handleRevokeApiKey(apiKey.id, apiKey.name)}
+                                                onClick={() => setApiKeyToRevoke(apiKey)}
                                                 disabled={apiKeyActionLoading || revoked}
                                                 className="px-4 py-2 bg-white dark:bg-neutral-900 text-red-700 dark:text-red-300 font-bold rounded-xl border-2 border-black dark:border-neutral-700 shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] dark:shadow-[2px_2px_0px_0px_rgba(255,255,255,0.2)] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] dark:hover:shadow-[4px_4px_0px_0px_rgba(255,255,255,0.2)] hover:-translate-y-0.5 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0 disabled:hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] dark:disabled:hover:shadow-[2px_2px_0px_0px_rgba(255,255,255,0.2)] flex items-center justify-center gap-2"
                                                 aria-label={`Revoke API key ${apiKey.name}`}
@@ -740,6 +740,14 @@ export const Profile: React.FC = () => {
 	                    )}
                 </div>
             </div>
+            <ConfirmModal
+                isOpen={Boolean(apiKeyToRevoke)}
+                title="Revoke API Key"
+                message={apiKeyToRevoke ? `Revoke API key "${apiKeyToRevoke.name}"? Existing integrations using this key will stop working.` : ''}
+                confirmText="Revoke"
+                onConfirm={() => apiKeyToRevoke && void handleRevokeApiKey(apiKeyToRevoke.id)}
+                onCancel={() => setApiKeyToRevoke(null)}
+            />
         </Layout>
     );
 };

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -79,6 +79,12 @@ export const Profile: React.FC = () => {
 
     useEffect(() => {
         if (authEnabled === false) return;
+        if (mustResetPassword) {
+            setApiKeys([]);
+            setApiKeysLoading(false);
+            setApiKeyError('');
+            return;
+        }
 
         const fetchApiKeys = async () => {
             setApiKeysLoading(true);
@@ -93,7 +99,7 @@ export const Profile: React.FC = () => {
         };
 
         void fetchApiKeys();
-    }, [authEnabled]);
+    }, [authEnabled, mustResetPassword]);
 
     useEffect(() => {
         if (mustResetPassword) {
@@ -258,6 +264,8 @@ export const Profile: React.FC = () => {
     };
 
     const handleCreateApiKey = async () => {
+        if (mustResetPassword || apiKeysLoading) return;
+
         const trimmedName = apiKeyName.trim();
         if (!trimmedName) {
             setApiKeyError('API key name is required');
@@ -308,6 +316,12 @@ export const Profile: React.FC = () => {
         } catch {
             setApiKeyError('Failed to copy token. Select and copy it manually.');
         }
+    };
+
+    const handleHideGeneratedToken = () => {
+        setGeneratedToken('');
+        setGeneratedTokenName('');
+        setCopiedToken(false);
     };
 
     const handleRevokeApiKey = async (id: string, name: string) => {
@@ -492,6 +506,16 @@ export const Profile: React.FC = () => {
                         </div>
                     </div>
 
+                    {mustResetPassword ? (
+                        <div className="p-4 bg-amber-50 dark:bg-amber-900/20 border-2 border-amber-200 dark:border-amber-800 rounded-xl">
+                            <p className="text-amber-900 dark:text-amber-200 font-bold">
+                                API key management is unavailable until you reset your password.
+                            </p>
+                            <p className="text-sm text-amber-800 dark:text-amber-200/80 font-medium mt-1">
+                                Change your password below, then return here to create and manage API keys.
+                            </p>
+                        </div>
+                    ) : (<>
                     {apiKeyError && (
                         <div className="mb-4 p-4 bg-red-50 dark:bg-red-900/20 border-2 border-red-200 dark:border-red-800 rounded-xl">
                             <p className="text-red-800 dark:text-red-200 font-medium">{apiKeyError}</p>
@@ -522,6 +546,12 @@ export const Profile: React.FC = () => {
                                     <Copy size={18} />
                                     {copiedToken ? 'Copied' : 'Copy Token'}
                                 </button>
+                                <button
+                                    onClick={handleHideGeneratedToken}
+                                    className="px-6 py-3 bg-white dark:bg-neutral-800 text-slate-700 dark:text-neutral-300 font-bold rounded-xl border-2 border-black dark:border-neutral-700 shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] dark:shadow-[2px_2px_0px_0px_rgba(255,255,255,0.2)] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] dark:hover:shadow-[4px_4px_0px_0px_rgba(255,255,255,0.2)] hover:-translate-y-0.5 transition-all duration-200"
+                                >
+                                    Done
+                                </button>
                             </div>
                         </div>
                     )}
@@ -543,7 +573,7 @@ export const Profile: React.FC = () => {
                         </div>
                         <button
                             onClick={() => void handleCreateApiKey()}
-                            disabled={apiKeyActionLoading || !apiKeyName.trim()}
+                            disabled={apiKeysLoading || apiKeyActionLoading || !apiKeyName.trim()}
                             className="sm:self-end px-6 py-3 bg-emerald-600 dark:bg-emerald-500 text-white font-bold rounded-xl border-2 border-black dark:border-neutral-700 shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] dark:shadow-[2px_2px_0px_0px_rgba(255,255,255,0.2)] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] dark:hover:shadow-[4px_4px_0px_0px_rgba(255,255,255,0.2)] hover:-translate-y-0.5 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0 disabled:hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] dark:disabled:hover:shadow-[2px_2px_0px_0px_rgba(255,255,255,0.2)]"
                         >
                             {apiKeyActionLoading ? 'Creating...' : 'Create API Key'}
@@ -606,6 +636,7 @@ export const Profile: React.FC = () => {
                             })}
                         </div>
                     )}
+                    </>)}
                 </div>
 
                 <div className="bg-white dark:bg-neutral-900 border-2 border-black dark:border-neutral-700 rounded-2xl shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] dark:shadow-[4px_4px_0px_0px_rgba(255,255,255,0.2)] p-6">

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -289,9 +289,6 @@ export const Profile: React.FC = () => {
         setApiKeyActionLoading(true);
         setApiKeyError('');
         setSuccess('');
-        setGeneratedToken('');
-        setGeneratedTokenName('');
-        setCopiedToken(false);
 
         try {
             const response = await api.createApiKey(trimmedName, selectedApiKeyScopes);
@@ -300,6 +297,7 @@ export const Profile: React.FC = () => {
             setSelectedApiKeyScopes([...api.API_KEY_SCOPES]);
             setGeneratedToken(response.token);
             setGeneratedTokenName(response.apiKey.name);
+            setCopiedToken(false);
             setSuccess('API key created. Copy the token now; it will not be shown again.');
         } catch (err: unknown) {
             setApiKeyError(getApiErrorMessage(err, 'Failed to create API key'));

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -4,10 +4,27 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import * as api from '../api';
 import type { Collection } from '../types';
-import { User, Lock, Save, X } from 'lucide-react';
+import { User, Lock, Save, X, KeyRound, Copy, Trash2 } from 'lucide-react';
 import { USER_KEY } from '../utils/impersonation';
 import { getPasswordPolicy, validatePassword } from '../utils/passwordPolicy';
 import { PasswordRequirements } from '../components/PasswordRequirements';
+
+const getApiErrorMessage = (err: unknown, fallback: string) => {
+    if (api.isAxiosError(err)) {
+        if (err.response?.data?.message) {
+            return err.response.data.message;
+        }
+        if (err.response?.data?.error) {
+            return err.response.data.error;
+        }
+    }
+    return fallback;
+};
+
+const formatApiKeyDate = (value: string | null) => {
+    if (!value) return 'Never';
+    return new Date(value).toLocaleString();
+};
 
 export const Profile: React.FC = () => {
     const { user: authUser, logout, authEnabled } = useAuth();
@@ -30,6 +47,15 @@ export const Profile: React.FC = () => {
     const [confirmPassword, setConfirmPassword] = useState('');
     const [showPasswordForm, setShowPasswordForm] = useState(false);
 
+    const [apiKeys, setApiKeys] = useState<api.ApiKeyMetadata[]>([]);
+    const [apiKeysLoading, setApiKeysLoading] = useState(false);
+    const [apiKeyName, setApiKeyName] = useState('');
+    const [apiKeyActionLoading, setApiKeyActionLoading] = useState(false);
+    const [apiKeyError, setApiKeyError] = useState('');
+    const [generatedToken, setGeneratedToken] = useState('');
+    const [generatedTokenName, setGeneratedTokenName] = useState('');
+    const [copiedToken, setCopiedToken] = useState(false);
+
     useEffect(() => {
         if (authEnabled === false) {
             navigate('/settings', { replace: true });
@@ -50,6 +76,24 @@ export const Profile: React.FC = () => {
         };
         fetchData();
     }, [authEnabled, authUser, navigate]);
+
+    useEffect(() => {
+        if (authEnabled === false) return;
+
+        const fetchApiKeys = async () => {
+            setApiKeysLoading(true);
+            setApiKeyError('');
+            try {
+                setApiKeys(await api.listApiKeys());
+            } catch (err: unknown) {
+                setApiKeyError(getApiErrorMessage(err, 'Failed to load API keys'));
+            } finally {
+                setApiKeysLoading(false);
+            }
+        };
+
+        void fetchApiKeys();
+    }, [authEnabled]);
 
     useEffect(() => {
         if (mustResetPassword) {
@@ -213,6 +257,79 @@ export const Profile: React.FC = () => {
         }
     };
 
+    const handleCreateApiKey = async () => {
+        const trimmedName = apiKeyName.trim();
+        if (!trimmedName) {
+            setApiKeyError('API key name is required');
+            return;
+        }
+
+        setApiKeyActionLoading(true);
+        setApiKeyError('');
+        setSuccess('');
+        setGeneratedToken('');
+        setGeneratedTokenName('');
+        setCopiedToken(false);
+
+        try {
+            const response = await api.createApiKey(trimmedName);
+            setApiKeys(prev => [response.apiKey, ...prev]);
+            setApiKeyName('');
+            setGeneratedToken(response.token);
+            setGeneratedTokenName(response.apiKey.name);
+            setSuccess('API key created. Copy the token now; it will not be shown again.');
+        } catch (err: unknown) {
+            setApiKeyError(getApiErrorMessage(err, 'Failed to create API key'));
+        } finally {
+            setApiKeyActionLoading(false);
+        }
+    };
+
+    const handleCopyGeneratedToken = async () => {
+        if (!generatedToken) return;
+
+        try {
+            if (navigator.clipboard?.writeText) {
+                await navigator.clipboard.writeText(generatedToken);
+            } else {
+                const textarea = document.createElement('textarea');
+                textarea.value = generatedToken;
+                textarea.setAttribute('readonly', 'true');
+                textarea.style.position = 'fixed';
+                textarea.style.left = '-9999px';
+                document.body.appendChild(textarea);
+                textarea.select();
+                document.execCommand('copy');
+                document.body.removeChild(textarea);
+            }
+            setCopiedToken(true);
+            setSuccess('API key token copied to clipboard');
+            window.setTimeout(() => setCopiedToken(false), 1500);
+        } catch {
+            setApiKeyError('Failed to copy token. Select and copy it manually.');
+        }
+    };
+
+    const handleRevokeApiKey = async (id: string, name: string) => {
+        const confirmed = window.confirm(`Revoke API key "${name}"? Existing integrations using this key will stop working.`);
+        if (!confirmed) return;
+
+        setApiKeyActionLoading(true);
+        setApiKeyError('');
+        setSuccess('');
+
+        try {
+            await api.revokeApiKey(id);
+            const revokedAt = new Date().toISOString();
+            setApiKeys(prev => prev.map(apiKey => apiKey.id === id ? { ...apiKey, revokedAt } : apiKey));
+            setSuccess('API key revoked');
+        } catch (err: unknown) {
+            setApiKeyError(getApiErrorMessage(err, 'Failed to revoke API key'));
+        } finally {
+            setApiKeyActionLoading(false);
+        }
+    };
+
     return (
         <Layout
             collections={collections}
@@ -360,6 +477,135 @@ export const Profile: React.FC = () => {
                             </div>
                         </div>
                     </div>
+                </div>
+
+                <div className="bg-white dark:bg-neutral-900 border-2 border-black dark:border-neutral-700 rounded-2xl shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] dark:shadow-[4px_4px_0px_0px_rgba(255,255,255,0.2)] p-6">
+                    <div className="flex items-center gap-3 mb-6">
+                        <div className="w-12 h-12 bg-emerald-50 dark:bg-neutral-800 rounded-xl flex items-center justify-center border-2 border-emerald-100 dark:border-neutral-700">
+                            <KeyRound size={24} className="text-emerald-600 dark:text-emerald-400" />
+                        </div>
+                        <div>
+                            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">API Keys</h2>
+                            <p className="text-sm text-slate-600 dark:text-neutral-400 font-medium">
+                                Create bearer tokens for scripts and integrations. Tokens are shown only once.
+                            </p>
+                        </div>
+                    </div>
+
+                    {apiKeyError && (
+                        <div className="mb-4 p-4 bg-red-50 dark:bg-red-900/20 border-2 border-red-200 dark:border-red-800 rounded-xl">
+                            <p className="text-red-800 dark:text-red-200 font-medium">{apiKeyError}</p>
+                        </div>
+                    )}
+
+                    {generatedToken && (
+                        <div className="mb-6 p-4 bg-amber-50 dark:bg-amber-900/20 border-2 border-amber-300 dark:border-amber-800 rounded-xl" aria-live="polite">
+                            <p className="text-amber-900 dark:text-amber-200 font-bold">
+                                Copy this token now. You will not be able to see it again.
+                            </p>
+                            <p className="text-sm text-amber-800 dark:text-amber-200/80 font-medium mt-1">
+                                New API key: {generatedTokenName}
+                            </p>
+                            <div className="mt-4 flex flex-col sm:flex-row gap-3">
+                                <input
+                                    aria-label={`Generated API token for ${generatedTokenName}`}
+                                    value={generatedToken}
+                                    readOnly
+                                    className="flex-1 min-w-0 px-4 py-3 bg-white dark:bg-neutral-800 border-2 border-black dark:border-neutral-700 rounded-xl text-slate-900 dark:text-white font-mono text-sm"
+                                    onFocus={(event) => event.target.select()}
+                                />
+                                <button
+                                    onClick={() => void handleCopyGeneratedToken()}
+                                    className="px-6 py-3 bg-emerald-600 dark:bg-emerald-500 text-white font-bold rounded-xl border-2 border-black dark:border-neutral-700 shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] dark:shadow-[2px_2px_0px_0px_rgba(255,255,255,0.2)] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] dark:hover:shadow-[4px_4px_0px_0px_rgba(255,255,255,0.2)] hover:-translate-y-0.5 transition-all duration-200 flex items-center justify-center gap-2"
+                                    aria-label="Copy generated API token"
+                                >
+                                    <Copy size={18} />
+                                    {copiedToken ? 'Copied' : 'Copy Token'}
+                                </button>
+                            </div>
+                        </div>
+                    )}
+
+                    <div className="flex flex-col sm:flex-row gap-3 mb-6">
+                        <div className="flex-1">
+                            <label htmlFor="apiKeyName" className="block text-sm font-bold text-slate-700 dark:text-neutral-300 mb-2">
+                                API Key Name
+                            </label>
+                            <input
+                                id="apiKeyName"
+                                type="text"
+                                value={apiKeyName}
+                                onChange={(event) => setApiKeyName(event.target.value)}
+                                maxLength={100}
+                                className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border-2 border-black dark:border-neutral-700 rounded-xl text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:focus:ring-emerald-400 font-medium"
+                                placeholder="Example: Backup script"
+                            />
+                        </div>
+                        <button
+                            onClick={() => void handleCreateApiKey()}
+                            disabled={apiKeyActionLoading || !apiKeyName.trim()}
+                            className="sm:self-end px-6 py-3 bg-emerald-600 dark:bg-emerald-500 text-white font-bold rounded-xl border-2 border-black dark:border-neutral-700 shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] dark:shadow-[2px_2px_0px_0px_rgba(255,255,255,0.2)] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] dark:hover:shadow-[4px_4px_0px_0px_rgba(255,255,255,0.2)] hover:-translate-y-0.5 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0 disabled:hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] dark:disabled:hover:shadow-[2px_2px_0px_0px_rgba(255,255,255,0.2)]"
+                        >
+                            {apiKeyActionLoading ? 'Creating...' : 'Create API Key'}
+                        </button>
+                    </div>
+
+                    {apiKeysLoading ? (
+                        <p className="text-slate-600 dark:text-neutral-400 font-medium">Loading API keys...</p>
+                    ) : apiKeys.length === 0 ? (
+                        <p className="text-slate-600 dark:text-neutral-400 font-medium">No API keys have been created yet.</p>
+                    ) : (
+                        <div className="space-y-4">
+                            {apiKeys.map(apiKey => {
+                                const revoked = Boolean(apiKey.revokedAt);
+                                return (
+                                    <div key={apiKey.id} className="p-4 bg-slate-50 dark:bg-neutral-800 border-2 border-slate-200 dark:border-neutral-700 rounded-xl">
+                                        <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
+                                            <div className="min-w-0">
+                                                <div className="flex flex-wrap items-center gap-2">
+                                                    <h3 className="text-lg font-bold text-slate-900 dark:text-white break-words">{apiKey.name}</h3>
+                                                    <span className={revoked ? "px-2 py-1 text-xs font-bold rounded-full bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-200 border border-red-200 dark:border-red-800" : "px-2 py-1 text-xs font-bold rounded-full bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200 border border-green-200 dark:border-green-800"}>
+                                                        {revoked ? 'Revoked' : 'Active'}
+                                                    </span>
+                                                </div>
+                                                <dl className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+                                                    <div>
+                                                        <dt className="font-bold text-slate-700 dark:text-neutral-300">Prefix</dt>
+                                                        <dd className="font-mono text-slate-600 dark:text-neutral-400 break-all">{apiKey.prefix}</dd>
+                                                    </div>
+                                                    <div>
+                                                        <dt className="font-bold text-slate-700 dark:text-neutral-300">Scopes</dt>
+                                                        <dd className="text-slate-600 dark:text-neutral-400">{apiKey.scopes.length > 0 ? apiKey.scopes.join(', ') : 'None'}</dd>
+                                                    </div>
+                                                    <div>
+                                                        <dt className="font-bold text-slate-700 dark:text-neutral-300">Created</dt>
+                                                        <dd className="text-slate-600 dark:text-neutral-400">{formatApiKeyDate(apiKey.createdAt)}</dd>
+                                                    </div>
+                                                    <div>
+                                                        <dt className="font-bold text-slate-700 dark:text-neutral-300">Last Used</dt>
+                                                        <dd className="text-slate-600 dark:text-neutral-400">{formatApiKeyDate(apiKey.lastUsedAt)}</dd>
+                                                    </div>
+                                                    <div>
+                                                        <dt className="font-bold text-slate-700 dark:text-neutral-300">Revoked</dt>
+                                                        <dd className="text-slate-600 dark:text-neutral-400">{formatApiKeyDate(apiKey.revokedAt)}</dd>
+                                                    </div>
+                                                </dl>
+                                            </div>
+                                            <button
+                                                onClick={() => void handleRevokeApiKey(apiKey.id, apiKey.name)}
+                                                disabled={apiKeyActionLoading || revoked}
+                                                className="px-4 py-2 bg-white dark:bg-neutral-900 text-red-700 dark:text-red-300 font-bold rounded-xl border-2 border-black dark:border-neutral-700 shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] dark:shadow-[2px_2px_0px_0px_rgba(255,255,255,0.2)] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] dark:hover:shadow-[4px_4px_0px_0px_rgba(255,255,255,0.2)] hover:-translate-y-0.5 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0 disabled:hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] dark:disabled:hover:shadow-[2px_2px_0px_0px_rgba(255,255,255,0.2)] flex items-center justify-center gap-2"
+                                                aria-label={`Revoke API key ${apiKey.name}`}
+                                            >
+                                                <Trash2 size={18} />
+                                                Revoke
+                                            </button>
+                                        </div>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    )}
                 </div>
 
                 <div className="bg-white dark:bg-neutral-900 border-2 border-black dark:border-neutral-700 rounded-2xl shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] dark:shadow-[4px_4px_0px_0px_rgba(255,255,255,0.2)] p-6">


### PR DESCRIPTION
So, this PR is focused on adding API key logic for excalidash.

First, thanks for such amazing tool, I wanted to have something like this for quite long time. I have it deployed with OIDC integration to Authelia. 

I'm also developing (more like vibe-coding) an obsidian plugin so that I can sync all my numerous drawings into excalidash collections and exactly for this reason I need api keys, since using full OIDC logic from plugin side is incredibly annoying and complicated. 

I have tested it and seems everything works just fine.

This PR was generated by GPT-5.5 model in general, with my guidance.