### PR TITLE
feat(auth): optional service token for machine-to-machine admin access

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -42,6 +42,14 @@ CSRF_SECRET=change-this-secret-in-production
 # BOOTSTRAP_SETUP_CODE_TTL_MS=900000
 # BOOTSTRAP_SETUP_CODE_MAX_ATTEMPTS=10
 
+# Service token (machine-to-machine admin)
+# A static bearer token for an external service that needs admin API access
+# without a user session (e.g. an automated user-provisioning service). A request
+# sending `Authorization: Bearer <SERVICE_API_TOKEN>` is treated as an admin and is
+# exempt from CSRF (it carries no cookies, so CSRF does not apply). Disabled unless
+# set; use a long random value (>= 32 chars).
+# SERVICE_API_TOKEN=
+
 # OIDC Configuration (required when AUTH_MODE=hybrid or AUTH_MODE=oidc_enforced)
 # OIDC_PROVIDER_NAME=Authentik
 # OIDC_ISSUER_URL=https://auth.example.com/application/o/excalidash/

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -348,6 +348,7 @@ export const createAuthRouter = (deps: CreateAuthRouterDeps): express.Router => 
   };
 
   const requireCsrf = (req: Request, res: Response): boolean => {
+    if (req.isServicePrincipal) return true;
     const origin = req.headers["origin"];
     const referer = req.headers["referer"];
     const originValue = Array.isArray(origin) ? origin[0] : origin;

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -26,6 +26,7 @@ interface Config {
   enforceHttpsRedirect: boolean;
   bootstrapSetupCodeTtlMs: number;
   bootstrapSetupCodeMaxAttempts: number;
+  serviceApiToken: string;
 }
 
 export type AuthMode = "local" | "hybrid" | "oidc_enforced";
@@ -306,6 +307,7 @@ export const config: Config = {
   frontendUrl: parseFrontendUrl(process.env.FRONTEND_URL),
   authMode: resolvedAuthMode,
   jwtSecret: resolveJwtSecret(getOptionalEnv("NODE_ENV", "development")),
+  serviceApiToken: getOptionalEnv("SERVICE_API_TOKEN", ""),
   jwtAccessExpiresIn: getOptionalEnv("JWT_ACCESS_EXPIRES_IN", "15m"),
   jwtRefreshExpiresIn: getOptionalEnv("JWT_REFRESH_EXPIRES_IN", "7d"),
   rateLimitMaxRequests: getRequiredEnvNumber("RATE_LIMIT_MAX_REQUESTS", 1000),

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import jwt from "jsonwebtoken";
+import crypto from "crypto";
 import { config } from "../config";
 import { PrismaClient } from "../generated/client";
 import { prisma as defaultPrisma } from "../db/prisma";
@@ -13,6 +14,7 @@ import {
 declare global {
   namespace Express {
     interface Request {
+      isServicePrincipal?: boolean;
       user?: {
         id: string;
         username?: string | null;
@@ -97,6 +99,21 @@ const verifyToken = (token: string): JwtPayload | null => {
     return decoded;
   } catch {
     return null;
+  }
+};
+
+// A static service token for machine-to-machine admin access (e.g. an external
+// user-provisioning service). Constant-time comparison; disabled unless
+// SERVICE_API_TOKEN is configured with at least 16 characters.
+const isServiceToken = (provided: string): boolean => {
+  const expected = config.serviceApiToken;
+  if (!expected || expected.length < 16 || provided.length !== expected.length) {
+    return false;
+  }
+  try {
+    return crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(expected));
+  } catch {
+    return false;
   }
 };
 
@@ -236,6 +253,20 @@ export const createAuthMiddleware = ({
         message: "Authentication token required",
       });
       return;
+    }
+
+    // Service token: machine-to-machine admin (no user session, no CSRF). Maps
+    // to a synthetic admin principal so the admin routes work unchanged.
+    if (isServiceToken(token)) {
+      req.user = {
+        id: "service",
+        username: null,
+        email: "service@local",
+        name: "Service",
+        role: "ADMIN",
+      };
+      req.isServicePrincipal = true;
+      return next();
     }
 
     const payload = verifyToken(token);


### PR DESCRIPTION
## What

Adds an **opt-in** `SERVICE_API_TOKEN`. A request whose bearer token matches it is treated as a synthetic admin principal and is **exempt from CSRF** (it carries no cookies, so the double-submit check does not apply).

## Why

ExcaliDash already ships a full admin user API (`GET/POST/PATCH /auth/users`), but it can only be reached by a logged-in admin browser session (access JWT cookie + CSRF token). There is no path for an **external service** to drive it.

My use case: a self-hosted hub uses ExcaliDash behind OIDC and provisions/updates users from a central control plane (create account, set role, deactivate) when a teammate is added. Without a service token, the only options are to script a full browser login + CSRF handshake, or to write to the DB directly — both brittle. A static service token makes this a clean, supported integration.

## How

- `config.ts`: read `SERVICE_API_TOKEN` (default empty).
- `middleware/auth.ts` `requireAuth`: if the bearer matches the configured token (constant-time compare), set a `role: "ADMIN"` principal and an `isServicePrincipal` flag, then continue. Ignored unless the token is set and ≥ 16 chars.
- `auth.ts` `requireCsrf`: returns early (no-op) for a service principal — CSRF protects cookie-based sessions, which this isn't.
- `backend/.env.example`: documented.

## Safety / compatibility

- **Disabled by default** — no behavior change unless `SERVICE_API_TOKEN` is set.
- **Constant-time comparison** (`crypto.timingSafeEqual`), minimum length guard.
- Only grants what an admin already can do via the existing admin API; no new endpoints.
- CSRF exemption is correct here: the request is header-authenticated and cookie-less, so it isn't a cross-site-request-forgery surface.

Happy to adjust naming (e.g. `ADMIN_SERVICE_TOKEN`), add tests, or gate it behind an explicit `ENABLE_SERVICE_TOKEN` flag if you prefer.