### PR TITLE
Allow drawing owners to move drawings into shared collections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,26 @@ services:
 - Realtime/editor behavior: `frontend/src/pages/Editor.tsx`
 - Deployment flow: `docker-compose*.yml`, `backend/Dockerfile`, `frontend/Dockerfile`, entrypoint scripts
 - Build/dev commands: `make build`, `npm test`, `make test-all`, `make test-e2e`
+- Running backend unit tests without a local Node.js install (Docker only):
+  ```bash
+  # Build the test image once (uses the builder stage — includes all dev deps + openssl)
+  docker build -f backend/Dockerfile --target builder -t excalidash-backend-test backend/
+
+  # Run all backend unit/integration tests
+  docker run --rm \
+    -v "$(pwd)/backend/src:/app/src" \
+    -v "$(pwd)/backend/vitest.config.ts:/app/vitest.config.ts" \
+    excalidash-backend-test \
+    sh -c "apk add --no-cache openssl && npx vitest run"
+
+  # Run a single test file
+  docker run --rm \
+    -v "$(pwd)/backend/src:/app/src" \
+    -v "$(pwd)/backend/vitest.config.ts:/app/vitest.config.ts" \
+    excalidash-backend-test \
+    sh -c "apk add --no-cache openssl && npx vitest run --reporter=verbose src/__tests__/collection-sharing.integration.ts"
+  ```
+  The image only needs to be rebuilt when `package.json`, `prisma/schema.prisma`, or the Dockerfile itself changes.
 - Development contributor flow:
   - `make install` → `make dev`
   - stop with `make dev-stop`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,24 +86,22 @@ services:
 - Build/dev commands: `make build`, `npm test`, `make test-all`, `make test-e2e`
 - Running backend unit tests without a local Node.js install (Docker only):
   ```bash
-  # Build the test image once (uses the builder stage — includes all dev deps + openssl)
+  # Build the test image once (uses the builder stage — includes all dev deps; openssl is installed at runtime for Prisma binaries)
   docker build -f backend/Dockerfile --target builder -t excalidash-backend-test backend/
 
   # Run all backend unit/integration tests
   docker run --rm \
-    -v "$(pwd)/backend/src:/app/src" \
     -v "$(pwd)/backend/vitest.config.ts:/app/vitest.config.ts" \
     excalidash-backend-test \
     sh -c "apk add --no-cache openssl && npx vitest run"
 
   # Run a single test file
   docker run --rm \
-    -v "$(pwd)/backend/src:/app/src" \
     -v "$(pwd)/backend/vitest.config.ts:/app/vitest.config.ts" \
     excalidash-backend-test \
     sh -c "apk add --no-cache openssl && npx vitest run --reporter=verbose src/__tests__/collection-sharing.integration.ts"
   ```
-  The image only needs to be rebuilt when `package.json`, `prisma/schema.prisma`, or the Dockerfile itself changes.
+  Rebuild the image after any source change (`docker build ...` above). Most layers are cached so rebuilds are fast.
 - Development contributor flow:
   - `make install` → `make dev`
   - stop with `make dev-stop`

--- a/backend/src/__tests__/collection-sharing.integration.ts
+++ b/backend/src/__tests__/collection-sharing.integration.ts
@@ -392,4 +392,74 @@ describe("Collection Sharing - Backend Integration", () => {
     expect(importDrawingResponse.status).toBe(403);
     expect(importDrawingResponse.body?.error).toContain("No edit access");
   });
