### PR TITLE
fix: backend container start without network

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,15 +16,26 @@ RUN npm ci && npm cache clean --force
 # Copy prisma schema
 COPY prisma ./prisma/
 
-# Set default provider for build-time Prisma generation (runtime can override via DATABASE_PROVIDER)
-RUN sed -i '/datasource db {/,/}/ s/provider = env("[^"]*")/provider = "sqlite"/; /datasource db {/,/}/ s/provider = "[^"]*"/provider = "sqlite"/' prisma/schema.prisma
-
-# Generate Prisma Client at build time (for TypeScript compilation)
-# Runtime will regenerate if DATABASE_PROVIDER differs
-RUN npx prisma generate
+# Pre-generate a Prisma Client for every supported provider. Generating here rather
+# than in the entrypoint keeps the runtime offline: `prisma generate` downloads any
+# engine listed in binaryTargets that npm install did not already fetch, which makes
+# the container unstartable in air-gapped environments.
+RUN cp prisma/schema.prisma /tmp/schema.prisma.orig && \
+    for provider in sqlite postgresql; do \
+        cp /tmp/schema.prisma.orig prisma/schema.prisma && \
+        sed -i '/datasource db {/,/}/ s/provider = env("[^"]*")/provider = "'"$provider"'"/; /datasource db {/,/}/ s/provider = "[^"]*"/provider = "'"$provider"'"/' prisma/schema.prisma && \
+        npx prisma generate && \
+        mv src/generated /app/prisma_client_"$provider"; \
+    done && \
+    cp /tmp/schema.prisma.orig prisma/schema.prisma && \
+    rm /tmp/schema.prisma.orig
 
 # Copy source code
 COPY src ./src
+
+# TypeScript needs a generated client to compile against; both providers emit the
+# same types, so either one works here.
+RUN rm -rf src/generated && cp -R /app/prisma_client_sqlite src/generated
 
 # Build TypeScript
 RUN npx tsc
@@ -55,8 +66,10 @@ COPY prisma ./prisma_template/
 # Copy built application from builder
 COPY --from=builder /app/dist ./dist
 
-# Copy the generated Prisma Client from builder (will be regenerated at runtime if provider changes)
-COPY --from=builder /app/src/generated ./dist/generated
+# Copy the Prisma Clients pre-generated for each supported provider. The entrypoint
+# installs the one matching DATABASE_PROVIDER, so no generation happens at startup.
+COPY --from=builder /app/prisma_client_sqlite ./prisma_client/sqlite
+COPY --from=builder /app/prisma_client_postgresql ./prisma_client/postgresql
 
 # Create necessary directories (ownership will be set in entrypoint)
 RUN mkdir -p /app/uploads /app/prisma

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -78,13 +78,19 @@ echo "Configuring Prisma for provider: ${DATABASE_PROVIDER}"
 sed -i '/datasource db {/,/}/ s/provider = env("[^"]*")/provider = "'"${DATABASE_PROVIDER}"'"/' /app/prisma/schema.prisma
 sed -i '/datasource db {/,/}/ s/provider = "[^"]*"/provider = "'"${DATABASE_PROVIDER}"'"/' /app/prisma/schema.prisma
 
-# Generate Prisma Client at runtime (run as root since schema is owned by root)
-echo "Generating Prisma Client..."
-npx prisma generate --schema=/app/prisma/schema.prisma
+# Install the Prisma Client that was pre-generated for this provider at build time.
+# Regenerating here would fetch engines from binaries.prisma.sh, so the container
+# would refuse to start in an air-gapped environment.
+PRISMA_CLIENT_DIR="/app/prisma_client/${DATABASE_PROVIDER}"
+if [ ! -d "${PRISMA_CLIENT_DIR}" ]; then
+    echo "ERROR: no Prisma Client bundled for provider '${DATABASE_PROVIDER}' at ${PRISMA_CLIENT_DIR}"
+    exit 1
+fi
 
-# Copy generated client to the expected location for the application
+echo "Installing pre-generated Prisma Client for provider: ${DATABASE_PROVIDER}"
+rm -rf /app/dist/generated
 mkdir -p /app/dist/generated
-cp -r /app/src/generated/* /app/dist/generated/
+cp -R "${PRISMA_CLIENT_DIR}/." /app/dist/generated/
 
 # 2. Fix permissions unconditionally (Running as root)
 echo "Fixing filesystem permissions..."


### PR DESCRIPTION
## Summary

The backend could not start without internet access.
`docker-entrypoint.sh` ran `npx prisma generate` on every container start, which downloads any engine listed in `binaryTargets` that npm install did not already fetch: so startup reached out to `binaries.prisma.sh` and failed in air-gapped environments.

The production stage only ever has the **native** engine (the `@prisma/engines` postinstall fetches nothing else), while `schema.prisma` requests three targets.
The complete client was already baked into the image by the builder stage; the runtime regeneration existed only to flip the datasource provider between `sqlite` and `postgresql`, which needs no download.

Fixes #258 
Fixes #216 
Fixes #243 

## Changes

- `backend/Dockerfile` — pre-generate a Prisma Client for each supported provider at build time, shipped as `/app/prisma_client/{sqlite,postgresql}`.
- `backend/docker-entrypoint.sh` — install the client matching `DATABASE_PROVIDER` instead of running `prisma generate`; fail with a clear message if it is missing.

Startup no longer performs any network I/O beyond connecting to the configured database, is faster, and no longer needs `/app/src` to be writable at runtime.

## Verification

All runs on a network with no internet access, confirmed air-gapped beforehand (`wget: bad address 'binaries.prisma.sh'`):

| Scenario | Result |
| --- | --- |
| sqlite, `podman run --network none` | boots, 15 migrations applied, listening on 8000 |
| postgresql, internal network + real `postgres:16-alpine` | boots, all migrations applied |
| `GET /health` on both (executes a real Prisma query) | `{"status":"ok","database":"ok"}` |

Confirmed the two bundled clients are distinct: `activeProvider` is `sqlite` and `postgresql` respectively, each with its own full set of engines.

## Trade-off

Image size grows 436 MB → 485 MB, since the second client duplicates the same ~46 MB of engine binaries.
This is dedupable by keeping one copy of the engines and overlaying only the provider-specific JS, at the cost of a less explicit entrypoint. Happy to change it if maintainers prefer the smaller image.
