### PR TITLE
Fix the E2E job locking itself out with 429

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,13 @@ jobs:
         run: |
           # Start backend server in background
           cd backend
-          DATABASE_URL="file:${{ github.workspace }}/backend/prisma/e2e-test.db" FRONTEND_URL="http://localhost:6767" npm run dev &
+          # The suite issues far more than the default 60 CSRF requests, so
+          # without raising the limits it locks itself out with HTTP 429.
+          DATABASE_URL="file:${{ github.workspace }}/backend/prisma/e2e-test.db" \
+            FRONTEND_URL="http://localhost:6767" \
+            CSRF_MAX_REQUESTS=100000 \
+            RATE_LIMIT_MAX_REQUESTS=100000 \
+            npm run dev &
           BACKEND_PID=$!
           cd ..
           


### PR DESCRIPTION
The E2E job has been failing since late June — on `main`, on Dependabot PRs, and on anything opened from a fork. 21 of 62 tests fail, 20 of them with:

```
Error: Failed to fetch CSRF token: 429 {"error":"Rate limit exceeded"}
```

The suite requests far more than the default 60 CSRF tokens, so the server locks it out partway through.

`e2e/playwright.config.ts` already accounts for this and raises `CSRF_MAX_REQUESTS` and `RATE_LIMIT_MAX_REQUESTS` for the servers it starts — but that block is skipped when `CI` is set, and the workflow starts the backend itself without them.

Passing the same values in the workflow is the whole change. Measured on a clean `main` checkout, same suite, same machine, only the limits differ:

| | result |
| --- | --- |
| current settings | 21 failed, 41 passed |
| with the limits raised | **62 passed** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
