### PR TITLE
Fix history preview crashing and improve UX

### DIFF
--- a/frontend/src/components/HistoryPanel.tsx
+++ b/frontend/src/components/HistoryPanel.tsx
@@ -113,13 +113,15 @@ export const HistoryPanel: React.FC<Props> = ({
   if (!isOpen) return null;
 
   return createPortal(
-    <div className="fixed inset-0 z-[90] flex justify-end">
-      <div
-        className="absolute inset-0 bg-neutral-900/20 backdrop-blur-sm"
-        onClick={onClose}
-      />
+    <div className={clsx("fixed inset-0 z-[90] flex justify-end", previewId && "pointer-events-none")}>
+      {!previewId && (
+        <div
+          className="absolute inset-0 bg-neutral-900/20 backdrop-blur-sm"
+          onClick={onClose}
+        />
+      )}
 
-      <div className="relative w-full max-w-sm bg-white dark:bg-neutral-900 border-l-2 border-black dark:border-neutral-700 shadow-[-4px_0px_0px_0px_rgba(0,0,0,1)] dark:shadow-[-4px_0px_0px_0px_rgba(255,255,255,0.08)] animate-in slide-in-from-right duration-200 flex flex-col h-full">
+      <div className="pointer-events-auto relative w-full max-w-sm bg-white dark:bg-neutral-900 border-l-2 border-black dark:border-neutral-700 shadow-[-4px_0px_0px_0px_rgba(0,0,0,1)] dark:shadow-[-4px_0px_0px_0px_rgba(255,255,255,0.08)] animate-in slide-in-from-right duration-200 flex flex-col h-full">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b-2 border-black dark:border-neutral-700 bg-white dark:bg-neutral-900">
           <div className="flex items-center gap-2">

--- a/frontend/src/pages/editor/EditorDialogs.tsx
+++ b/frontend/src/pages/editor/EditorDialogs.tsx
@@ -64,12 +64,11 @@ export const EditorDialogs: React.FC<EditorDialogsProps> = ({
             }
             excalidrawAPI.updateScene({
               elements,
-              appState: {
-                ...snapshot.appState,
-                collaborators: undefined,
-              },
+              appState: { collaborators: new Map() },
               captureUpdate: CaptureUpdateAction.NEVER,
             });
+            excalidrawAPI.scrollToContent(elements, { animate: false, fitToViewport: true });
+            excalidrawAPI.setActiveTool({ type: "hand" });
             return;
           }
           if (previewBackupRef.current) {


### PR DESCRIPTION
Spreading snapshot.appState into updateScene caused a crash because collaborators was set to undefined while Excalidraw expects a Map. Replace the full appState spread with a minimal object (collaborators as an empty Map) so the editor's current view is preserved.

Add scrollToContent after loading snapshot elements so they are always visible regardless of the current viewport position. Switch to the hand tool on preview entry to prevent accidental edits; the original tool is restored automatically when the backup appState is reapplied on exit.

Remove the backdrop blur and pointer-events overlay while a preview is active so the canvas remains fully interactive during inspection.