### PR TITLE
feat: ci workflows for image building

### DIFF
--- a/.github/workflows/image_cleanup.yml
+++ b/.github/workflows/image_cleanup.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Delete alpha images
         uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53   # v3.1.0
         with:
-          account: tiagura #${{ github.repository_owner }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          account: ${{ github.repository_owner }}
+          token: ${{ github.token }} #${{ secrets.GITHUB_TOKEN }}
           image-names: "excalidash/frontend excalidash/backend"
           # This is not good enough it will match tags like v1.0.0(-featureX)? and M.m.p(-featureX)? and not delete them
           # however, it will also match image tags from branches that their names start with v or a number

--- a/.github/workflows/image_cleanup.yml
+++ b/.github/workflows/image_cleanup.yml
@@ -7,10 +7,6 @@ on:
   # Scheduled workflow
   schedule:
     - cron: '0 0 * * *' # Runs daily at midnight
-  
-  push:
-    branches:
-      - '*'
 
 permissions:
   packages: write
@@ -26,7 +22,7 @@ jobs:
         uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53   # v3.1.0
         with:
           account: ${{ github.repository_owner }}
-          token: ${{ github.token }} #${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           image-names: "excalidash/frontend excalidash/backend"
           # This is not good enough it will match tags like v1.0.0(-featureX)? and M.m.p(-featureX)? and not delete them
           # however, it will also match image tags from branches that their names start with v or a number

--- a/.github/workflows/image_cleanup.yml
+++ b/.github/workflows/image_cleanup.yml
@@ -7,6 +7,10 @@ on:
   # Scheduled workflow
   schedule:
     - cron: '0 0 * * *' # Runs daily at midnight
+  
+  push:
+    branches:
+      - '*'
 
 permissions:
   packages: write

--- a/.github/workflows/image_cleanup.yml
+++ b/.github/workflows/image_cleanup.yml
@@ -1,0 +1,34 @@
+name: Clean up GHCR
+
+on:
+  # Manual trigger
+  workflow_dispatch:
+              
+  # Scheduled workflow
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup-ghcr:
+    name: Clean up old GHCR alpha images
+    runs-on: ubuntu-latest
+
+    steps:
+      # Keep images at least 2 weeks old, and keep the 10 most recent images for each image name and tag pattern.
+      - name: Delete alpha images
+        uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53   # v3.1.0
+        with:
+          account: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: "excalidash/frontend excalidash/backend"
+          # This is not good enough it will match tags like v1.0.0(-featureX)? and M.m.p(-featureX)? and not delete them
+          # however, it will also match image tags from branches that their names start with v or a number
+          # and so these images will not be deleted, to improve this,
+          # we might need to add a more specific branch naming convention for alpha images, e.g. task/*, feature/*, bugfix/*, etc.
+          # but this will do for now
+          image-tags: "!v* ![0-9]*"
+          cut-off: 2w
+          keep-n-most-recent: 10

--- a/.github/workflows/image_cleanup.yml
+++ b/.github/workflows/image_cleanup.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Delete alpha images
         uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53   # v3.1.0
         with:
-          account: ${{ github.repository_owner }}
+          account: tiagura #${{ github.repository_owner }}
           token: ${{ secrets.GITHUB_TOKEN }}
           image-names: "excalidash/frontend excalidash/backend"
           # This is not good enough it will match tags like v1.0.0(-featureX)? and M.m.p(-featureX)? and not delete them

--- a/.github/workflows/image_cleanup.yml
+++ b/.github/workflows/image_cleanup.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Delete alpha images
         uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53   # v3.1.0
         with:
-          account: ${{ github.repository_owner }}
-          token: ${{ github.token }}
+          account: user
+          token: ${{ secrets.GITHUB_TOKEN }}
           image-names: "excalidash/frontend excalidash/backend"
           # This is not good enough it will match tags like v1.0.0(-featureX)? and M.m.p(-featureX)? and not delete them
           # however, it will also match image tags from branches that their names start with v or a number