+
+  it("allows drawing owner to move their own drawing into a shared collection where they have edit role", async () => {
+    const collection = await prisma.collection.create({
+      data: { name: "Editor Move Target", userId: owner.id },
+      select: { id: true },
+    });
+
+    await ownerAgent
+      .post(`/collections/${collection.id}/shares`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${ownerToken}`)
+      .set(ownerCsrfHeaderName, ownerCsrfToken)
+      .send({ identifier: editor.email, role: "edit" });
+
+    const editorDrawing = await prisma.drawing.create({
+      data: {
+        name: "Editor's Own Drawing",
+        elements: "[]",
+        appState: "{}",
+        files: "{}",
+        userId: editor.id,
+      },
+      select: { id: true },
+    });
+
+    const moveResponse = await editorAgent
+      .put(`/drawings/${editorDrawing.id}`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${editorToken}`)
+      .set(editorCsrfHeaderName, editorCsrfToken)
+      .send({ collectionId: collection.id });
+
+    expect(moveResponse.status).toBe(200);
+    expect(moveResponse.body?.collectionId).toBe(collection.id);
+  });
+
+  it("prevents drawing owner from moving their own drawing into a shared collection where they have view-only role", async () => {
+    const collection = await prisma.collection.create({
+      data: { name: "Viewer Move Target", userId: owner.id },
+      select: { id: true },
+    });
+
+    await ownerAgent
+      .post(`/collections/${collection.id}/shares`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${ownerToken}`)
+      .set(ownerCsrfHeaderName, ownerCsrfToken)
+      .send({ identifier: viewer.email, role: "view" });
+
+    const viewerDrawing = await prisma.drawing.create({
+      data: {
+        name: "Viewer's Own Drawing",
+        elements: "[]",
+        appState: "{}",
+        files: "{}",
+        userId: viewer.id,
+      },
+      select: { id: true },
+    });
+
+    const moveResponse = await viewerAgent
+      .put(`/drawings/${viewerDrawing.id}`)
+      .set("User-Agent", userAgent)
+      .set("Authorization", `Bearer ${viewerToken}`)
+      .set(viewerCsrfHeaderName, viewerCsrfToken)
+      .send({ collectionId: collection.id });
+
+    expect(moveResponse.status).toBe(404);
+    expect(moveResponse.body?.error).toBe("Collection not found");
+  });
 });

--- a/backend/src/routes/dashboard/drawingCreateUpdateRoutes.ts
+++ b/backend/src/routes/dashboard/drawingCreateUpdateRoutes.ts
@@ -236,11 +236,20 @@ export const registerDrawingCreateUpdateRoutes = (
           (data as Prisma.DrawingUncheckedUpdateInput).collectionId =
             trashCollectionId;
         } else if (payload.collectionId) {
-          const collection = await prisma.collection.findFirst({
+          const ownedCollection = await prisma.collection.findFirst({
             where: { id: payload.collectionId, userId: ownerUserId },
           });
-          if (!collection)
-            return res.status(404).json({ error: "Collection not found" });
+          if (!ownedCollection) {
+            const sharedCollection = await prisma.collectionShare.findFirst({
+              where: {
+                collectionId: payload.collectionId,
+                granteeUserId: ownerUserId,
+                role: "edit",
+              },
+            });
+            if (!sharedCollection)
+              return res.status(404).json({ error: "Collection not found" });
+          }
           (data as Prisma.DrawingUncheckedUpdateInput).collectionId =
             payload.collectionId;
         } else {

--- a/backend/src/routes/dashboard/drawingCreateUpdateRoutes.ts
+++ b/backend/src/routes/dashboard/drawingCreateUpdateRoutes.ts
@@ -185,6 +185,8 @@ export const registerDrawingCreateUpdateRoutes = (
         version?: number;
       };
       const ownerUserId = existingDrawing.userId;
+      const actingUserId =
+        principal?.kind === "user" ? principal.userId : ownerUserId;
       const trashCollectionId = getUserTrashCollectionId(ownerUserId);
       const isSceneUpdate =
         payload.elements !== undefined ||
@@ -237,13 +239,13 @@ export const registerDrawingCreateUpdateRoutes = (
             trashCollectionId;
         } else if (payload.collectionId) {
           const ownedCollection = await prisma.collection.findFirst({
-            where: { id: payload.collectionId, userId: ownerUserId },
+            where: { id: payload.collectionId, userId: actingUserId },
           });
           if (!ownedCollection) {
             const sharedCollection = await prisma.collectionShare.findFirst({
               where: {
                 collectionId: payload.collectionId,
-                granteeUserId: ownerUserId,
+                granteeUserId: actingUserId,
                 role: "edit",
               },
             });


### PR DESCRIPTION
Previously, the collection lookup on move was filtered by the drawing owner's userId, which silently rejected any target collection not owned by that same user — including collections shared with edit access. This meant drag-and-drop into a shared collection always returned 404 with no visual feedback.

The fix checks for a CollectionShare row with role "edit" when the target collection is not owned by the drawing owner, mirroring the same access model already used for creating drawings inside shared collections.

Two integration tests cover the new behaviour: one confirms the move succeeds for an editor-role share, and one confirms it is still blocked for a view-only share.

AGENTS.md is updated with Docker-based instructions for running the backend test suite without a local Node.js install.