### PR TITLE
fix: prevent compressed image sync loop

### DIFF
--- a/frontend/src/pages/editor/useEditorPersistence.test.ts
+++ b/frontend/src/pages/editor/useEditorPersistence.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useEditorPersistence } from "./useEditorPersistence";
+import * as api from "../../api";
+import { compressExcalidrawFiles } from "../../utils/imageCompression";
+
+vi.mock("../../api", () => ({
+  updateDrawing: vi.fn(),
+  updateLibrary: vi.fn(),
+  isAxiosError: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("../../utils/imageCompression", () => ({
+  compressExcalidrawFiles: vi.fn(),
+}));
+
+vi.mock("@excalidraw/excalidraw", () => ({
+  exportToSvg: vi.fn(),
+}));
+
+const ref = <T,>(current: T) => ({ current });
+
+describe("useEditorPersistence", () => {
+  it("keeps the editor file map as the sync baseline after compression", async () => {
+    const editorFiles = {
+      image: { id: "image", dataURL: "data:image/png;base64,original" },
+    };
+    const compressedFiles = {
+      image: { id: "image", dataURL: "data:image/webp;base64,compressed" },
+    };
+    vi.mocked(compressExcalidrawFiles).mockResolvedValue({
+      files: compressedFiles,
+      changed: true,
+      changedIds: ["image"],
+    });
+    vi.mocked(api.updateDrawing).mockResolvedValue({
+      version: 2,
+      files: compressedFiles,
+    } as any);
+
+    const refs = {
+      currentDrawingVersion: ref<number | null>(1),
+      debouncedSave: ref<any>(null),
+      excalidrawAPI: ref({ addFiles: vi.fn() }),
+      isSyncing: ref(false),
+      isUnmounting: ref(false),
+      lastLocalChangeAt: ref(0),
+      lastPersistedElements: ref<readonly any[]>([]),
+      lastPersistedFiles: ref<Record<string, any>>({}),
+      lastSyncedFiles: ref<Record<string, any>>({}),
+      latestAppState: ref<any>(null),
+      latestElements: ref<readonly any[]>([]),
+      latestFiles: ref<any>(editorFiles),
+      saveQueue: ref(Promise.resolve()),
+      suspiciousBlankLoad: ref(false),
+    };
+
+    const { result } = renderHook(() =>
+      useEditorPersistence({
+        refs,
+        user: null,
+        normalizeImageElementStatus: (elements) => elements || [],
+        resolveSafeSnapshot: (elements) => ({
+          snapshot: elements || [],
+          prevented: false,
+          staleEmptySnapshot: false,
+          staleNonRenderableSnapshot: false,
+        }),
+      }),
+    );
+
+    await act(async () => {
+      await result.current.saveDataRef.current?.(
+        "drawing",
+        [{ id: "element", type: "image", fileId: "image" }],
+        {},
+        editorFiles,
+      );
+    });
+
+    expect(api.updateDrawing).toHaveBeenCalledWith(
+      "drawing",
+      expect.objectContaining({ files: compressedFiles }),
+    );
+    expect(refs.latestFiles.current).toBe(compressedFiles);
+    expect(refs.lastSyncedFiles.current).toBe(editorFiles);
+  });
+});

--- a/frontend/src/pages/editor/useEditorPersistence.ts
+++ b/frontend/src/pages/editor/useEditorPersistence.ts
@@ -123,6 +123,7 @@ export const useEditorPersistence = ({
         return;
       }
       let persistableFiles = files ?? refs.latestFiles.current ?? {};
+      const editorFilesBeforeCompression = persistableFiles;
       const compressedFilesResult =
         await compressExcalidrawFiles(persistableFiles);
       if (compressedFilesResult.changed) {
@@ -141,7 +142,9 @@ export const useEditorPersistence = ({
           }
         }
         refs.latestFiles.current = persistableFiles;
-        refs.lastSyncedFiles.current = persistableFiles;
+        // Excalidraw may retain the original blob when addFiles receives an
+        // existing content-derived ID, so keep sync comparisons on that map.
+        refs.lastSyncedFiles.current = editorFilesBeforeCompression;
       }
       const filesChangedSincePersist =
         Object.keys(


### PR DESCRIPTION
## Summary
- keep the pre-compression Excalidraw file map as the realtime sync baseline
- continue using compressed files for persistence
- add a hook regression test for content-derived file IDs that Excalidraw does not replace

## Problem
When image compression changes a file payload, `addFiles()` may retain the existing in-memory file because the ID is content-derived. Updating `lastSyncedFiles` to the compressed map then makes the file polling path detect the unchanged editor blob as new on every interval, causing repeated socket emissions and scene saves.

## Verification
- `npm test -- src/pages/editor/useEditorPersistence.test.ts`
- `npm run build`