--- a/.github/workflows/image_full_build.yml
+++ b/.github/workflows/image_full_build.yml
@@ -1,0 +1,50 @@
+name: Build and Push all images to GHCR
+
+on:
+  # Manuall trigger to build and push images to GHCR
+  workflow_dispatch:
+    inputs:
+      force_rebuild:
+        type: boolean
+        description: "Force rebuild and push even if image already exists in GHCR"
+        default: false
+      build_environment:
+        type: choice
+        description: "Environment for Backoffice build (only applicable for BOOPC image)"
+        default: dev
+        options:
+          - dev
+          - prod
+
+  # Allow this workflow to be called by other workflows
+  workflow_call:
+    outputs:
+      frontend_image_tag:
+        description: "The tag of the built frontend image in GHCR"
+        value: ${{ jobs.build-frontend.outputs.full_url }} 
+      backend_image_tag:
+        description: "The tag of the built backend image in GHCR"
+        value: ${{ jobs.build-backend.outputs.full_url }}
+
+  push:
+    branches:
+      - '*'
+
+concurrency:
+  group: build-all-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-frontend:
+    uses: ./.github/workflows/image_single_build.yml
+    with:
+      build_target: frontend
+
+  build-backend:
+    uses: ./.github/workflows/image_single_build.yml
+    with:
+      build_target: backend

--- a/.github/workflows/image_full_build.yml
+++ b/.github/workflows/image_full_build.yml
@@ -29,9 +29,8 @@ on:
   push:
     tags:
       # Triggers on tags that match the pattern vX.Y.Z or vX.Y.Z-<suffix>
-      - 'v[0-9]+.[0-9]+.[0-9]+(-[a-zA-Z0-9]+)?$'
-    branches:
-      - '*'
+      # or without the v prefix, e.g. 1.2.3 or 1.2.3-<suffix>
+      - 'v?[0-9]+.[0-9]+.[0-9]+(-[a-zA-Z0-9]+)?$'
 
 concurrency:
   group: build-all-${{ github.ref }}

--- a/.github/workflows/image_full_build.yml
+++ b/.github/workflows/image_full_build.yml
@@ -27,6 +27,9 @@ on:
         value: ${{ jobs.build-backend.outputs.full_url }}
 
   push:
+    tags:
+      # Triggers on tags that match the pattern vX.Y.Z or vX.Y.Z-<suffix>
+      - 'v[0-9]+.[0-9]+.[0-9]+(-[a-zA-Z0-9]+)?$'
     branches:
       - '*'
 

--- a/.github/workflows/image_single_build.yml
+++ b/.github/workflows/image_single_build.yml
@@ -65,7 +65,7 @@ jobs:
             echo "component=frontend"                     >> "$GITHUB_OUTPUT"
             echo "description=Frontend"                   >> "$GITHUB_OUTPUT"
             echo "dockerfile_path=./frontend/Dockerfile"  >> "$GITHUB_OUTPUT"
-            echo "context=./frontend"                     >> "$GITHUB_OUTPUT"
+            echo "context=."                              >> "$GITHUB_OUTPUT"
           else
             echo "Invalid build_target input: $TARGET. Must be 'backend' or 'frontend'." >&2
             exit 1
@@ -79,7 +79,7 @@ jobs:
       # Release formats:
       #   Final : X.Y.Z-X                             e.g. tag M.m.p, with optional v prefix and -COMMENT suffix (e.g. 1.0.0-featureX)
       #   Alpha : <normalised_branch>-<commit_hash>   e.g. feature_stbrpameo_42-ba3e794
-      - name: Compute release label
+      - name: Compute container image tag and full URL
         id: meta
         env:
           GITHUB_REF: ${{ github.ref_name }}
@@ -90,7 +90,7 @@ jobs:
           CREATED=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           REGISTRY="ghcr.io"
           REPO_NAME=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
-          echo "Ref: $REF"
+
           # ---- Determine TAG from the ref ----
           # Final: git tag X.Y.Z(-azAZ09), e.g. 1.0.0, v1.0.0, 1.0.0-featureX, v1.0.0-featureX
           if echo "$REF" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$'; then
@@ -100,11 +100,9 @@ jobs:
           # Alpha: dev, main branches
           else
             BRANCH=$(git rev-parse --abbrev-ref HEAD)
