### PR TITLE
feat: share collections with other users

### DIFF
--- a/backend/prisma/migrations/20260614000000_add_collection_sharing/migration.sql
+++ b/backend/prisma/migrations/20260614000000_add_collection_sharing/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "CollectionPermission" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "collectionId" TEXT NOT NULL,
+    "granteeUserId" TEXT NOT NULL,
+    "permission" TEXT NOT NULL,
+    "createdByUserId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "CollectionPermission_collectionId_fkey" FOREIGN KEY ("collectionId") REFERENCES "Collection" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "CollectionPermission_granteeUserId_fkey" FOREIGN KEY ("granteeUserId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "CollectionPermission_granteeUserId_idx" ON "CollectionPermission"("granteeUserId");
+
+-- CreateIndex
+CREATE INDEX "CollectionPermission_collectionId_idx" ON "CollectionPermission"("collectionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CollectionPermission_collectionId_granteeUserId_key" ON "CollectionPermission"("collectionId", "granteeUserId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,6 +22,7 @@ model User {
   drawings            Drawing[]
   collections         Collection[]
   drawingPermissions  DrawingPermission[]
+  collectionPermissions CollectionPermission[]
   passwordResetTokens PasswordResetToken[]
   refreshTokens       RefreshToken[]
   auditLogs           AuditLog[]
@@ -52,6 +53,7 @@ model Collection {
   userId    String
   user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   drawings  Drawing[]
+  permissions CollectionPermission[]
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
 
@@ -108,6 +110,22 @@ model DrawingPermission {
   @@unique([drawingId, granteeUserId], name: "drawingId_granteeUserId")
   @@index([granteeUserId])
   @@index([drawingId])
+}
+
+model CollectionPermission {
+  id           String   @id @default(uuid())
+  collectionId String
+  collection   Collection @relation(fields: [collectionId], references: [id], onDelete: Cascade)
+  granteeUserId String
+  granteeUser  User     @relation(fields: [granteeUserId], references: [id], onDelete: Cascade)
+  permission   String // "view" | "edit"
+  createdByUserId String
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@unique([collectionId, granteeUserId], name: "collectionId_granteeUserId")
+  @@index([granteeUserId])
+  @@index([collectionId])
 }
 
 model DrawingLinkShare {

--- a/backend/src/__tests__/collection-sharing.integration.ts
+++ b/backend/src/__tests__/collection-sharing.integration.ts
@@ -1,0 +1,203 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import request from "supertest";
+import bcrypt from "bcrypt";
+import jwt, { SignOptions } from "jsonwebtoken";
+import { StringValue } from "ms";
+import { PrismaClient } from "../generated/client";
+import { config } from "../config";
+import { getTestPrisma, setupTestDb, createTestDrawingPayload } from "./testUtils";
+
+describe("Collections - Sharing", () => {
+  const userAgent = "vitest-collection-sharing";
+  let prisma: PrismaClient;
+  let app: any;
+  let seq = 0;
+
+  const signOptions: SignOptions = { expiresIn: config.jwtAccessExpiresIn as StringValue };
+
+  // A per-user supertest agent that carries the JWT and a CSRF token (cookie + header),
+  // matching how the browser client authenticates mutating requests.
+  const mkUser = async (label: string) => {
+    seq += 1;
+    const passwordHash = await bcrypt.hash("password123", 10);
+    const user = await prisma.user.create({
+      data: { email: `${label}-${seq}@test.local`, passwordHash, name: label, role: "USER", isActive: true },
+      select: { id: true, email: true },
+    });
+    const token = jwt.sign(
+      { userId: user.id, email: user.email, type: "access" },
+      config.jwtSecret,
+      signOptions
+    );
+
+    const agent = request.agent(app);
+    const csrf = await agent.get("/csrf-token").set("User-Agent", userAgent).set("Authorization", `Bearer ${token}`);
+    const csrfHeader = (csrf.body?.header as string) || "x-csrf-token";
+    const csrfToken = csrf.body?.token as string;
+    const withAuth = (r: request.Test) =>
+      r.set("User-Agent", userAgent).set("Authorization", `Bearer ${token}`).set(csrfHeader, csrfToken);
+
+    return {
+      id: user.id,
+      email: user.email,
+      get: (url: string) => withAuth(agent.get(url)),
+      post: (url: string) => withAuth(agent.post(url)),
+      put: (url: string) => withAuth(agent.put(url)),
+      del: (url: string) => withAuth(agent.delete(url)),
+    };
+  };
+
+  const mkCollection = (ownerId: string, name = "C") =>
+    prisma.collection.create({ data: { name, userId: ownerId }, select: { id: true } });
+
+  const mkDrawing = (ownerId: string, collectionId: string | null, name = "D") =>
+    prisma.drawing.create({
+      data: { name, elements: "[]", appState: "{}", files: "{}", userId: ownerId, collectionId, version: 1 },
+      select: { id: true },
+    });
+
+  const grant = (collectionId: string, granteeUserId: string, permission: "view" | "edit", by: string) =>
+    prisma.collectionPermission.create({ data: { collectionId, granteeUserId, permission, createdByUserId: by } });
+
+  beforeAll(async () => {
+    setupTestDb();
+    prisma = getTestPrisma();
+    ({ app } = await import("../index"));
+    await prisma.systemConfig.upsert({
+      where: { id: "default" },
+      update: { authEnabled: true, registrationEnabled: false },
+      create: { id: "default", authEnabled: true, registrationEnabled: false },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("lists shared collections and lets a grantee browse + open the drawings inside", async () => {
+    const a = await mkUser("owner");
+    const b = await mkUser("grantee");
+    const c = await mkCollection(a.id);
+    const d = await mkDrawing(a.id, c.id);
+    await grant(c.id, b.id, "edit", a.id);
+
+    const list = await b.get("/collections");
+    expect(list.status).toBe(200);
+    expect(Array.isArray(list.body)).toBe(true);
+    const row = (list.body as any[]).find((x) => x.id === c.id);
+    expect(row?.accessLevel).toBe("edit");
+
+    const browse = await b.get(`/collections/${c.id}/drawings`);
+    expect(browse.status).toBe(200);
+    expect((browse.body.drawings as any[]).map((x) => x.id)).toContain(d.id);
+
+    const open = await b.get(`/drawings/${d.id}`);
+    expect(open.status).toBe(200);
+    expect(open.body.id).toBe(d.id);
+    expect(open.body.accessLevel).toBe("edit");
+  });
+
+  it("view grants are read-only: grantee cannot edit a drawing or add to the collection", async () => {
+    const a = await mkUser("owner");
+    const b = await mkUser("viewer");
+    const c = await mkCollection(a.id);
+    const d = await mkDrawing(a.id, c.id);
+    await grant(c.id, b.id, "view", a.id);
+
+    expect((await b.get(`/drawings/${d.id}`)).body.accessLevel).toBe("view");
+    expect((await b.put(`/drawings/${d.id}`).send({ name: "hacked" })).status).toBe(404);
+    expect(
+      (await b.post(`/drawings`).send({ ...createTestDrawingPayload({ name: "sneak" }), collectionId: c.id })).status
+    ).toBe(404);
+  });
+
+  it("an edit grantee can add a drawing, and it becomes visible to the collection owner", async () => {
+    const a = await mkUser("owner");
+    const b = await mkUser("contributor");
+    const c = await mkCollection(a.id);
+    await grant(c.id, b.id, "edit", a.id);
+
+    const add = await b.post(`/drawings`).send({ ...createTestDrawingPayload({ name: "from-b" }), collectionId: c.id });
+    expect(add.status).toBe(200);
+    const addedId = add.body.id as string;
+
+    const ownerBrowse = await a.get(`/collections/${c.id}/drawings`);
+    expect((ownerBrowse.body.drawings as any[]).map((x) => x.id)).toContain(addedId);
+
+    const ownerOpen = await a.get(`/drawings/${addedId}`);
+    expect(ownerOpen.status).toBe(200);
+    expect(ownerOpen.body.accessLevel).toBe("owner");
+  });
+
+  it("non-members get 404 on the collection, its drawings, and inherited drawings", async () => {
+    const a = await mkUser("owner");
+    const stranger = await mkUser("stranger");
+    const c = await mkCollection(a.id);
+    const d = await mkDrawing(a.id, c.id);
+
+    expect((await stranger.get(`/collections/${c.id}`)).status).toBe(404);
+    expect((await stranger.get(`/collections/${c.id}/drawings`)).status).toBe(404);
+    expect((await stranger.get(`/drawings/${d.id}`)).status).toBe(404);
+  });
+
+  it("only the owner can grant or revoke; editors cannot", async () => {
+    const a = await mkUser("owner");
+    const b = await mkUser("editor");
+    const target = await mkUser("target");
+    const c = await mkCollection(a.id);
+    await grant(c.id, b.id, "edit", a.id);
+
+    const grantAttempt = await b.post(`/collections/${c.id}/permissions`).send({ granteeUserId: target.id, permission: "view" });
+    expect(grantAttempt.status).toBe(404);
+
+    const real = await prisma.collectionPermission.findFirst({ where: { collectionId: c.id, granteeUserId: b.id } });
+    const revokeAttempt = await b.del(`/collections/${c.id}/permissions/${real!.id}`);
+    expect(revokeAttempt.status).toBe(404);
+  });
+
+  it("rejects self-share and sharing the trash collection", async () => {
+    const a = await mkUser("owner");
+    const c = await mkCollection(a.id);
+
+    expect((await a.post(`/collections/${c.id}/permissions`).send({ granteeUserId: a.id, permission: "edit" })).status).toBe(400);
+    expect((await a.post(`/collections/trash/permissions`).send({ granteeUserId: a.id, permission: "edit" })).status).toBe(400);
+  });
+
+  it("revoking access takes effect immediately for the collection and its drawings", async () => {
+    const a = await mkUser("owner");
+    const b = await mkUser("revoked");
+    const c = await mkCollection(a.id);
+    const d = await mkDrawing(a.id, c.id);
+    const perm = await grant(c.id, b.id, "edit", a.id);
+
+    expect((await b.get(`/collections/${c.id}`)).status).toBe(200);
+    expect((await a.del(`/collections/${c.id}/permissions/${perm.id}`)).status).toBe(200);
+    expect((await b.get(`/collections/${c.id}`)).status).toBe(404);
+    expect((await b.get(`/drawings/${d.id}`)).status).toBe(404);
+  });
+
+  it("inherited drawing access is the max of direct permission and collection permission", async () => {
+    const a = await mkUser("owner");
+    const b = await mkUser("mixed");
+    const c = await mkCollection(a.id);
+    const d = await mkDrawing(a.id, c.id);
+    await grant(c.id, b.id, "view", a.id);
+    await prisma.drawingPermission.create({
+      data: { drawingId: d.id, granteeUserId: b.id, permission: "edit", createdByUserId: a.id },
+    });
+
+    expect((await b.get(`/drawings/${d.id}`)).body.accessLevel).toBe("edit");
+    expect((await b.put(`/drawings/${d.id}`).send({ name: "ok" })).status).toBe(200);
+  });
+
+  it("a non-owner cannot move a drawing between collections, and collection ids are not leaked", async () => {
+    const a = await mkUser("owner");
+    const b = await mkUser("editor");
+    const c = await mkCollection(a.id);
+    const d = await mkDrawing(a.id, c.id);
+    await grant(c.id, b.id, "edit", a.id);
+
+    expect((await b.put(`/drawings/${d.id}`).send({ collectionId: null })).status).toBe(403);
+    expect((await b.get(`/drawings/${d.id}`)).body.collectionId).toBeNull();
+  });
+});

--- a/backend/src/authz/sharing.ts
+++ b/backend/src/authz/sharing.ts
@@ -125,7 +125,7 @@ export const getDrawingAccess = async (params: {
   if (params.principal?.kind === "user") {
     const drawing = await params.prisma.drawing.findUnique({
       where: { id: params.drawingId },
-      select: { userId: true },
+      select: { userId: true, collectionId: true },
     });
     if (!drawing) return "none";
     if (drawing.userId === params.principal.userId) return "owner";
@@ -140,6 +140,16 @@ export const getDrawingAccess = async (params: {
       select: { permission: true },
     });
     baseAccess = normalizeDrawingPermission(perm?.permission) ?? baseAccess;
+
+    // A drawing inherits the access the principal has on its containing collection.
+    if (drawing.collectionId) {
+      const collectionAccess = await getCollectionAccess({
+        prisma: params.prisma,
+        principal: params.principal,
+        collectionId: drawing.collectionId,
+      });
+      baseAccess = maxAccess(baseAccess, collectionAccess);
+    }
   }
 
   // Google Docs-style link policy: applies regardless of whether the visitor is signed in.
@@ -164,6 +174,41 @@ export const canEditDrawing = (
   access === "edit" || access === "owner";
 
 export const isOwnerAccess = (access: DrawingAccess): boolean => access === "owner";
+
+export type CollectionAccess = DrawingAccess;
+
+export const getCollectionAccess = async (params: {
+  prisma: PrismaClient;
+  principal: DrawingPrincipal | null;
+  collectionId: string;
+}): Promise<CollectionAccess> => {
+  if (params.principal?.kind !== "user") return "none";
+
+  const collection = await params.prisma.collection.findUnique({
+    where: { id: params.collectionId },
+    select: { userId: true },
+  });
+  if (!collection) return "none";
+  if (collection.userId === params.principal.userId) return "owner";
+
+  const perm = await params.prisma.collectionPermission.findUnique({
+    where: {
+      collectionId_granteeUserId: {
+        collectionId: params.collectionId,
+        granteeUserId: params.principal.userId,
+      },
+    },
+    select: { permission: true },
+  });
+  return normalizeDrawingPermission(perm?.permission) ?? "none";
+};
+
+export const canViewCollection = (access: CollectionAccess): boolean => access !== "none";
+
+export const canEditCollection = (access: CollectionAccess): boolean =>
+  access === "edit" || access === "owner";
+
+export const isCollectionOwner = (access: CollectionAccess): boolean => access === "owner";
 
 const getActiveLinkShareAccess = async (params: {
   prisma: PrismaClient;

--- a/backend/src/routes/dashboard/collections.ts
+++ b/backend/src/routes/dashboard/collections.ts
@@ -1,6 +1,11 @@
 import express from "express";
 import { DashboardRouteDeps } from "./types";
 import { getUserTrashCollectionId, isTrashCollectionId } from "./trash";
+import {
+  getCollectionAccess,
+  canViewCollection,
+  normalizeDrawingPermission,
+} from "../../authz/sharing";
 
 export const registerCollectionRoutes = (
   app: express.Express,
@@ -23,19 +28,37 @@ export const registerCollectionRoutes = (
     const trashCollectionId = getUserTrashCollectionId(req.user.id);
     await ensureTrashCollection(prisma, req.user.id);
 
-    const rawCollections = await prisma.collection.findMany({
-      where: { userId: req.user.id },
-      orderBy: { createdAt: "desc" },
-    });
+    const [rawCollections, sharedCollections] = await Promise.all([
+      prisma.collection.findMany({
+        where: { userId: req.user.id },
+        orderBy: { createdAt: "desc" },
+      }),
+      prisma.collection.findMany({
+        where: {
+          userId: { not: req.user.id },
+          permissions: { some: { granteeUserId: req.user.id } },
+        },
+        orderBy: { createdAt: "desc" },
+        include: {
+          permissions: { where: { granteeUserId: req.user.id }, select: { permission: true } },
+        },
+      }),
+    ]);
+
     const hasInternalTrash = rawCollections.some((collection) => collection.id === trashCollectionId);
-    const collections = rawCollections
+    const owned = rawCollections
       .filter((collection) => !(hasInternalTrash && collection.id === "trash"))
       .map((collection) =>
         collection.id === trashCollectionId
-          ? { ...collection, id: "trash", name: "Trash" }
-          : collection
+          ? { ...collection, id: "trash", name: "Trash", accessLevel: "owner" }
+          : { ...collection, accessLevel: "owner" }
       );
-    return res.json(collections);
+    const shared = sharedCollections.map(({ permissions, ...collection }) => ({
+      ...collection,
+      accessLevel: normalizeDrawingPermission(permissions[0]?.permission) ?? "view",
+    }));
+
+    return res.json([...owned, ...shared]);
   }));
 
   app.post("/collections", requireAuth, asyncHandler(async (req, res) => {
@@ -54,6 +77,201 @@ export const registerCollectionRoutes = (
       data: { name: sanitizedName, userId: req.user.id },
     });
     return res.json(newCollection);
+  }));
+
+  // Read a single collection the caller owns or has been granted access to.
+  app.get("/collections/:id", requireAuth, asyncHandler(async (req, res) => {
+    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+    const { id } = req.params;
+    const access = await getCollectionAccess({
+      prisma,
+      principal: { kind: "user", userId: req.user.id },
+      collectionId: id,
+    });
+    if (!canViewCollection(access)) return res.status(404).json({ error: "Collection not found" });
+
+    const collection = await prisma.collection.findUnique({ where: { id } });
+    if (!collection) return res.status(404).json({ error: "Collection not found" });
+    return res.json({ ...collection, accessLevel: access });
+  }));
+
+  // Browse every drawing in a collection the caller can access (owner sees contributors' drawings too).
+  app.get("/collections/:id/drawings", requireAuth, asyncHandler(async (req, res) => {
+    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+    const { id } = req.params;
+    const access = await getCollectionAccess({
+      prisma,
+      principal: { kind: "user", userId: req.user.id },
+      collectionId: id,
+    });
+    if (!canViewCollection(access)) return res.status(404).json({ error: "Collection not found" });
+
+    const drawings = await prisma.drawing.findMany({
+      where: { collectionId: id },
+      select: {
+        id: true,
+        name: true,
+        preview: true,
+        version: true,
+        userId: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+      orderBy: { updatedAt: "desc" },
+    });
+
+    const responsePayload = drawings.map(({ userId, ...drawing }) => ({
+      ...drawing,
+      collectionId: id,
+      accessLevel: userId === req.user!.id ? "owner" : access,
+    }));
+
+    return res.json({ drawings: responsePayload, totalCount: responsePayload.length });
+  }));
+
+  // Owner-only: resolve users by name/email in the context of a collection you own (reduces enumeration risk).
+  app.get("/collections/:id/share-resolve", requireAuth, asyncHandler(async (req, res) => {
+    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+    const { id } = req.params;
+    const qRaw = typeof req.query.q === "string" ? req.query.q.trim() : "";
+    const q = qRaw.toLowerCase();
+    if (q.length < 3) return res.json({ users: [] });
+
+    const collection = await prisma.collection.findUnique({ where: { id }, select: { userId: true } });
+    if (!collection || collection.userId !== req.user.id) {
+      return res.status(404).json({ error: "Collection not found" });
+    }
+
+    const users = await prisma.user.findMany({
+      where: {
+        isActive: true,
+        id: { not: req.user.id },
+        OR: [
+          { email: { contains: q } },
+          { name: { contains: q } },
+          { username: { contains: q } },
+        ],
+      },
+      select: { id: true, name: true, email: true },
+      take: 10,
+    });
+
+    return res.json({ users });
+  }));
+
+  app.get("/collections/:id/sharing", requireAuth, asyncHandler(async (req, res) => {
+    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+    const { id } = req.params;
+
+    const collection = await prisma.collection.findUnique({ where: { id }, select: { userId: true } });
+    if (!collection || collection.userId !== req.user.id) {
+      return res.status(404).json({ error: "Collection not found" });
+    }
+
+    const permissions = await prisma.collectionPermission.findMany({
+      where: { collectionId: id },
+      select: {
+        id: true,
+        granteeUserId: true,
+        permission: true,
+        createdAt: true,
+        updatedAt: true,
+        granteeUser: { select: { id: true, name: true, email: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    return res.json({ permissions });
+  }));
+
+  app.post("/collections/:id/permissions", requireAuth, asyncHandler(async (req, res) => {
+    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+    const { id } = req.params;
+
+    if (id === "trash" || isTrashCollectionId(id, req.user.id)) {
+      return res.status(400).json({ error: "Validation error", message: "Cannot share the trash collection" });
+    }
+
+    const collection = await prisma.collection.findUnique({ where: { id }, select: { userId: true } });
+    if (!collection || collection.userId !== req.user.id) {
+      return res.status(404).json({ error: "Collection not found" });
+    }
+
+    const granteeUserId = typeof req.body?.granteeUserId === "string" ? req.body.granteeUserId : null;
+    const permission = normalizeDrawingPermission(req.body?.permission);
+    if (!granteeUserId || !permission) {
+      return res.status(400).json({ error: "Validation error", message: "Invalid grantee or permission" });
+    }
+    if (granteeUserId === req.user.id) {
+      return res.status(400).json({ error: "Validation error", message: "Cannot share with yourself" });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: granteeUserId },
+      select: { id: true, isActive: true },
+    });
+    if (!user || !user.isActive) {
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    const saved = await prisma.collectionPermission.upsert({
+      where: {
+        collectionId_granteeUserId: { collectionId: id, granteeUserId },
+      },
+      update: { permission, createdByUserId: req.user.id },
+      create: { collectionId: id, granteeUserId, permission, createdByUserId: req.user.id },
+      select: {
+        id: true,
+        granteeUserId: true,
+        permission: true,
+        createdAt: true,
+        updatedAt: true,
+        granteeUser: { select: { id: true, name: true, email: true } },
+      },
+    });
+
+    invalidateDrawingsCache();
+
+    if (config.enableAuditLogging) {
+      await logAuditEvent({
+        userId: req.user.id,
+        action: "collection_shared_user_upsert",
+        resource: `collection:${id}`,
+        ipAddress: req.ip || req.connection.remoteAddress || undefined,
+        userAgent: req.headers["user-agent"] || undefined,
+        details: { collectionId: id, granteeUserId, permission },
+      });
+    }
+
+    return res.json({ permission: saved });
+  }));
+
+  app.delete("/collections/:id/permissions/:permId", requireAuth, asyncHandler(async (req, res) => {
+    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+    const { id, permId } = req.params;
+
+    const collection = await prisma.collection.findUnique({ where: { id }, select: { userId: true } });
+    if (!collection || collection.userId !== req.user.id) {
+      return res.status(404).json({ error: "Collection not found" });
+    }
+
+    await prisma.collectionPermission.deleteMany({
+      where: { id: permId, collectionId: id },
+    });
+    invalidateDrawingsCache();
+
+    if (config.enableAuditLogging) {
+      await logAuditEvent({
+        userId: req.user.id,
+        action: "collection_shared_user_revoke",
+        resource: `collection:${id}`,
+        ipAddress: req.ip || req.connection.remoteAddress || undefined,
+        userAgent: req.headers["user-agent"] || undefined,
+        details: { collectionId: id, permissionId: permId },
+      });
+    }
+
+    return res.json({ success: true });
   }));
 
   app.put("/collections/:id", requireAuth, asyncHandler(async (req, res) => {
@@ -113,7 +331,7 @@ export const registerCollectionRoutes = (
 
     await prisma.$transaction([
       prisma.drawing.updateMany({
-        where: { collectionId: id, userId: req.user.id },
+        where: { collectionId: id },
         data: { collectionId: null },
       }),
       prisma.collection.deleteMany({ where: { id, userId: req.user.id } }),

--- a/backend/src/routes/dashboard/drawings.ts
+++ b/backend/src/routes/dashboard/drawings.ts
@@ -9,11 +9,12 @@ import {
 } from "./trash";
 import {
   buildShareLinkToken,
+  canEditCollection,
   canEditDrawing,
   canViewDrawing,
+  getCollectionAccess,
   getDrawingAccess,
   hashShareLinkToken,
-  isOwnerAccess,
   normalizeDrawingPermission,
   type DrawingPrincipal,
 } from "../../authz/sharing";
@@ -390,10 +391,12 @@ export const registerDrawingRoutes = (
       toInternalTrashCollectionId(targetCollectionIdRaw, req.user.id) ?? null;
 
     if (targetCollectionId && !isTrashCollectionId(targetCollectionId, req.user.id)) {
-      const collection = await prisma.collection.findFirst({
-        where: { id: targetCollectionId, userId: req.user.id },
+      const collectionAccess = await getCollectionAccess({
+        prisma,
+        principal: { kind: "user", userId: req.user.id },
+        collectionId: targetCollectionId,
       });
-      if (!collection) return res.status(404).json({ error: "Collection not found" });
+      if (!canEditCollection(collectionAccess)) return res.status(404).json({ error: "Collection not found" });
     } else if (targetCollectionIdRaw === "trash") {
       await ensureTrashCollection(prisma, req.user.id);
     }
@@ -467,7 +470,7 @@ export const registerDrawingRoutes = (
     if (payload.preview !== undefined) data.preview = payload.preview;
 
     if (payload.collectionId !== undefined) {
-      if (!isOwnerAccess(access)) {
+      if (req.user?.id !== ownerUserId) {
         return res.status(403).json({
           error: "Forbidden",
           message: "Only the owner can move drawings between collections",
@@ -477,10 +480,12 @@ export const registerDrawingRoutes = (
         await ensureTrashCollection(prisma, ownerUserId);
         (data as Prisma.DrawingUncheckedUpdateInput).collectionId = trashCollectionId;
       } else if (payload.collectionId) {
-        const collection = await prisma.collection.findFirst({
-          where: { id: payload.collectionId, userId: ownerUserId },
+        const targetAccess = await getCollectionAccess({
+          prisma,
+          principal: { kind: "user", userId: req.user!.id },
+          collectionId: payload.collectionId,
         });
-        if (!collection) return res.status(404).json({ error: "Collection not found" });
+        if (!canEditCollection(targetAccess)) return res.status(404).json({ error: "Collection not found" });
         (data as Prisma.DrawingUncheckedUpdateInput).collectionId = payload.collectionId;
       } else {
         (data as Prisma.DrawingUncheckedUpdateInput).collectionId = null;

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -578,6 +578,40 @@ export const revokeLinkShare = async (drawingId: string, shareId: string): Promi
   return response.data;
 };
 
+// Collection sharing (named-user ACL; mirrors drawing permissions, no link shares)
+export const resolveCollectionShareUsers = async (collectionId: string, q: string): Promise<ShareResolvedUser[]> => {
+  const response = await api.get<{ users: ShareResolvedUser[] }>(`/collections/${collectionId}/share-resolve`, {
+    params: { q },
+  });
+  return response.data.users;
+};
+
+export const getCollectionSharing = async (collectionId: string): Promise<{ permissions: DrawingPermissionRow[] }> => {
+  const response = await api.get<{ permissions: DrawingPermissionRow[] }>(`/collections/${collectionId}/sharing`);
+  return response.data;
+};
+
+export const upsertCollectionPermission = async (
+  collectionId: string,
+  params: { granteeUserId: string; permission: "view" | "edit" }
+): Promise<{ permission: DrawingPermissionRow }> => {
+  const response = await api.post<{ permission: DrawingPermissionRow }>(`/collections/${collectionId}/permissions`, params);
+  return response.data;
+};
+
+export const revokeCollectionPermission = async (collectionId: string, permissionId: string): Promise<{ success: true }> => {
+  const response = await api.delete<{ success: true }>(`/collections/${collectionId}/permissions/${permissionId}`);
+  return response.data;
+};
+
+export const getCollectionDrawings = async (collectionId: string): Promise<PaginatedDrawings<DrawingSummary>> => {
+  const response = await api.get<PaginatedDrawings<DrawingSummary>>(`/collections/${collectionId}/drawings`);
+  return {
+    ...response.data,
+    drawings: response.data.drawings.map(deserializeDrawingSummary),
+  };
+};
+
 export const createDrawing = async (
   name?: string,
   collectionId?: string | null

--- a/frontend/src/components/ShareModal.tsx
+++ b/frontend/src/components/ShareModal.tsx
@@ -18,8 +18,9 @@ import * as api from "../api";
 import { useAuth } from "../context/AuthContext";
 
 type Props = {
-  drawingId: string;
-  drawingName: string;
+  resourceType: "drawing" | "collection";
+  resourceId: string;
+  resourceName: string;
   isOpen: boolean;
   onClose: () => void;
 };
@@ -140,9 +141,10 @@ const CustomSelect: React.FC<{
   );
 };
 
-export const ShareModal: React.FC<Props> = ({ drawingId, drawingName, isOpen, onClose }) => {
+export const ShareModal: React.FC<Props> = ({ resourceType, resourceId, resourceName, isOpen, onClose }) => {
   const { user } = useAuth();
   const currentUserId = user?.id || null;
+  const isCollection = resourceType === "collection";
 
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -161,7 +163,7 @@ export const ShareModal: React.FC<Props> = ({ drawingId, drawingName, isOpen, on
   const [isCopied, setIsCopied] = useState(false);
 
   const origin = typeof window !== "undefined" ? window.location.origin : "";
-  const shareableEditorUrl = `${origin}/shared/${drawingId}`;
+  const shareableEditorUrl = `${origin}/shared/${resourceId}`;
 
   const activeLink = useMemo(() => {
     const now = Date.now();
@@ -194,8 +196,13 @@ export const ShareModal: React.FC<Props> = ({ drawingId, drawingName, isOpen, on
     setIsLoading(true);
     setError(null);
     try {
-      const data = await api.getDrawingSharing(drawingId);
-      setSharing(data);
+      const data = isCollection
+        ? await api.getCollectionSharing(resourceId)
+        : await api.getDrawingSharing(resourceId);
+      setSharing({
+        permissions: data.permissions,
+        linkShares: (data as { linkShares?: api.DrawingLinkShareRow[] }).linkShares ?? [],
+      });
     } catch (err: unknown) {
       let message = "Failed to load sharing settings";
       if (api.isAxiosError(err)) {
@@ -206,7 +213,7 @@ export const ShareModal: React.FC<Props> = ({ drawingId, drawingName, isOpen, on
     } finally {
       setIsLoading(false);
     }
-  }, [drawingId]);
+  }, [resourceId, isCollection]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -230,7 +237,9 @@ export const ShareModal: React.FC<Props> = ({ drawingId, drawingName, isOpen, on
     let cancelled = false;
     const run = async () => {
       try {
-        const users = await api.resolveShareUsers(drawingId, q);
+        const users = isCollection
+          ? await api.resolveCollectionShareUsers(resourceId, q)
+          : await api.resolveShareUsers(resourceId, q);
         const filtered = currentUserId ? users.filter((u) => u.id !== currentUserId) : users;
         if (!cancelled) setUserResults(filtered);
       } catch {
@@ -242,7 +251,7 @@ export const ShareModal: React.FC<Props> = ({ drawingId, drawingName, isOpen, on
       cancelled = true;
       window.clearTimeout(t);
     };
-  }, [currentUserId, drawingId, isOpen, userQuery]);
+  }, [currentUserId, resourceId, isOpen, userQuery, isCollection]);
 
   const handleCopy = async (text: string) => {
     if (!text) return;
@@ -271,7 +280,7 @@ export const ShareModal: React.FC<Props> = ({ drawingId, drawingName, isOpen, on
     setIsLoading(true);
     setError(null);
     try {
-      await api.upsertDrawingPermission(drawingId, { granteeUserId: uId, permission: userPermission });
+      await (isCollection ? api.upsertCollectionPermission : api.upsertDrawingPermission)(resourceId, { granteeUserId: uId, permission: userPermission });
       await refresh();
       setUserQuery("");
       setUserResults([]);
@@ -291,7 +300,7 @@ export const ShareModal: React.FC<Props> = ({ drawingId, drawingName, isOpen, on
     setIsLoading(true);
     setError(null);
     try {
-      await api.revokeDrawingPermission(drawingId, permissionId);
+      await (isCollection ? api.revokeCollectionPermission : api.revokeDrawingPermission)(resourceId, permissionId);
       await refresh();
     } catch {
       setError("Failed to revoke access");
@@ -305,14 +314,14 @@ export const ShareModal: React.FC<Props> = ({ drawingId, drawingName, isOpen, on
     setError(null);
     try {
       if (activeLink) {
-        await api.revokeLinkShare(drawingId, activeLink.id);
+        await api.revokeLinkShare(resourceId, activeLink.id);
       }
       
       const perm = newPermission ?? linkPermission;
       setLinkPermission(perm);
       const expiresAt = newExpiry ?? calculateExpiresAt(expiryOption, customExpiry);
       
-      await api.createLinkShare(drawingId, {
+      await api.createLinkShare(resourceId, {
         permission: perm,
         expiresAt,
       });
@@ -336,7 +345,7 @@ export const ShareModal: React.FC<Props> = ({ drawingId, drawingName, isOpen, on
     setIsLoading(true);
     setError(null);
     try {
-      await api.revokeLinkShare(drawingId, activeLink.id);
+      await api.revokeLinkShare(resourceId, activeLink.id);
       await refresh();
     } catch {
       setError("Failed to revoke link");
@@ -355,8 +364,8 @@ export const ShareModal: React.FC<Props> = ({ drawingId, drawingName, isOpen, on
       
       <div className="relative w-full max-w-[420px] bg-white dark:bg-neutral-900 rounded-[20px] border-2 border-black dark:border-neutral-700 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] dark:shadow-[6px_6px_0px_0px_rgba(255,255,255,0.05)] flex flex-col animate-in fade-in zoom-in-95 duration-200">
         <div className="px-5 py-3.5 flex items-center justify-between border-b-2 border-black dark:border-neutral-700">
-          <h2 className="text-base font-black text-slate-800 dark:text-neutral-100 truncate pr-4" title={drawingName}>
-            Share "{drawingName}"
+          <h2 className="text-base font-black text-slate-800 dark:text-neutral-100 truncate pr-4" title={resourceName}>
+            Share "{resourceName}"
           </h2>
           <button
             onClick={onClose}
@@ -442,7 +451,7 @@ export const ShareModal: React.FC<Props> = ({ drawingId, drawingName, isOpen, on
                         if (val === "remove") {
                           await handleRevokeUser(p.id);
                         } else {
-                          await api.upsertDrawingPermission(drawingId, { granteeUserId: p.granteeUserId, permission: val as any });
+                          await (isCollection ? api.upsertCollectionPermission : api.upsertDrawingPermission)(resourceId, { granteeUserId: p.granteeUserId, permission: val as any });
                           void refresh();
                         }
                       }}
@@ -459,6 +468,7 @@ export const ShareModal: React.FC<Props> = ({ drawingId, drawingName, isOpen, on
             </div>
           </section>
 
+          {!isCollection && (
           <section className="pt-5 border-t-2 border-black dark:border-neutral-700">
             <h3 className="text-[9px] font-black uppercase tracking-[0.2em] text-slate-400 dark:text-neutral-500 px-1 mb-3">General access</h3>
             
@@ -554,9 +564,11 @@ export const ShareModal: React.FC<Props> = ({ drawingId, drawingName, isOpen, on
               </div>
             </div>
           </section>
+          )}
         </div>
 
         <div className="px-5 py-5 flex items-center justify-between border-t-2 border-black dark:border-neutral-700 bg-slate-50 dark:bg-neutral-800/50 rounded-b-[18px]">
+          {isCollection ? <div /> : (
           <button
             onClick={() => handleCopy(currentLinkUrl)}
             disabled={!activeLink}
@@ -571,7 +583,8 @@ export const ShareModal: React.FC<Props> = ({ drawingId, drawingName, isOpen, on
             {isCopied ? <Check size={16} strokeWidth={3} /> : <LinkIcon size={16} strokeWidth={3} />}
             {isCopied ? "COPIED!" : "COPY LINK"}
           </button>
-          
+          )}
+
           <button
             onClick={onClose}
             className="px-8 py-2.5 rounded-xl bg-indigo-600 dark:bg-indigo-500 text-white border-2 border-black font-black text-[10px] uppercase tracking-[0.2em] hover:-translate-y-0.5 hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] active:translate-y-0 active:shadow-none transition-all shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]"

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { LayoutGrid, Folder, Plus, Trash2, Edit2, Archive, FolderOpen, Settings as SettingsIcon, User, LogOut, Shield } from 'lucide-react';
+import { LayoutGrid, Folder, Plus, Trash2, Edit2, Archive, FolderOpen, Settings as SettingsIcon, User, LogOut, Shield, Share2 } from 'lucide-react';
 import type { Collection } from '../types';
 import clsx from 'clsx';
 import { ConfirmModal } from './ConfirmModal';
+import { ShareModal } from './ShareModal';
 import { Logo } from './Logo';
 import { useAuth } from '../context/AuthContext';
 import { getInitialsFromName } from '../utils/user';
@@ -130,6 +131,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; type: 'item' | 'background'; id?: string } | null>(null);
   const [collectionToDelete, setCollectionToDelete] = useState<string | null>(null);
   const [isTrashDragOver, setIsTrashDragOver] = useState(false);
+  const [shareCollection, setShareCollection] = useState<{ id: string; name: string } | null>(null);
 
   useEffect(() => {
     const handleClickOutside = () => setContextMenu(null);
@@ -252,6 +254,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 isActive={selectedCollectionId === collection.id}
                 onClick={() => onSelectCollection(collection.id)}
                 onDoubleClick={() => {
+                  if (collection.accessLevel && collection.accessLevel !== 'owner') return;
                   setEditingId(collection.id);
                   setEditName(collection.name);
                 }}
@@ -376,31 +379,53 @@ export const Sidebar: React.FC<SidebarProps> = ({
             onClick={(e) => e.stopPropagation()}
           >
             {contextMenu.type === 'item' && contextMenu.id ? (
-              <>
-                <button
-                  onClick={() => {
-                    const collection = collections.find(c => c.id === contextMenu.id);
-                    if (collection) {
-                      setEditingId(collection.id);
-                      setEditName(collection.name);
-                    }
-                    setContextMenu(null);
-                  }}
-                  className="w-full px-3 py-2 text-sm text-left text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 hover:text-indigo-600 dark:hover:text-indigo-400 flex items-center gap-2"
-                >
-                  <Edit2 size={14} /> Rename Collection
-                </button>
+              (() => {
+                const ctxCollection = collections.find(c => c.id === contextMenu.id);
+                const ctxOwned = !ctxCollection?.accessLevel || ctxCollection.accessLevel === 'owner';
+                if (!ctxOwned) {
+                  return (
+                    <div className="px-3 py-2 text-sm text-left text-slate-400 dark:text-neutral-500 flex items-center gap-2">
+                      <Share2 size={14} /> Shared with you
+                    </div>
+                  );
+                }
+                return (
+                  <>
+                    <button
+                      onClick={() => {
+                        if (ctxCollection) setShareCollection({ id: ctxCollection.id, name: ctxCollection.name });
+                        setContextMenu(null);
+                      }}
+                      className="w-full px-3 py-2 text-sm text-left text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 hover:text-indigo-600 dark:hover:text-indigo-400 flex items-center gap-2"
+                    >
+                      <Share2 size={14} /> Share Collection
+                    </button>
 
-                <button
-                  onClick={() => {
-                    setCollectionToDelete(contextMenu.id!);
-                    setContextMenu(null);
-                  }}
-                  className="w-full px-3 py-2 text-sm text-left text-rose-600 dark:text-rose-400 hover:bg-rose-50 dark:hover:bg-rose-900/30 flex items-center gap-2"
-                >
-                  <Trash2 size={14} /> Delete Collection
-                </button>
-              </>
+                    <button
+                      onClick={() => {
+                        if (ctxCollection) {
+                          setEditingId(ctxCollection.id);
+                          setEditName(ctxCollection.name);
+                        }
+                        setContextMenu(null);
+                      }}
+                      className="w-full px-3 py-2 text-sm text-left text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 hover:text-indigo-600 dark:hover:text-indigo-400 flex items-center gap-2"
+                    >
+                      <Edit2 size={14} /> Rename Collection
+                    </button>
+
+                    <button
+                      onClick={() => {
+                        setCollectionToDelete(contextMenu.id!);
+                        setContextMenu(null);
+                      }}
+                      className="w-full px-3 py-2 text-sm text-left text-rose-600 dark:text-rose-400 hover:bg-rose-50 dark:hover:bg-rose-900/30 flex items-center gap-2"
+                    >
+                      <Trash2 size={14} /> Delete Collection
+                    </button>
+                  </>
+                );
+              })()
             ) : (
               <button
                 onClick={() => {
@@ -430,7 +455,15 @@ export const Sidebar: React.FC<SidebarProps> = ({
         onCancel={() => setCollectionToDelete(null)}
       />
 
-
+      {shareCollection && (
+        <ShareModal
+          resourceType="collection"
+          resourceId={shareCollection.id}
+          resourceName={shareCollection.name}
+          isOpen={!!shareCollection}
+          onClose={() => setShareCollection(null)}
+        />
+      )}
     </>
   );
 };

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -259,8 +259,10 @@ export const Dashboard: React.FC = () => {
 
   const isTrashView = selectedCollectionId === 'trash';
   const isSharedView = selectedCollectionId === 'shared';
+  const selectedCollection = collections.find((c) => c.id === selectedCollectionId);
+  const isReadOnlyCollection = selectedCollection?.accessLevel === 'view';
   const handleCreateDrawing = async () => {
-    if (isTrashView || isSharedView) return;
+    if (isTrashView || isSharedView || isReadOnlyCollection) return;
     try {
       const targetCollectionId = selectedCollectionId === undefined ? null : selectedCollectionId;
       const { id } = await api.createDrawing('Untitled Drawing', targetCollectionId);
@@ -271,7 +273,7 @@ export const Dashboard: React.FC = () => {
   };
 
   const handleImportDrawings = async (files: FileList | null) => {
-    if (!files || isTrashView || isSharedView) return;
+    if (!files || isTrashView || isSharedView || isReadOnlyCollection) return;
 
     const fileArray = Array.from(files);
     const targetCollectionId = selectedCollectionId === undefined ? null : selectedCollectionId;
@@ -888,10 +890,10 @@ export const Dashboard: React.FC = () => {
 
           <button
             onClick={handleCreateDrawing}
-            disabled={isTrashView || isSharedView}
+            disabled={isTrashView || isSharedView || isReadOnlyCollection}
             className={clsx(
               "h-[42px] w-full sm:w-auto flex items-center justify-center gap-2 px-6 rounded-xl border-2 border-black dark:border-neutral-700 shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] dark:shadow-[2px_2px_0px_0px_rgba(255,255,255,0.2)] transition-all font-bold text-sm whitespace-nowrap",
-              isTrashView || isSharedView
+              isTrashView || isSharedView || isReadOnlyCollection
                 ? "bg-slate-100 dark:bg-slate-800 text-slate-400 dark:text-slate-600 border-slate-300 dark:border-slate-700 shadow-none cursor-not-allowed"
                 : "bg-indigo-600 dark:bg-neutral-800 text-white hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] dark:hover:shadow-[4px_4px_0px_0px_rgba(255,255,255,0.2)] hover:-translate-y-1 active:translate-y-0 active:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] dark:active:shadow-[2px_2px_0px_0px_rgba(255,255,255,0.2)]"
             )}

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -1922,8 +1922,9 @@ export const Editor: React.FC = () => {
       {id ? (
         <>
           <ShareModal
-            drawingId={id}
-            drawingName={drawingName}
+            resourceType="drawing"
+            resourceId={id}
+            resourceName={drawingName}
             isOpen={isShareOpen}
             onClose={() => setIsShareOpen(false)}
           />

--- a/frontend/src/pages/dashboard/useDashboardData.ts
+++ b/frontend/src/pages/dashboard/useDashboardData.ts
@@ -37,6 +37,10 @@ export const useDashboardData = ({
     setIsLoading(true);
     try {
       const isSharedView = selectedCollectionId === "shared";
+      const isCollectionView =
+        typeof selectedCollectionId === "string" &&
+        selectedCollectionId !== "shared" &&
+        selectedCollectionId !== "trash";
       const drawingsPromise = isSharedView
         ? api.getSharedDrawings(debouncedSearch, {
             limit: pageSize,
@@ -44,6 +48,8 @@ export const useDashboardData = ({
             sortField,
             sortDirection,
           })
+        : isCollectionView
+        ? api.getCollectionDrawings(selectedCollectionId as string)
         : api.getDrawings(debouncedSearch, selectedCollectionId, {
             limit: pageSize,
             offset: 0,
@@ -92,6 +98,12 @@ export const useDashboardData = ({
     setIsFetchingMore(true);
     try {
       const isSharedView = selectedCollectionId === "shared";
+      const isCollectionView =
+        typeof selectedCollectionId === "string" &&
+        selectedCollectionId !== "shared" &&
+        selectedCollectionId !== "trash";
+      // Collection browse returns the full set in one request; nothing more to page.
+      if (isCollectionView) return;
       const drawingsRes = await (isSharedView
         ? api.getSharedDrawings(debouncedSearch, {
             limit: pageSize,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -19,4 +19,5 @@ export interface Collection {
   id: string;
   name: string;
   createdAt: number;
+  accessLevel?: "view" | "edit" | "owner";
 }


### PR DESCRIPTION
needed this for my use cases, so im pushing this PR if useful. feature in action: https://cap.so/s/7ga0da58ys82x27


begin claude summary...

## Summary

Adds collection-level sharing — share a whole collection with specific people instead of sharing each drawing one at a time. Closes #93, closes #156 (related: #121).

Drawings inside a shared collection are visible to everyone with access, and editors can add their own drawings to it. The implementation mirrors the existing per-drawing sharing (`DrawingPermission` + `authz/sharing.ts`) as closely as possible.

## How it works

- New `CollectionPermission` model (`view` / `edit`), mirroring `DrawingPermission`.
- `getCollectionAccess()` in `authz/sharing.ts`, and **a drawing now inherits the access a user has on its containing collection**. That single rule is what makes sharing a collection grant access to everything inside it, while keeping `getDrawingAccess` the one source of truth (`max(direct, collection)`).
- Collection endpoints mirror the drawing ones: `GET /collections/:id/sharing`, `POST` / `DELETE /collections/:id/permissions`, `GET /collections/:id/share-resolve`, plus `GET /collections/:id` and a leak-safe `GET /collections/:id/drawings` so members (and the owner) can browse the full collection contents.
- `GET /collections` also returns collections shared with the caller, each tagged `accessLevel: "view" | "edit" | "owner"`.
- Frontend: `ShareModal` is parameterized by `resourceType` (`"drawing" | "collection"`); a "Share Collection" action in the sidebar; shared collections are listed with an indicator; and the dashboard browses a shared collection via the new endpoint.

## Design decisions

- **view** = open the collection and its drawings read-only; **edit** = also add/edit drawings in it.
- Rename / delete / re-share a collection stay **owner-only**.
- A drawing added by an editor is **owned by the adder** (it appears in their own library too) and shows up in the shared collection for all members.
- Named-user ACL only for now (no "anyone with the link" for collections yet — drawings keep theirs); straightforward to add later by mirroring `DrawingLinkShare`.
- Deleting a collection un-files its drawings (`collectionId = null`) for all members rather than deleting them.

## Tests

`backend/src/__tests__/collection-sharing.integration.ts` — 9 adversarial integration tests: view vs edit, non-member denial, owner-only grant/revoke, self/trash-share rejection, immediate revoke, `max(direct, collection)` inheritance, non-owner cannot move drawings between collections, and `collectionId` not leaked to grantees.

## Note

The second commit excludes test files from the production `tsc` build — the backend `Dockerfile` runs `npx tsc`, which was pulling untyped test mocks into the type check. vitest still type-checks and runs the tests separately. Happy to drop or split that out if you'd prefer it in its own PR.
