### PR TITLE
Fix trackpad two-finger pan being forced into zoom

### DIFF
--- a/frontend/src/pages/editor/canvasZoomForwarding.test.ts
+++ b/frontend/src/pages/editor/canvasZoomForwarding.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { isLikelyTrackpadWheelEvent } from "./canvasZoomForwarding";
+
+const wheelEvent = (deltaX: number, deltaY: number): WheelEvent =>
+  ({ deltaX, deltaY }) as WheelEvent;
+
+describe("isLikelyTrackpadWheelEvent", () => {
+  it("treats a whole-number, vertical-only wheel tick as a mouse wheel", () => {
+    expect(isLikelyTrackpadWheelEvent(wheelEvent(0, 100))).toBe(false);
+  });
+
+  it("treats a small whole-number vertical tick as a mouse wheel", () => {
+    expect(isLikelyTrackpadWheelEvent(wheelEvent(0, 3))).toBe(false);
+  });
+
+  it("treats a negative whole-number vertical tick as a mouse wheel", () => {
+    expect(isLikelyTrackpadWheelEvent(wheelEvent(0, -120))).toBe(false);
+  });
+
+  it("treats an all-zero event as a mouse wheel (no signal otherwise)", () => {
+    expect(isLikelyTrackpadWheelEvent(wheelEvent(0, 0))).toBe(false);
+  });
+
+  it("treats a nonzero deltaX as a trackpad gesture", () => {
+    expect(isLikelyTrackpadWheelEvent(wheelEvent(-5, 12))).toBe(true);
+  });
+
+  it("treats a fractional deltaY as a trackpad gesture", () => {
+    expect(isLikelyTrackpadWheelEvent(wheelEvent(0, 2.4))).toBe(true);
+  });
+
+  it("treats a fractional deltaX as a trackpad gesture", () => {
+    expect(isLikelyTrackpadWheelEvent(wheelEvent(0.75, 0))).toBe(true);
+  });
+});

--- a/frontend/src/pages/editor/canvasZoomForwarding.test.ts
+++ b/frontend/src/pages/editor/canvasZoomForwarding.test.ts
@@ -1,35 +1,303 @@
-import { describe, expect, it } from "vitest";
-import { isLikelyTrackpadWheelEvent } from "./canvasZoomForwarding";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  attachCanvasZoomForwarding,
+  createTrackpadGestureDetector,
+  isLikelyTrackpadWheelEvent,
+} from "./canvasZoomForwarding";
 