-            echo "Branch: $BRANCH"
-            BRANCHL=$(echo "$REF" \
+            BRANCHL=$(echo "$BRANCH" \
               | tr '[:upper:]' '[:lower:]' \
               | sed 's#[^a-z0-9._-]#-#g')
-            echo "Normalised branch: $BRANCHL"
             COMMIT_HASH=$(git rev-parse --short HEAD)
             RELEASE="${BRANCHL}-${COMMIT_HASH}"
           fi

--- a/.github/workflows/image_single_build.yml
+++ b/.github/workflows/image_single_build.yml
@@ -90,7 +90,7 @@ jobs:
           CREATED=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           REGISTRY="ghcr.io"
           REPO_NAME=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
- 
+          echo "Ref: $REF"
           # ---- Determine TAG from the ref ----
           # Final: git tag X.Y.Z(-azAZ09), e.g. 1.0.0, v1.0.0, 1.0.0-featureX, v1.0.0-featureX
           if echo "$REF" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$'; then
@@ -100,9 +100,11 @@ jobs:
           # Alpha: dev, main branches
           else
             BRANCH=$(git rev-parse --abbrev-ref HEAD)
+            echo "Branch: $BRANCH"
             BRANCHL=$(echo "$REF" \
               | tr '[:upper:]' '[:lower:]' \
               | sed 's#[^a-z0-9._-]#-#g')
+            echo "Normalised branch: $BRANCHL"
             COMMIT_HASH=$(git rev-parse --short HEAD)
             RELEASE="${BRANCHL}-${COMMIT_HASH}"
           fi

--- a/.github/workflows/image_single_build.yml
+++ b/.github/workflows/image_single_build.yml
@@ -1,0 +1,146 @@
+name: Build and Push to GHCR
+
+on:
+  # Manuall trigger to build and push images to GHCR
+  workflow_dispatch:
+    inputs:
+      build_target:
+        type: choice
+        description: "Choose which image to build and push (e.g. 'backend', 'frontend')"
+        required: true
+        options:
+          - backend
+          - frontend
+
+  # Allow this workflow to be called by other workflows
+  workflow_call:
+    inputs:
+      build_target:
+        type: string
+        description: "Specify which image to build and push (e.g. 'backend', 'frontend')"
+        required: true
+    outputs:
+      full_url:
+        description: "The tag of the built image in GHCR"
+        value: ${{ jobs.build-and-push.outputs.full_url }}
+
+# Stop any in-progress runs of this workflow for the same build_target and branch/tag, and cancel them.
+concurrency:
+  group: build-${{ inputs.build_target }}-${{ github.ref }}
+  cancel-in-progress: true
+  
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    outputs:
+      full_url: ${{ steps.meta.outputs.full_url }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Solve component dockerfile path and context
+        id: component
+        env:
+          BUILD_TARGET: ${{ inputs.build_target }}
+        run: |
+          # From the input build_target, determine which component to build and set the appropriate Dockerfile path and context
+          # ignore case sensitivity and allow partial matches
+          TARGET=$(echo "$BUILD_TARGET" | tr '[:upper:]' '[:lower:]')
+          if [[ "$TARGET" == "backend" ]]; then
+            echo "component=backend"                      >> "$GITHUB_OUTPUT"
+            echo "description=Backend"                    >> "$GITHUB_OUTPUT"
+            echo "dockerfile_path=./backend/Dockerfile"   >> "$GITHUB_OUTPUT"
+            echo "context=./backend"                      >> "$GITHUB_OUTPUT"
+
+          elif [[ "$TARGET" == "frontend" ]]; then
+            echo "component=frontend"                     >> "$GITHUB_OUTPUT"
+            echo "description=Frontend"                   >> "$GITHUB_OUTPUT"
+            echo "dockerfile_path=./frontend/Dockerfile"  >> "$GITHUB_OUTPUT"
+            echo "context=./frontend"                     >> "$GITHUB_OUTPUT"
+          else
+            echo "Invalid build_target input: $TARGET. Must be 'backend' or 'frontend'." >&2
+            exit 1
+          fi
+ 
+      # Derive image tags based on the ref (branch or tag) being built.
+      # Type detection:
+      #   Final - git tag matching (v)?X.Y.Z
+      #   Alpha — any other branch (feature/, task/, bugfix/, ...)
+      #
+      # Release formats:
+      #   Final : X.Y.Z-X                             e.g. tag M.m.p, with optional v prefix and -COMMENT suffix (e.g. 1.0.0-featureX)
+      #   Alpha : <normalised_branch>-<commit_hash>   e.g. feature_stbrpameo_42-ba3e794
+      - name: Compute release label
+        id: meta
+        env:
+          GITHUB_REF: ${{ github.ref_name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          COMPONENT: ${{ steps.component.outputs.component }}
+        run: |
+          REF="${GITHUB_REF}"
+          CREATED=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          REGISTRY="ghcr.io"
+          REPO_NAME=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+ 
+          # ---- Determine TAG from the ref ----
+          # Final: git tag X.Y.Z(-azAZ09), e.g. 1.0.0, v1.0.0, 1.0.0-featureX, v1.0.0-featureX
+          if echo "$REF" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$'; then
+            VERSION=$(echo "$REF" | sed 's|^v\?\([0-9]\+\.[0-9]\+\.[0-9]\+\).*$|\1|')
+            RELEASE="${VERSION}"
+ 
+          # Alpha: dev, main branches
+          else
+            BRANCH=$(git rev-parse --abbrev-ref HEAD)
+            BRANCHL=$(echo "$REF" \
+              | tr '[:upper:]' '[:lower:]' \
+              | sed 's#[^a-z0-9._-]#-#g')
+            COMMIT_HASH=$(git rev-parse --short HEAD)
+            RELEASE="${BRANCHL}-${COMMIT_HASH}"
+          fi
+
+          FULL_URL="${REGISTRY}/${REPO_NAME}/${COMPONENT}:${RELEASE}"
+ 
+          echo "full_url=${FULL_URL}"   >> "$GITHUB_OUTPUT"
+          echo "created=${CREATED}"     >> "$GITHUB_OUTPUT"
+          echo "tag=${RELEASE}"         >> "$GITHUB_OUTPUT"
+ 
+          echo "### Image tags"                            >> "$GITHUB_STEP_SUMMARY"
+          echo "| Component     | FULL URL |"              >> "$GITHUB_STEP_SUMMARY"
+          echo "|---------------|----------|"              >> "$GITHUB_STEP_SUMMARY"
+          echo "| ${COMPONENT}  | \`${FULL_URL}\` |"       >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee   # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Set up Docker Buildx setup
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5   # v4.1.0
+
+      # Build and push the image
+      - name: Build and push image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf   # v7.2.0
+        with:
+          context: ${{ steps.component.outputs.context }}
+          file: ${{ steps.component.outputs.dockerfile_path }}
+          push: true
+          tags: ${{ steps.meta.outputs.full_url }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.meta.outputs.created }}
+            org.opencontainers.image.description="ExcaliDash: ${{ steps.component.outputs.description }}"
+            org.opencontainers.image.licenses="GNU Lesser General Public License v3.0"
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version="${{ steps.meta.outputs.tag }}"


### PR DESCRIPTION
This PR introduces two GitHub Actions workflows for building and publishing the project's Docker images to GitHub Container Registry (GHCR).

- The **Build and Push to GHCR** workflow is a reusable workflow that builds and publishes a single component (`backend` or `frontend`). It can be executed manually or invoked from another workflow and exposes the resulting image tag as an output.

- The **Build and Push all images to GHCR** workflow orchestrates the build of both project images by invoking the reusable workflow for each component. It supports manual execution, can be reused by other workflows, and is automatically triggered when a release tag (`vX.Y.Z`, `X.Y.Z`, with or without a suffix) is pushed.

- Images are tagged according to the Git reference that triggered the build: release tags generate version tags (`X.Y.Z`), while branch builds generate development tags in the format `<branch>-<commit>`.

- The **Clean up GHCR** workflow removes old development images from GitHub Container Registry (GHCR). It can be triggered manually or runs automatically once per day, deleting alpha images older than two weeks while keeping the 10 most recent ones.

  Due to the action's filtering limitations, release images are excluded using the patterns `!v* ![0-9]*`, which may also preserve alpha images whose branch names start with `v` or a number. Adding branch naming convention for alpha images (e.g. task/*, feature/*, bugfix/*, etc) will allow to filter it better while also providing better branch organization and consistency.