-const wheelEvent = (deltaX: number, deltaY: number): WheelEvent =>
-  ({ deltaX, deltaY }) as WheelEvent;
+/**
+ * `isLikelyTrackpadWheelEvent` and `createTrackpadGestureDetector` only read
+ * `deltaX`/`deltaY`/`deltaMode`/`timeStamp`, so a plain object cast is enough
+ * for the pure-function unit tests below. The integration tests further down
+ * use real `WheelEvent`s dispatched through the DOM instead.
+ */
+const fakeWheelEvent = (
+  fields: Partial<
+    Pick<WheelEvent, "deltaX" | "deltaY" | "deltaMode" | "timeStamp">
+  >,
+): WheelEvent =>
+  ({
+    deltaX: 0,
+    deltaY: 0,
+    deltaMode: 0,
+    timeStamp: 0,
+    ...fields,
+  }) as WheelEvent;
 
 describe("isLikelyTrackpadWheelEvent", () => {
-  it("treats a whole-number, vertical-only wheel tick as a mouse wheel", () => {
-    expect(isLikelyTrackpadWheelEvent(wheelEvent(0, 100))).toBe(false);
+  it("treats a full-magnitude vertical-only tick as a mouse wheel", () => {
+    expect(isLikelyTrackpadWheelEvent(fakeWheelEvent({ deltaY: 100 }))).toBe(
+      false,
+    );
   });
 
-  it("treats a small whole-number vertical tick as a mouse wheel", () => {
-    expect(isLikelyTrackpadWheelEvent(wheelEvent(0, 3))).toBe(false);
+  it("treats a negative full-magnitude vertical tick as a mouse wheel", () => {
+    expect(isLikelyTrackpadWheelEvent(fakeWheelEvent({ deltaY: -120 }))).toBe(
+      false,
+    );
   });
 
-  it("treats a negative whole-number vertical tick as a mouse wheel", () => {
-    expect(isLikelyTrackpadWheelEvent(wheelEvent(0, -120))).toBe(false);
+  it("treats a fractional mouse notch at 90% browser zoom as a mouse wheel", () => {
+    // Regression test: Chromium scales wheel deltas by the page zoom factor,
+    // so a standard 100px notch arrives fractional at any zoom but 100%
+    // (~111.1111145 at 90%, trimmed here to keep the literal within double
+    // precision). An earlier heuristic keyed on fractional-ness and misread
+    // this as a trackpad, silently breaking wheel-to-zoom for zoomed-in mouse
+    // users.
+    expect(
+      isLikelyTrackpadWheelEvent(
+        fakeWheelEvent({ deltaY: 111.111114501953, deltaX: 0 }),
+      ),
+    ).toBe(false);
   });
 
-  it("treats an all-zero event as a mouse wheel (no signal otherwise)", () => {
-    expect(isLikelyTrackpadWheelEvent(wheelEvent(0, 0))).toBe(false);
+  it("treats a small integer vertical tick as a trackpad gesture", () => {
+    // Regression test: macOS axis-locks a deliberately vertical two-finger
+    // pan to deltaX === 0, and its per-event deltas can be whole numbers, so
+    // magnitude is the only signal left for issue #265's headline scenario.
+    expect(
+      isLikelyTrackpadWheelEvent(fakeWheelEvent({ deltaY: 3, deltaX: 0 })),
+    ).toBe(true);
   });
 
   it("treats a nonzero deltaX as a trackpad gesture", () => {
-    expect(isLikelyTrackpadWheelEvent(wheelEvent(-5, 12))).toBe(true);
+    expect(
+      isLikelyTrackpadWheelEvent(fakeWheelEvent({ deltaX: -5, deltaY: 12 })),
+    ).toBe(true);
   });
 
-  it("treats a fractional deltaY as a trackpad gesture", () => {
-    expect(isLikelyTrackpadWheelEvent(wheelEvent(0, 2.4))).toBe(true);
+  it("treats a large two-axis delta as a trackpad gesture via deltaX", () => {
+    expect(
+      isLikelyTrackpadWheelEvent(fakeWheelEvent({ deltaX: 60, deltaY: 200 })),
+    ).toBe(true);
   });
 
-  it("treats a fractional deltaX as a trackpad gesture", () => {
-    expect(isLikelyTrackpadWheelEvent(wheelEvent(0.75, 0))).toBe(true);
+  it("treats an all-zero event as a trackpad gesture (below the notch floor)", () => {
+    expect(isLikelyTrackpadWheelEvent(fakeWheelEvent({}))).toBe(true);
+  });
+
+  it("ignores line-mode events regardless of magnitude", () => {
+    expect(
+      isLikelyTrackpadWheelEvent(
+        fakeWheelEvent({ deltaY: 3, deltaX: 0, deltaMode: 1 }),
+      ),
+    ).toBe(false);
+    expect(
+      isLikelyTrackpadWheelEvent(
+        fakeWheelEvent({ deltaY: 3, deltaX: 2, deltaMode: 1 }),
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores page-mode events regardless of magnitude", () => {
+    expect(
+      isLikelyTrackpadWheelEvent(
+        fakeWheelEvent({ deltaY: 1, deltaX: 1, deltaMode: 2 }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("createTrackpadGestureDetector", () => {
+  it("classifies the first event on its own merits", () => {
+    const isTrackpadGesture = createTrackpadGestureDetector();
+    expect(
+      isTrackpadGesture(fakeWheelEvent({ deltaY: 3, timeStamp: 100 })),
+    ).toBe(true);
+  });
+
+  it("reuses a trackpad verdict for a mouse-shaped event in the same gesture", () => {
+    const isTrackpadGesture = createTrackpadGestureDetector();
+    expect(
+      isTrackpadGesture(fakeWheelEvent({ deltaY: 3, timeStamp: 100 })),
+    ).toBe(true);
+    expect(
+      isTrackpadGesture(fakeWheelEvent({ deltaY: 100, timeStamp: 150 })),
+    ).toBe(true);
+  });
+
+  it("reuses a mouse verdict for a trackpad-shaped event in the same gesture", () => {
+    const isTrackpadGesture = createTrackpadGestureDetector();
+    expect(
+      isTrackpadGesture(fakeWheelEvent({ deltaY: 100, timeStamp: 100 })),
+    ).toBe(false);
+    expect(
+      isTrackpadGesture(fakeWheelEvent({ deltaY: 3, timeStamp: 150 })),
+    ).toBe(false);
+  });
+
+  it("re-classifies after a gap of at least the gesture timeout", () => {
+    const isTrackpadGesture = createTrackpadGestureDetector();
+    expect(
+      isTrackpadGesture(fakeWheelEvent({ deltaY: 100, timeStamp: 100 })),
+    ).toBe(false);
+    expect(
+      isTrackpadGesture(fakeWheelEvent({ deltaY: 3, timeStamp: 250 })),
+    ).toBe(true);
+  });
+
+  it("keeps extending the same gesture across a run of close events", () => {
+    const isTrackpadGesture = createTrackpadGestureDetector();
+    const verdicts = [100, 200, 300, 400].map((timeStamp) =>
+      isTrackpadGesture(fakeWheelEvent({ deltaY: 3, deltaX: 1, timeStamp })),
+    );
+    // Each event is 100ms after the previous one, so the whole run stays a
+    // single gesture even though the total span exceeds the timeout.
+    expect(verdicts).toEqual([true, true, true, true]);
+  });
+});
+
+const setupDom = () => {
+  const outer = document.createElement("div");
+  const excalidrawContainer = document.createElement("div");
+  const canvas = document.createElement("canvas");
+  excalidrawContainer.appendChild(canvas);
+  outer.appendChild(excalidrawContainer);
+  document.body.appendChild(outer);
+  const receivedByExcalidraw: WheelEvent[] = [];
+  // Stand-in for Excalidraw's own handler: bubble phase, passive:false,
+  // always preventDefaults canvas-targeted wheel events.
+  excalidrawContainer.addEventListener(
+    "wheel",
+    (e) => {
+      receivedByExcalidraw.push(e as WheelEvent);
+      e.preventDefault();
+    },
+    { passive: false },
+  );
+  return { outer, canvas, receivedByExcalidraw };
+};
+
+const wheelEvent = (init: WheelEventInit): WheelEvent =>
+  new WheelEvent("wheel", {
+    bubbles: true,
+    cancelable: true,
+    deltaMode: 0,
+    ...init,
+  });
+
+describe("attachCanvasZoomForwarding", () => {
+  const cleanups: Array<() => void> = [];
+
+  afterEach(() => {
+    while (cleanups.length) cleanups.pop()?.();
+    document.body.innerHTML = "";
+  });
+
+  const attach = (container: HTMLElement) => {
+    cleanups.push(attachCanvasZoomForwarding(container));
+  };
+
+  it("converts a mouse-shaped wheel event into a ctrl+wheel zoom", () => {
+    const { outer, canvas, receivedByExcalidraw } = setupDom();
+    attach(outer);
+
+    const event = wheelEvent({ deltaY: 100, deltaX: 0 });
+    canvas.dispatchEvent(event);
+
+    expect(receivedByExcalidraw).toHaveLength(1);
+    expect(receivedByExcalidraw[0].ctrlKey).toBe(true);
+    expect(receivedByExcalidraw[0].deltaY).toBe(100);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("lets a trackpad-shaped event through untouched, still cancelled downstream", () => {
+    const { outer, canvas, receivedByExcalidraw } = setupDom();
+    attach(outer);
+
+    const event = wheelEvent({ deltaY: 3.5, deltaX: -1.25 });
+    canvas.dispatchEvent(event);
+
+    expect(receivedByExcalidraw).toHaveLength(1);
+    expect(receivedByExcalidraw[0]).toBe(event);
+    expect(receivedByExcalidraw[0].ctrlKey).toBe(false);
+    expect(receivedByExcalidraw[0].deltaY).toBe(3.5);
+    expect(receivedByExcalidraw[0].deltaX).toBe(-1.25);
+    // Excalidraw's own handler still cancels it, so there is no double-scroll
+    // or overscroll page-bounce even though we skipped preventDefault.
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("lets shift+wheel with an axis-swapped delta through to native shift-pan", () => {
+    // Many browsers move the delta onto deltaX for shift+wheel before the
+    // event fires. The horizontal-component signal therefore lets shift+wheel
+    // reach Excalidraw's native horizontal pan instead of forcing zoom — an
+    // intentional behavior change, documented here so it isn't mistaken for a
+    // regression.
+    const { outer, canvas, receivedByExcalidraw } = setupDom();
+    attach(outer);
+
+    const event = wheelEvent({ deltaX: 100, deltaY: 0, shiftKey: true });
+    canvas.dispatchEvent(event);
+
+    expect(receivedByExcalidraw).toHaveLength(1);
+    expect(receivedByExcalidraw[0]).toBe(event);
+    expect(receivedByExcalidraw[0].ctrlKey).toBe(false);
+    expect(receivedByExcalidraw[0].deltaX).toBe(100);
+  });
+
+  it("keeps a whole trackpad gesture panning when one event looks mouse-shaped", () => {
+    // Regression test for mid-pan zoom jitter: a single event in a long
+    // two-finger pan can land at or above the notch floor with deltaX === 0.
+    // The gesture latch must hold the trackpad verdict for it.
+    const { outer, canvas, receivedByExcalidraw } = setupDom();
+    attach(outer);
+
+    const first = wheelEvent({ deltaY: 3, deltaX: 0 });
+    canvas.dispatchEvent(first);
+    const second = wheelEvent({ deltaY: 100, deltaX: 0 });
+    canvas.dispatchEvent(second);
+
+    expect(second.timeStamp - first.timeStamp).toBeLessThan(150);
+    expect(receivedByExcalidraw).toHaveLength(2);
+    expect(receivedByExcalidraw[0]).toBe(first);
+    expect(receivedByExcalidraw[1]).toBe(second);
+    expect(receivedByExcalidraw.map((e) => e.ctrlKey)).toEqual([false, false]);
+  });
+
+  it("does not intercept ctrl+wheel or meta+wheel", () => {
+    const { outer, canvas, receivedByExcalidraw } = setupDom();
+    attach(outer);
+
+    const ctrlEvent = wheelEvent({ deltaY: 100, ctrlKey: true });
+    canvas.dispatchEvent(ctrlEvent);
+    const metaEvent = wheelEvent({ deltaY: 100, metaKey: true });
+    canvas.dispatchEvent(metaEvent);
+
+    expect(receivedByExcalidraw).toEqual([ctrlEvent, metaEvent]);
+  });
+
+  it("ignores wheel events over the editor UI chrome", () => {
+    const { outer, canvas, receivedByExcalidraw } = setupDom();
+    const uiWrapper = document.createElement("div");
+    uiWrapper.className = "layer-ui__wrapper";
+    const uiCanvas = document.createElement("canvas");
+    uiWrapper.appendChild(uiCanvas);
+    // Nested inside the Excalidraw container so the stand-in handler still
+    // sees the event — otherwise this test would pass vacuously.
+    canvas.parentElement?.appendChild(uiWrapper);
+    attach(outer);
+
+    const event = wheelEvent({ deltaY: 100 });
+    uiCanvas.dispatchEvent(event);
+
+    expect(receivedByExcalidraw).toEqual([event]);
+    expect(receivedByExcalidraw[0].ctrlKey).toBe(false);
+  });
+
+  it("stops intercepting after cleanup", () => {
+    const { outer, canvas, receivedByExcalidraw } = setupDom();
+    const detach = attachCanvasZoomForwarding(outer);
+    detach();
+
+    const event = wheelEvent({ deltaY: 100 });
+    canvas.dispatchEvent(event);
+
+    expect(receivedByExcalidraw).toEqual([event]);
+    expect(receivedByExcalidraw[0].ctrlKey).toBe(false);
+  });
+
+  it("returns a no-op cleanup for a null container", () => {
+    expect(() => attachCanvasZoomForwarding(null)()).not.toThrow();
   });
 });

--- a/frontend/src/pages/editor/canvasZoomForwarding.ts
+++ b/frontend/src/pages/editor/canvasZoomForwarding.ts
@@ -3,7 +3,42 @@
  * inverts that on the canvas so a plain wheel zooms: intercept plain wheel
  * events over the canvas (not the editor UI chrome) and re-dispatch them as
  * synthetic ctrl+wheel. Returns a cleanup that detaches the listener.
+ *
+ * Trackpad two-finger pan gestures also arrive as plain (non-ctrl) wheel
+ * events, so without further filtering this inversion would break native
+ * trackpad panning. `isLikelyTrackpadWheelEvent` below is a heuristic used to
+ * let those events pass through untouched. Pinch-to-zoom gestures already
+ * carry `ctrlKey: true` from the browser and are unaffected by any of this —
+ * they're excluded by the existing `!event.ctrlKey` check.
  */
+
+/**
+ * Best-effort heuristic to distinguish a trackpad two-finger gesture from a
+ * physical mouse wheel tick. `WheelEvent` carries no explicit "input device"
+ * signal, so this combines two commonly used proxies:
+ *
+ * 1. Non-zero `deltaX`: a plain mouse wheel is a single vertical axis and
+ *    essentially never reports a horizontal component on its own, whereas a
+ *    trackpad two-finger pan is inherently a two-axis gesture and commonly
+ *    reports some `deltaX` even when the pan is mostly vertical.
+ * 2. Fractional (non-integer) `deltaX`/`deltaY`: trackpads report continuous,
+ *    high-resolution pixel deltas, while mouse wheels click in fixed, whole
+ *    number steps (commonly multiples of 100/120, or a line-height value).
+ *
+ * Not perfect — some high-resolution/free-spin mouse wheels (e.g. Logitech
+ * MX Master) can report fractional deltas and would be misclassified as a
+ * trackpad, and a trackpad pan that happens to be purely vertical with
+ * whole-number deltas would be misclassified as a mouse wheel. This covers
+ * the common cases well enough to restore native trackpad panning without
+ * breaking wheel-to-zoom for typical mice.
+ */
+export const isLikelyTrackpadWheelEvent = (event: WheelEvent): boolean => {
+  const hasHorizontalComponent = event.deltaX !== 0;
+  const hasFractionalDelta =
+    !Number.isInteger(event.deltaX) || !Number.isInteger(event.deltaY);
+  return hasHorizontalComponent || hasFractionalDelta;
+};
+
 export const attachCanvasZoomForwarding = (
   container: HTMLElement | null,
 ): (() => void) => {
@@ -20,7 +55,8 @@ export const attachCanvasZoomForwarding = (
       !isEditorUi &&
       !event.ctrlKey &&
       !event.metaKey &&
-      !(event as any)._isFakeZoom
+      !(event as any)._isFakeZoom &&
+      !isLikelyTrackpadWheelEvent(event)
     ) {
       event.preventDefault();
       event.stopPropagation();
@@ -37,6 +73,9 @@ export const attachCanvasZoomForwarding = (
       (zoomEvent as any)._isFakeZoom = true;
       target.dispatchEvent(zoomEvent);
     }
+    // else: let the event flow through untouched — Excalidraw's native pan
+    // handles trackpad two-finger gestures the same way it already handles
+    // ctrl/cmd+wheel and pinch-to-zoom.
   };
   container.addEventListener("wheel", handleWheel, {
     capture: true,

--- a/frontend/src/pages/editor/canvasZoomForwarding.ts
+++ b/frontend/src/pages/editor/canvasZoomForwarding.ts
@@ -6,43 +6,117 @@
  *
  * Trackpad two-finger pan gestures also arrive as plain (non-ctrl) wheel
  * events, so without further filtering this inversion would break native
- * trackpad panning. `isLikelyTrackpadWheelEvent` below is a heuristic used to
- * let those events pass through untouched. Pinch-to-zoom gestures already
- * carry `ctrlKey: true` from the browser and are unaffected by any of this —
- * they're excluded by the existing `!event.ctrlKey` check.
+ * trackpad panning. `createTrackpadGestureDetector` below classifies each
+ * plain wheel event and lets trackpad-shaped gestures pass through
+ * untouched. Excalidraw's own wheel handler (bubble phase, passive:false,
+ * on its container inside ours) then receives the un-intercepted event and
+ * calls preventDefault on it itself, so skipping our preventDefault here is
+ * safe — no double-scroll, no overscroll navigation. Pinch-to-zoom gestures
+ * already carry `ctrlKey: true` from the browser and are unaffected by any
+ * of this — they're excluded by the `!event.ctrlKey` check below. Shift+wheel
+ * from a physical mouse commonly reports its delta on `deltaX` (many
+ * browsers swap axes for shift+wheel before the event fires), so it now
+ * also passes through to Excalidraw's native shift-pan instead of being
+ * forced into zoom — an intentional side effect of the horizontal-component
+ * signal below, not a bug.
  */
 
 /**
- * Best-effort heuristic to distinguish a trackpad two-finger gesture from a
- * physical mouse wheel tick. `WheelEvent` carries no explicit "input device"
- * signal, so this combines two commonly used proxies:
+ * The magnitude (in `DOM_DELTA_PIXEL` units) of one discrete mouse-wheel
+ * "notch". Chromium reports wheel deltas in CSS pixels, so this scales with
+ * the page's zoom level (a 100px notch becomes ~111px at 90% zoom, ~67px at
+ * 150% zoom) — the same scaling applies to a trackpad's much smaller
+ * per-event deltas, so the *relative* gap this threshold relies on is
+ * preserved across ordinary zoom levels, even though the absolute floor
+ * isn't exact at either extreme.
+ */
+const MOUSE_NOTCH_FLOOR_PX = 40;
+
+/**
+ * How long (ms) two consecutive wheel events can be apart and still count
+ * as the same physical gesture. Both trackpad pans and mouse-wheel spins
+ * fire many events well under 100ms apart; a gap this large means the user
+ * lifted their fingers or stopped turning the wheel.
+ */
+const GESTURE_TIMEOUT_MS = 150;
+
+/**
+ * Best-effort per-event heuristic: does this wheel event look like it came
+ * from a trackpad rather than a physical mouse wheel?
  *
- * 1. Non-zero `deltaX`: a plain mouse wheel is a single vertical axis and
- *    essentially never reports a horizontal component on its own, whereas a
- *    trackpad two-finger pan is inherently a two-axis gesture and commonly
- *    reports some `deltaX` even when the pan is mostly vertical.
- * 2. Fractional (non-integer) `deltaX`/`deltaY`: trackpads report continuous,
- *    high-resolution pixel deltas, while mouse wheels click in fixed, whole
- *    number steps (commonly multiples of 100/120, or a line-height value).
+ * Only `DOM_DELTA_PIXEL` (mode `0`) events are classified — the mode both
+ * trackpads and mouse-wheel reporting use on macOS/Chromium/Safari, where
+ * issue #265 was reported. Other delta modes (line/page) fall back to
+ * `false`, leaving the pre-existing wheel-to-zoom behavior unchanged for
+ * them, since the magnitude floor below isn't meaningful in those units.
  *
- * Not perfect — some high-resolution/free-spin mouse wheels (e.g. Logitech
- * MX Master) can report fractional deltas and would be misclassified as a
- * trackpad, and a trackpad pan that happens to be purely vertical with
- * whole-number deltas would be misclassified as a mouse wheel. This covers
- * the common cases well enough to restore native trackpad panning without
- * breaking wheel-to-zoom for typical mice.
+ * Two independent signals, either sufficient on its own:
+ * 1. Non-zero `deltaX`: a physical mouse wheel is single-axis and
+ *    essentially never reports a horizontal component by itself, while a
+ *    trackpad two-finger pan is inherently two-axis. (macOS axis-locks a
+ *    deliberately vertical two-finger pan to `deltaX === 0`, so this alone
+ *    doesn't catch that case — see signal 2.)
+ * 2. Small magnitude on both axes (`< MOUSE_NOTCH_FLOOR_PX`): a mouse wheel
+ *    reports one large, fixed-size step per physical click; a trackpad
+ *    reports many small, continuous per-event deltas.
+ *
+ * Deliberately NOT used: whether the delta is a whole number. A prior
+ * version of this heuristic used fractional-ness as the second signal, but
+ * Chromium scales `deltaY` by the page's zoom factor, so a standard mouse
+ * notch becomes fractional (e.g. ~111.11) at any zoom level other than
+ * 100% — that check alone silently broke wheel-to-zoom for zoomed-in mouse
+ * users.
+ *
+ * Not perfect — a fast, hard trackpad flick can occasionally produce a
+ * single event at or above the notch floor, and extreme browser zoom
+ * levels shift both mouse and trackpad magnitudes together — but combined
+ * with the gesture latch below, this covers the common cases without the
+ * false positive above.
  */
 export const isLikelyTrackpadWheelEvent = (event: WheelEvent): boolean => {
+  if (event.deltaMode !== 0) return false;
   const hasHorizontalComponent = event.deltaX !== 0;
-  const hasFractionalDelta =
-    !Number.isInteger(event.deltaX) || !Number.isInteger(event.deltaY);
-  return hasHorizontalComponent || hasFractionalDelta;
+  const isSmallMagnitude =
+    Math.abs(event.deltaY) < MOUSE_NOTCH_FLOOR_PX &&
+    Math.abs(event.deltaX) < MOUSE_NOTCH_FLOOR_PX;
+  return hasHorizontalComponent || isSmallMagnitude;
+};
+
+/**
+ * Wraps `isLikelyTrackpadWheelEvent` with a per-gesture latch. Classifying
+ * every wheel event independently means a single event that happens to hit
+ * neither signal above — e.g. one event in an axis-locked vertical trackpad
+ * pan that lands at or above the notch floor — would flip the verdict and
+ * briefly zoom instead of pan mid-gesture. Once a gesture is classified,
+ * that verdict is reused for any subsequent event arriving within
+ * `GESTURE_TIMEOUT_MS`; a gap that large starts a fresh classification.
+ *
+ * `lastEventTime` starts at `-Infinity` rather than `0` so the very first
+ * event is always classified on its own merits: `event.timeStamp` is
+ * measured from the document's time origin, so a wheel event arriving in
+ * the first 150ms of the page's life would otherwise be treated as a
+ * continuation of a gesture that never happened.
+ */
+export const createTrackpadGestureDetector = () => {
+  let lastEventTime = Number.NEGATIVE_INFINITY;
+  let lastVerdict = false;
+  return (event: WheelEvent): boolean => {
+    const isContinuationOfLastGesture =
+      event.timeStamp - lastEventTime < GESTURE_TIMEOUT_MS;
+    const verdict = isContinuationOfLastGesture
+      ? lastVerdict
+      : isLikelyTrackpadWheelEvent(event);
+    lastEventTime = event.timeStamp;
+    lastVerdict = verdict;
+    return verdict;
+  };
 };
 
 export const attachCanvasZoomForwarding = (
   container: HTMLElement | null,
 ): (() => void) => {
   if (!container) return () => {};
+  const isTrackpadGesture = createTrackpadGestureDetector();
   const handleWheel = (event: WheelEvent) => {
     const target = event.target as HTMLElement | null;
     if (!target) return;
@@ -56,7 +130,7 @@ export const attachCanvasZoomForwarding = (
       !event.ctrlKey &&
       !event.metaKey &&
       !(event as any)._isFakeZoom &&
-      !isLikelyTrackpadWheelEvent(event)
+      !isTrackpadGesture(event)
     ) {
       event.preventDefault();
       event.stopPropagation();
@@ -73,9 +147,10 @@ export const attachCanvasZoomForwarding = (
       (zoomEvent as any)._isFakeZoom = true;
       target.dispatchEvent(zoomEvent);
     }
-    // else: let the event flow through untouched — Excalidraw's native pan
-    // handles trackpad two-finger gestures the same way it already handles
-    // ctrl/cmd+wheel and pinch-to-zoom.
+    // else: leave the event alone — Excalidraw's own wheel handler (bubble
+    // phase, passive:false, on its container inside ours) receives it and
+    // calls preventDefault itself. Covers trackpad gestures, shift+wheel
+    // horizontal pan, ctrl/cmd+wheel, and pinch-to-zoom.
   };
   container.addEventListener("wheel", handleWheel, {
     capture: true,


### PR DESCRIPTION
## Summary
- Trackpad two-finger pan gestures were being intercepted and forced into zoom by the canvas's wheel-to-zoom inversion, since both arrive as plain (non-ctrl) wheel events.
- Adds `isLikelyTrackpadWheelEvent`, a heuristic that classifies a wheel event as trackpad-shaped using `deltaMode` + magnitude (not fractional-ness — see below), plus `createTrackpadGestureDetector`, a per-gesture latch so one gesture's classification doesn't flip event-to-event. Trackpad-shaped gestures pass through untouched to Excalidraw's native pan; mouse wheel ticks still zoom as before. Pinch-to-zoom (ctrlKey) is unaffected.

## Revision note
An earlier version of this PR used "is the delta a whole number" as the trackpad signal. A review caught that this silently broke wheel-to-zoom for mouse users at any browser zoom level other than 100% (Chromium scales wheel deltas by the zoom factor, making a normal mouse notch fractional) and could still jitter into zoom mid-trackpad-pan since classification was per-event. This revision replaces that signal with a `deltaMode`-gated magnitude threshold and adds the gesture latch.

## Test plan
- [x] `npm test` in `frontend/` — full suite passes, including new unit tests for `isLikelyTrackpadWheelEvent` and `createTrackpadGestureDetector`, and new integration tests dispatching real DOM wheel events through `attachCanvasZoomForwarding` (mouse → converted to zoom, trackpad → passthrough, shift+wheel → passthrough, rapid mixed-signal sequence → latch holds)
- [x] `npm run lint` — clean on touched files
- [x] Manual: two-finger trackpad pan pans the canvas — **not verified on physical trackpad hardware**, would appreciate a check from a reviewer with a trackpad
- [x] Manual: mouse wheel still zooms the canvas, including at non-100% browser zoom — **not verified on physical mouse hardware**
- [x] Manual: trackpad pinch-to-zoom still zooms the canvas — **not verified on physical trackpad hardware**

Fixes #265
